### PR TITLE
DDO-1965 Fix bug in Argo app generation for dynamic environments

### DIFF
--- a/internal/thelma/cli/commands/render/selector/filter_builder.go
+++ b/internal/thelma/cli/commands/render/selector/filter_builder.go
@@ -25,13 +25,12 @@ type filterBuilder struct {
 func (f *filterBuilder) combine() terra.ReleaseFilter {
 	var destFilters []terra.DestinationFilter
 
-	// build a list of destination filters that will be intersected / combined with And()
-	destFilters = append(destFilters, f.destinationFilters...)
-
 	if len(f.destinationIncludes) > 0 {
 		// union destinationIncludes and add to the destination filter list
 		destFilters = append(destFilters, filter.Destinations().Or(f.destinationIncludes...))
 	} else {
+		// add intersection destinations
+		destFilters = append(destFilters, f.destinationFilters...)
 		// convert environment filters into a destination filter that permits environments matching the filter
 		if len(f.environmentFilters) > 0 {
 			// intersect all env filters

--- a/internal/thelma/gitops/state_loader.go
+++ b/internal/thelma/gitops/state_loader.go
@@ -145,7 +145,7 @@ func loadDynamicEnvironments(yamlEnvironments map[string]terra.Environment, sb s
 					chartVersion:   templateRelease.ChartVersion(),
 					chartName:      templateRelease.ChartName(),
 					repo:           templateRelease.Repo(),
-					namespace:      templateRelease.Namespace(),
+					namespace:      environmentNamespace(dynamicEnv.Name), // make sure we use _this_ environment name to create the namespace, not the template name
 					clusterName:    templateRelease.ClusterName(),
 					clusterAddress: templateRelease.ClusterAddress(),
 					destination:    nil, // replaced after env is constructed

--- a/internal/thelma/gitops/statefixtures/fixtures/default/statebucket/state.json
+++ b/internal/thelma/gitops/statefixtures/fixtures/default/statebucket/state.json
@@ -17,7 +17,7 @@
       },
       "hybrid": true,
       "fiab": {
-        "name": "fiab-automation-swirly-rabbit",
+        "name": "fiab-automation-funky-chipmunk",
         "ip": "10.0.0.2"
       }
     },

--- a/internal/thelma/render/helmfile/stateval/stateval_test.go
+++ b/internal/thelma/render/helmfile/stateval/stateval_test.go
@@ -7,18 +7,78 @@ import (
 	"testing"
 )
 
-func Test_BuildArgoAppValues(t *testing.T) {
+func Test_BuildStateValues(t *testing.T) {
 	state := statefixtures.LoadFixture(statefixtures.Default, t)
 
+	chartPath := t.TempDir()
+
 	testCases := []struct {
-		name     string
-		release  terra.Release
-		expected ArgoAppValues
+		name              string
+		release           terra.Release
+		expectedAppValues AppValues
+		expectedArgoApp   ArgoApp
 	}{
+		{
+			name:    "static env release",
+			release: state.Release("sam", "dev"),
+			expectedAppValues: AppValues{
+				ChartPath: chartPath,
+				Release: Release{
+					Name:       "sam",
+					Type:       "app",
+					Namespace:  "terra-dev",
+					AppVersion: "2d309b1645a0",
+				},
+				Destination: Destination{
+					Name:       "dev",
+					Type:       "environment",
+					ConfigBase: "live",
+					ConfigName: "dev",
+				},
+				Environment: Environment{
+					Name:     "dev",
+					IsHybrid: false,
+				},
+			},
+			expectedArgoApp: ArgoApp{
+				ProjectName:    "terra-dev",
+				ClusterName:    "terra-dev",
+				ClusterAddress: "https://35.238.186.116",
+			},
+		},
+		{
+			name:    "template env release",
+			release: state.Release("sam", "swatomation"),
+			expectedAppValues: AppValues{
+				ChartPath: chartPath,
+				Release: Release{
+					Name:       "sam",
+					Type:       "app",
+					Namespace:  "terra-swatomation",
+					AppVersion: "2d309b1645a0",
+				},
+				Destination: Destination{
+					Name:       "swatomation",
+					Type:       "environment",
+					ConfigBase: "bee",
+					ConfigName: "swatomation",
+				},
+				Environment: Environment{
+					Name:     "swatomation",
+					IsHybrid: false,
+				},
+			},
+			expectedArgoApp: ArgoApp{
+				ProjectName:    "terra-swatomation",
+				ClusterName:    "terra-qa",
+				ClusterAddress: "https://35.224.175.229",
+			},
+		},
 		{
 			name:    "dynamic env release",
 			release: state.Release("sam", "fiab-funky-chipmunk"),
-			expected: ArgoAppValues{
+			expectedAppValues: AppValues{
+				ChartPath: chartPath,
 				Release: Release{
 					Name:       "sam",
 					Type:       "app",
@@ -30,11 +90,6 @@ func Test_BuildArgoAppValues(t *testing.T) {
 					Type:       "environment",
 					ConfigBase: "bee",
 					ConfigName: "swatomation",
-				},
-				ArgoApp: ArgoApp{
-					ProjectName:    "terra-fiab-funky-chipmunk",
-					ClusterName:    "terra-qa",
-					ClusterAddress: "https://35.224.175.229",
 				},
 				Environment: Environment{
 					Name:     "fiab-funky-chipmunk",
@@ -48,12 +103,63 @@ func Test_BuildArgoAppValues(t *testing.T) {
 					},
 				},
 			},
+			expectedArgoApp: ArgoApp{
+				ProjectName:    "terra-fiab-funky-chipmunk",
+				ClusterName:    "terra-qa",
+				ClusterAddress: "https://35.224.175.229",
+			},
+		},
+		{
+			name:    "cluster release",
+			release: state.Release("diskmanager", "terra-dev"),
+			expectedAppValues: AppValues{
+				ChartPath: chartPath,
+				Release: Release{
+					Name:      "diskmanager",
+					Type:      "cluster",
+					Namespace: "default",
+				},
+				Destination: Destination{
+					Name:       "terra-dev",
+					Type:       "cluster",
+					ConfigBase: "terra",
+					ConfigName: "terra-dev",
+				},
+				Cluster: Cluster{
+					Name: "terra-dev",
+				},
+			},
+			expectedArgoApp: ArgoApp{
+				ProjectName:    "cluster-terra-dev",
+				ClusterName:    "terra-dev",
+				ClusterAddress: "https://35.238.186.116",
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, BuildArgoAppValues(tc.release))
+			assert.Equal(t, tc.expectedAppValues, BuildAppValues(tc.release, chartPath))
+
+			var expectedArgoApp ArgoAppValues
+			expectedArgoApp.ArgoApp = tc.expectedArgoApp
+			// copy common settings over from app values
+			expectedArgoApp.Release = tc.expectedAppValues.Release
+			expectedArgoApp.Destination = tc.expectedAppValues.Destination
+			expectedArgoApp.Environment = tc.expectedAppValues.Environment
+			expectedArgoApp.Cluster = tc.expectedAppValues.Cluster
+
+			assert.Equal(t, expectedArgoApp, BuildArgoAppValues(tc.release))
+
+			var expectedArgoProject ArgoProjectValues
+			// copy project name over from expected argo app
+			expectedArgoProject.ArgoProject = ArgoProject{
+				ProjectName: expectedArgoApp.ArgoApp.ProjectName,
+			}
+			// copy common settings over from app values
+			expectedArgoProject.Destination = tc.expectedAppValues.Destination
+
+			assert.Equal(t, expectedArgoProject, BuildArgoProjectValues(tc.release.Destination()))
 		})
 	}
 }

--- a/internal/thelma/render/helmfile/stateval/stateval_test.go
+++ b/internal/thelma/render/helmfile/stateval/stateval_test.go
@@ -1,0 +1,59 @@
+package stateval
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/gitops/statefixtures"
+	"github.com/broadinstitute/thelma/internal/thelma/terra"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_BuildArgoAppValues(t *testing.T) {
+	state := statefixtures.LoadFixture(statefixtures.Default, t)
+
+	testCases := []struct {
+		name     string
+		release  terra.Release
+		expected ArgoAppValues
+	}{
+		{
+			name:    "dynamic env release",
+			release: state.Release("sam", "fiab-funky-chipmunk"),
+			expected: ArgoAppValues{
+				Release: Release{
+					Name:       "sam",
+					Type:       "app",
+					Namespace:  "terra-fiab-funky-chipmunk",
+					AppVersion: "2d309b1645a0",
+				},
+				Destination: Destination{
+					Name:       "fiab-funky-chipmunk",
+					Type:       "environment",
+					ConfigBase: "bee",
+					ConfigName: "swatomation",
+				},
+				ArgoApp: ArgoApp{
+					ProjectName:    "terra-fiab-funky-chipmunk",
+					ClusterName:    "terra-qa",
+					ClusterAddress: "https://35.224.175.229",
+				},
+				Environment: Environment{
+					Name:     "fiab-funky-chipmunk",
+					IsHybrid: true,
+					Fiab: struct {
+						Name string `yaml:"Name,omitempty"`
+						IP   string `yaml:"IP,omitempty"`
+					}{
+						Name: "fiab-automation-funky-chipmunk",
+						IP:   "10.0.0.2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, BuildArgoAppValues(tc.release))
+		})
+	}
+}

--- a/internal/thelma/utils/shell/real.go
+++ b/internal/thelma/utils/shell/real.go
@@ -29,7 +29,7 @@ func (r *RealRunner) Run(cmd Command) error {
 	return r.RunWith(cmd, RunOptions{})
 }
 
-// Capture runs a Command, streaming stdout and stderr to the given writers.
+// RunWith runs a Command, streaming stdout and stderr to the given writers.
 // An error is returned if the command exits non-zero.
 func (r *RealRunner) RunWith(cmd Command, opts RunOptions) error {
 	// Handle options into local variables


### PR DESCRIPTION
Before this change, swat BEEs were being deployed to the `terra-swatomation` namespace; they need to go to the correct environment namespace.