### PR TITLE
DDO-2070 Fixes for pinning and sync behavior

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -35,13 +35,6 @@ type CreateOptions struct {
 	WaitHealthy   bool
 }
 
-type VersionOptions struct {
-	AppVersion          string
-	ChartVersion        string
-	TerraHelmfileRef    string
-	FirecloudDevelopRef string
-}
-
 func NewBees(argocd argocd.ArgoCD, stateLoader terra.StateLoader) (Bees, error) {
 	state, err := stateLoader.Load()
 	if err != nil {
@@ -131,11 +124,6 @@ func (b *bees) DeleteWith(name string, options DeleteOptions) (terra.Environment
 	log.Info().Msgf("Deleted environment %s from state", name)
 
 	log.Info().Msgf("Deleting Argo apps for %s", name)
-	if err = b.RefreshBeeGenerator(); err != nil {
-		return env, err
-	}
-
-	log.Info().Msgf("Deleting Argo project for %s", name)
 	if err = b.RefreshBeeGenerator(); err != nil {
 		return env, err
 	}

--- a/internal/thelma/cli/commands/bee/pin/pin_command.go
+++ b/internal/thelma/cli/commands/bee/pin/pin_command.go
@@ -170,12 +170,15 @@ func (cmd *pinCommand) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 
 	log.Info().Msgf("Updated version overrides for %s", cmd.options.name)
 
-	if err = bees.SyncGeneratorFor(env); err != nil {
+	if err = bees.RefreshBeeGenerator(); err != nil {
+		return err
+	}
+	if err = bees.SyncEnvironmentGenerator(env); err != nil {
 		return err
 	}
 
 	if cmd.options.sync {
-		if err = bees.SyncArgoAppsFor(env, func(options *argocd.SyncOptions) {
+		if err = bees.SyncArgoAppsIn(env, func(options *argocd.SyncOptions) {
 			options.WaitHealthy = cmd.options.waitHealthy
 		}); err != nil {
 			return err

--- a/internal/thelma/cli/commands/bee/unpin/unpin_command.go
+++ b/internal/thelma/cli/commands/bee/unpin/unpin_command.go
@@ -86,7 +86,10 @@ func (cmd *unpinCommand) Run(app app.ThelmaApp, rc cli.RunContext) error {
 	}
 	log.Info().Msgf("Removed all version overrides for %s", cmd.options.name)
 
-	if err = bees.SyncGeneratorForName(cmd.options.name); err != nil {
+	if err = bees.RefreshBeeGenerator(); err != nil {
+		return err
+	}
+	if err = bees.SyncEnvironmentGenerator(env); err != nil {
 		return err
 	}
 

--- a/internal/thelma/render/helmfile/stateval/argo.go
+++ b/internal/thelma/render/helmfile/stateval/argo.go
@@ -23,6 +23,14 @@ type ArgoApp struct {
 type ArgoProject struct {
 	// ProjectName name of the ArgoCD project that is being rendered
 	ProjectName string `yaml:"ProjectName"`
+	// Generator settings for the project's application generator, if enabled
+	Generator Generator `yaml:"Generator"`
+}
+
+// Generator information about an Argo project's application generator
+type Generator struct {
+	// Name name of the project's application generator
+	Name string `yaml:"Name"`
 	// TerraHelmfileRef override terra-helmfile ref for the project's app generator
 	TerraHelmfileRef string `yaml:"TerraHelmfileRef"`
 }
@@ -39,7 +47,10 @@ func forArgoApp(r terra.Release) ArgoApp {
 
 func forArgoProject(d terra.Destination) ArgoProject {
 	return ArgoProject{
-		ProjectName:      argocd.ProjectName(d),
-		TerraHelmfileRef: d.TerraHelmfileRef(),
+		ProjectName: argocd.ProjectName(d),
+		Generator: Generator{
+			Name:             argocd.GeneratorName(d),
+			TerraHelmfileRef: d.TerraHelmfileRef(),
+		},
 	}
 }

--- a/internal/thelma/render/helmfile/stateval/stateval_test.go
+++ b/internal/thelma/render/helmfile/stateval/stateval_test.go
@@ -13,10 +13,11 @@ func Test_BuildStateValues(t *testing.T) {
 	chartPath := t.TempDir()
 
 	testCases := []struct {
-		name              string
-		release           terra.Release
-		expectedAppValues AppValues
-		expectedArgoApp   ArgoApp
+		name                string
+		release             terra.Release
+		expectedAppValues   AppValues
+		expectedArgoApp     ArgoApp
+		expectedArgoProject ArgoProject
 	}{
 		{
 			name:    "static env release",
@@ -73,6 +74,13 @@ func Test_BuildStateValues(t *testing.T) {
 				ClusterName:    "terra-qa",
 				ClusterAddress: "https://35.224.175.229",
 			},
+			expectedArgoProject: ArgoProject{
+				ProjectName: "terra-swatomation",
+				Generator: Generator{
+					Name:             "terra-swatomation-generator",
+					TerraHelmfileRef: "",
+				},
+			},
 		},
 		{
 			name:    "dynamic env release",
@@ -110,6 +118,13 @@ func Test_BuildStateValues(t *testing.T) {
 				TerraHelmfileRef:    "my-th-branch-1",
 				FirecloudDevelopRef: "my-fc-branch-1",
 			},
+			expectedArgoProject: ArgoProject{
+				ProjectName: "terra-fiab-funky-chipmunk",
+				Generator: Generator{
+					Name:             "terra-fiab-funky-chipmunk-generator",
+					TerraHelmfileRef: "",
+				},
+			},
 		},
 		{
 			name:    "cluster release",
@@ -136,6 +151,13 @@ func Test_BuildStateValues(t *testing.T) {
 				ClusterName:    "terra-dev",
 				ClusterAddress: "https://35.238.186.116",
 			},
+			expectedArgoProject: ArgoProject{
+				ProjectName: "cluster-terra-dev",
+				Generator: Generator{
+					Name:             "cluster-terra-dev-generator",
+					TerraHelmfileRef: "",
+				},
+			},
 		},
 	}
 
@@ -153,15 +175,7 @@ func Test_BuildStateValues(t *testing.T) {
 
 			assert.Equal(t, expectedArgoApp, BuildArgoAppValues(tc.release))
 
-			var expectedArgoProject ArgoProjectValues
-			// copy project name over from expected argo app
-			expectedArgoProject.ArgoProject = ArgoProject{
-				ProjectName: expectedArgoApp.ArgoApp.ProjectName,
-			}
-			// copy common settings over from app values
-			expectedArgoProject.Destination = tc.expectedAppValues.Destination
-
-			assert.Equal(t, expectedArgoProject, BuildArgoProjectValues(tc.release.Destination()))
+			assert.Equal(t, tc.expectedArgoProject, BuildArgoProjectValues(tc.release.Destination()))
 		})
 	}
 }

--- a/internal/thelma/render/helmfile/stateval/stateval_test.go
+++ b/internal/thelma/render/helmfile/stateval/stateval_test.go
@@ -46,6 +46,13 @@ func Test_BuildStateValues(t *testing.T) {
 				ClusterName:    "terra-dev",
 				ClusterAddress: "https://35.238.186.116",
 			},
+			expectedArgoProject: ArgoProject{
+				ProjectName: "terra-dev",
+				Generator: Generator{
+					Name:             "terra-dev-generator",
+					TerraHelmfileRef: "",
+				},
+			},
 		},
 		{
 			name:    "template env release",
@@ -175,7 +182,12 @@ func Test_BuildStateValues(t *testing.T) {
 
 			assert.Equal(t, expectedArgoApp, BuildArgoAppValues(tc.release))
 
-			assert.Equal(t, tc.expectedArgoProject, BuildArgoProjectValues(tc.release.Destination()))
+			var expectedArgoProject ArgoProjectValues
+			expectedArgoProject.ArgoProject = tc.expectedArgoProject
+			// copy common settings over from app values
+			expectedArgoProject.Destination = tc.expectedAppValues.Destination
+
+			assert.Equal(t, expectedArgoProject, BuildArgoProjectValues(tc.release.Destination()))
 		})
 	}
 }

--- a/internal/thelma/state/api/terra/environments.go
+++ b/internal/thelma/state/api/terra/environments.go
@@ -27,7 +27,7 @@ type Environments interface {
 	// UnpinVersions removes version overrides in the given environment
 	// TODO this should move to Environment at some point
 	UnpinVersions(environmentName string) (map[string]VersionOverride, error)
-	// PinEnvironmentToTerraHelmfileREf pins an environment to a specific terra-helmfile ref
+	// PinEnvironmentToTerraHelmfileRef pins an environment to a specific terra-helmfile ref
 	// Note this can be overridden by individual service version overrides
 	PinEnvironmentToTerraHelmfileRef(environmentName string, terraHelmfileRef string) error
 	// Delete deletes the environment with the given name

--- a/internal/thelma/state/providers/gitops/statebucket/statebucket.go
+++ b/internal/thelma/state/providers/gitops/statebucket/statebucket.go
@@ -183,6 +183,8 @@ func (s *statebucket) UnpinVersions(environmentName string) (map[string]terra.Ve
 	err := s.updateEnvironment(environmentName, func(e *DynamicEnvironment) {
 		var deletions []string
 
+		e.TerraHelmfileRef = ""
+
 		for releaseName, override := range e.Overrides {
 			result[releaseName] = override.Versions
 			override.UnpinVersions()

--- a/internal/thelma/tools/argocd/names.go
+++ b/internal/thelma/tools/argocd/names.go
@@ -40,6 +40,12 @@ func ProjectName(destination terra.Destination) string {
 	}
 }
 
+// GeneratorName name of a destinations app generator, eg. "terra-dev-generator"
+func GeneratorName(destination terra.Destination) string {
+	projectName := ProjectName(destination)
+	return fmt.Sprintf("%s-generator", projectName)
+}
+
 // releaseSelector returns set of selectors for all argo apps associated with a release
 // (often just the primary application, but can include the legacy configs application as well)
 func releaseSelector(release terra.Release) map[string]string {


### PR DESCRIPTION
### Sync behavior changes
So, we still need to sync the terra-bee-generator on every deploy in order to update the branch of the dedicated BEE environment generator.

To work around [this bug](https://github.com/argoproj/argo-cd/issues/4505#issuecomment-880271371), I've enabled autosync with prune on the terra-bee-generator app. Now creating a bee will:
* Hard refresh the terra-bee-generator (it has auto-sync + pruning enabled)
* Hard refresh + sync the environment generator
* Hard refresh + sync all apps generated by the environment generator

(The syncing bug is a big issue with the bee generator but less so with the per-environment generator and argo apps.)

### Pin fixes
Fix an issue where unpinning didn't truly unpin terra-helmfile branches