### PR TITLE
[no ticket] Add M1 builds to Thelma's artifact bucket

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,13 @@ jobs:
           os: darwin
           arch: amd64
           version: ${{ steps.tag.outputs.tag }}
+      - name: Build M1 darwin binary distribution
+        uses: ./.github/actions/make
+        with:
+          target: "release"
+          os: darwin
+          arch: arm64
+          version: ${{ steps.tag.outputs.tag }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:


### PR DESCRIPTION
Me having an M1 slowly paying off :sadpanda: `arm64` is how I build go locally so should work