### PR TITLE
[DDO-2066] preview ➡️  bee

### DIFF
--- a/internal/thelma/cli/commands/bee/vars/vars_command.go
+++ b/internal/thelma/cli/commands/bee/vars/vars_command.go
@@ -79,7 +79,7 @@ func (cmd *varsCommand) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 				port = 389
 			}
 
-			host := fmt.Sprintf("%s.%s.preview.envs-terra.bio", r.Name(), env.Name())
+			host := fmt.Sprintf("%s.%s.bee.envs-terra.bio", r.Name(), env.Name())
 			url := fmt.Sprintf("%s://%s", proto, host)
 
 			fmt.Printf("%s_HOST=%s\n", upname, host)

--- a/internal/thelma/state/providers/gitops/statefixtures/fixtures/default/thelma-home/clusters/terra/terra-qa.yaml
+++ b/internal/thelma/state/providers/gitops/statefixtures/fixtures/default/thelma-home/clusters/terra/terra-qa.yaml
@@ -3,7 +3,7 @@
 address: https://35.224.175.229
 
 releases:
-  # TODO: these will eventually be enabled as part of our preview environment
+  # TODO: these will eventually be enabled as part of our BEE environment
   #       implementation
   diskmanager:
     enabled: false


### PR DESCRIPTION
Tweak a comment (unimportant) and the host FQDN generation logic (very important) to use `bee` instead of `preview`