### PR TITLE
DDO-2167 First pass at adding build number to `helmfile` state values

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout 3m --verbose
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/internal/thelma/cli/commands/bee/pin/pin_command.go
+++ b/internal/thelma/cli/commands/bee/pin/pin_command.go
@@ -180,11 +180,11 @@ func (cmd *pinCommand) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 	log.Info().Msgf("Updated version overrides for %s", cmd.options.name)
 
 	if cmd.options.buildNumber != 0 {
-		oldNumber, err := state.Environments().SetBuildNumber(cmd.options.name, cmd.options.buildNumber)
+		oldBuildNumber, err := state.Environments().SetBuildNumber(cmd.options.name, cmd.options.buildNumber)
 		if err != nil {
 			return err
 		}
-		log.Info().Msgf("Set build number to %d for %s (was: %d)", cmd.options.buildNumber, cmd.options.name, oldNumber)
+		log.Info().Msgf("Set build number to %d for %s (was: %d)", cmd.options.buildNumber, cmd.options.name, oldBuildNumber)
 	}
 
 	if err = bees.RefreshBeeGenerator(); err != nil {

--- a/internal/thelma/cli/commands/bee/pin/pin_command.go
+++ b/internal/thelma/cli/commands/bee/pin/pin_command.go
@@ -116,7 +116,7 @@ func (cmd *pinCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 	cobraCommand.Flags().StringVar(&cmd.options.firecloudDevelopRef, flagNames.firecloudDevelopRef, "", "Pin to specific firecloud-develop ref")
 	cobraCommand.Flags().StringVar(&cmd.options.versionsFile, flagNames.versionsFile, "", "Path to versions file")
 	cobraCommand.Flags().StringVar(&cmd.options.versionsFormat, flagNames.versionsFormat, "yaml", fmt.Sprintf("Format of --%s. One of: %s", flagNames.versionsFile, utils.QuoteJoin(versionFormats())))
-	cobraCommand.Flags().IntVar(&cmd.options.buildNumber, flagNames.buildNumber, 0, "Build number to set")
+	cobraCommand.Flags().IntVar(&cmd.options.buildNumber, flagNames.buildNumber, 0, "Configure environment's currently running build number (for use in CI/CD pipelines)")
 	cobraCommand.Flags().BoolVar(&cmd.options.ifExists, flagNames.ifExists, false, "Do not return an error if the BEE does not exist")
 	cobraCommand.Flags().BoolVar(&cmd.options.sync, flagNames.sync, true, "Sync all services in BEE after updating versions")
 	cobraCommand.Flags().BoolVar(&cmd.options.waitHealthy, flagNames.waitHealthy, true, "Wait for BEE's Argo apps to become healthy after syncing")

--- a/internal/thelma/cli/commands/bee/unpin/unpin_command.go
+++ b/internal/thelma/cli/commands/bee/unpin/unpin_command.go
@@ -91,6 +91,12 @@ func (cmd *unpinCommand) Run(app app.ThelmaApp, rc cli.RunContext) error {
 	}
 	log.Info().Msgf("Removed all version overrides for %s", cmd.options.name)
 
+	buildNumber, err := state.Environments().UnsetBuildNumber(cmd.options.name)
+	if err != nil {
+		return err
+	}
+	log.Info().Msgf("Unset build number for %s (was %d)", cmd.options.name, buildNumber)
+
 	if err = bees.RefreshBeeGenerator(); err != nil {
 		return err
 	}

--- a/internal/thelma/render/helmfile/stateval/environment.go
+++ b/internal/thelma/render/helmfile/stateval/environment.go
@@ -7,7 +7,7 @@ type Environment struct {
 	// Name of the environment this release is being deployed to
 	Name string `yaml:"Name"`
 	// BuildNumber Number for a running CI build currently running against this environment (0 if unset)
-	BuildNumber int `yaml:"BuildNumber""`
+	BuildNumber int `yaml:"BuildNumber"`
 	// DEPRECATED (remove once we are no longer running hybrids bee/fiab envs)
 	IsHybrid bool `yaml:"IsHybrid"`
 	// DEPRECATED (remove once we are no longer running hybrid bee/fiab envs)

--- a/internal/thelma/render/helmfile/stateval/environment.go
+++ b/internal/thelma/render/helmfile/stateval/environment.go
@@ -6,6 +6,8 @@ import "github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 type Environment struct {
 	// Name of the environment this release is being deployed to
 	Name string `yaml:"Name"`
+	// BuildNumber Number for a running CI build currently running against this environment (0 if unset)
+	BuildNumber int `yaml:"BuildNumber""`
 	// DEPRECATED (remove once we are no longer running hybrids bee/fiab envs)
 	IsHybrid bool `yaml:"IsHybrid"`
 	// DEPRECATED (remove once we are no longer running hybrid bee/fiab envs)
@@ -18,6 +20,7 @@ type Environment struct {
 func forEnvironment(environment terra.Environment) Environment {
 	var env Environment
 	env.Name = environment.Name()
+	env.BuildNumber = environment.BuildNumber()
 	env.IsHybrid = environment.IsHybrid()
 	if environment.IsHybrid() {
 		env.Fiab.Name = environment.Fiab().Name()

--- a/internal/thelma/render/helmfile/stateval/stateval_test.go
+++ b/internal/thelma/render/helmfile/stateval/stateval_test.go
@@ -38,8 +38,9 @@ func Test_BuildStateValues(t *testing.T) {
 					RequireSuitable: false,
 				},
 				Environment: Environment{
-					Name:     "dev",
-					IsHybrid: false,
+					Name:        "dev",
+					IsHybrid:    false,
+					BuildNumber: 0,
 				},
 				Cluster: Cluster{
 					Name:                "terra-dev",
@@ -79,8 +80,9 @@ func Test_BuildStateValues(t *testing.T) {
 					RequireSuitable: true,
 				},
 				Environment: Environment{
-					Name:     "prod",
-					IsHybrid: false,
+					Name:        "prod",
+					BuildNumber: 0,
+					IsHybrid:    false,
 				},
 				Cluster: Cluster{
 					Name:                "terra-prod",
@@ -120,8 +122,9 @@ func Test_BuildStateValues(t *testing.T) {
 					RequireSuitable: false,
 				},
 				Environment: Environment{
-					Name:     "swatomation",
-					IsHybrid: false,
+					Name:        "swatomation",
+					BuildNumber: 0,
+					IsHybrid:    false,
 				},
 				Cluster: Cluster{
 					Name:                "terra-qa",
@@ -161,8 +164,9 @@ func Test_BuildStateValues(t *testing.T) {
 					RequireSuitable: false,
 				},
 				Environment: Environment{
-					Name:     "fiab-funky-chipmunk",
-					IsHybrid: true,
+					Name:        "fiab-funky-chipmunk",
+					BuildNumber: 456,
+					IsHybrid:    true,
 					Fiab: struct {
 						Name string `yaml:"Name,omitempty"`
 						IP   string `yaml:"IP,omitempty"`

--- a/internal/thelma/state/api/terra/environment.go
+++ b/internal/thelma/state/api/terra/environment.go
@@ -21,5 +21,8 @@ type Environment interface {
 	// deriving full hostnames/URLs in this environment.
 	// E.g. 'true' for dynamic/template environments, 'false' for static
 	NamePrefixesDomain() bool
+	// BuildNumber returns the current build number for any CI builds actively running against the environment.
+	// Returns 0 if no build number has been set.
+	BuildNumber() int
 	Destination
 }

--- a/internal/thelma/state/api/terra/environments.go
+++ b/internal/thelma/state/api/terra/environments.go
@@ -30,6 +30,10 @@ type Environments interface {
 	// PinEnvironmentToTerraHelmfileRef pins an environment to a specific terra-helmfile ref
 	// Note this can be overridden by individual service version overrides
 	PinEnvironmentToTerraHelmfileRef(environmentName string, terraHelmfileRef string) error
+	// SetBuildNumber sets the number for the currently-running build, returning the previous value
+	SetBuildNumber(environmentName string, buildNumber int) (int, error)
+	// UnsetBuildNumber unsets the build number in an environment (i.e. sets it to zero)
+	UnsetBuildNumber(environmentName string) (int, error)
 	// Delete deletes the environment with the given name
 	Delete(name string) error
 }

--- a/internal/thelma/state/providers/gitops/environment.go
+++ b/internal/thelma/state/providers/gitops/environment.go
@@ -16,6 +16,7 @@ type environment struct {
 	fiab               terra.Fiab             // DEPRECATED fiab associated with this environment, if there is one
 	baseDomain         string                 // the stable domain part for this environment
 	namePrefixesDomain bool                   // if baseDomain should be prefixed with destination.name
+	buildNumber        int                    // buildNumber number of a CI build running against the environment, if there is one
 	destination
 }
 
@@ -31,6 +32,7 @@ func newEnvironment(
 	baseDomain string,
 	namePrefixesDomain bool,
 	releases map[string]*appRelease,
+	buildNumber int,
 ) *environment {
 	return &environment{
 		defaultCluster:     defaultCluster,
@@ -40,6 +42,7 @@ func newEnvironment(
 		fiab:               fiab,
 		baseDomain:         baseDomain,
 		namePrefixesDomain: namePrefixesDomain,
+		buildNumber:        buildNumber,
 		destination: destination{
 			name:            name,
 			base:            base,
@@ -104,6 +107,10 @@ func (e *environment) BaseDomain() string {
 
 func (e *environment) NamePrefixesDomain() bool {
 	return e.namePrefixesDomain
+}
+
+func (e *environment) BuildNumber() int {
+	return e.buildNumber
 }
 
 // environmentNamespace return environment namespace for a given environment name

--- a/internal/thelma/state/providers/gitops/environments.go
+++ b/internal/thelma/state/providers/gitops/environments.go
@@ -100,6 +100,14 @@ func (e *environments) UnpinVersions(environmentName string) (map[string]terra.V
 	return e.state.statebucket.UnpinVersions(environmentName)
 }
 
+func (e *environments) SetBuildNumber(environmentName string, buildNumber int) (int, error) {
+	return e.state.statebucket.SetBuildNumber(environmentName, buildNumber)
+}
+
+func (e *environments) UnsetBuildNumber(environmentName string) (int, error) {
+	return e.state.statebucket.UnsetBuildNumber(environmentName)
+}
+
 func (e *environments) Delete(name string) error {
 	return e.state.statebucket.Delete(name)
 }

--- a/internal/thelma/state/providers/gitops/state_loader.go
+++ b/internal/thelma/state/providers/gitops/state_loader.go
@@ -171,6 +171,7 @@ func loadDynamicEnvironments(yamlEnvironments map[string]*environment, sb stateb
 			template.baseDomain,
 			template.namePrefixesDomain,
 			_releases,
+			dynamicEnv.BuildNumber,
 		)
 		env.terraHelmfileRef = dynamicEnv.TerraHelmfileRef
 
@@ -320,6 +321,7 @@ func loadEnvironment(destConfig destinationConfig, _versions Versions, clusters 
 		envConfig.BaseDomain,
 		envConfig.NamePrefixesDomain,
 		_releases,
+		0,
 	)
 
 	for _, _release := range _releases {

--- a/internal/thelma/state/providers/gitops/statebucket/dynamic_environment.go
+++ b/internal/thelma/state/providers/gitops/statebucket/dynamic_environment.go
@@ -12,6 +12,7 @@ type DynamicEnvironment struct {
 	Hybrid           bool                 `json:"hybrid"` // Deprecated / temporary (while we run bees in hybrid mode)
 	Fiab             Fiab                 `json:"fiab"`   // Deprecated / temporary (while we run bees in hybrid mode)
 	TerraHelmfileRef string               `json:"terraHelmfileRef"`
+	BuildNumber      int                  `json:"buildNumber"`
 }
 
 // Fiab (DEPRECATED) is a struct for representing a Fiab in the state file

--- a/internal/thelma/state/providers/gitops/statebucket/dynamic_environment_test.go
+++ b/internal/thelma/state/providers/gitops/statebucket/dynamic_environment_test.go
@@ -29,7 +29,8 @@ func Test_DynamicEnvironment_JSON_Marshaller(t *testing.T) {
     "ip": "",
     "name": ""
   },
-  "terraHelmfileRef": ""
+  "terraHelmfileRef": "",
+  "buildNumber": 0
 }`,
 		},
 		{
@@ -38,6 +39,7 @@ func Test_DynamicEnvironment_JSON_Marshaller(t *testing.T) {
 				d.Name = "e1"
 				d.Template = "t1"
 				d.TerraHelmfileRef = "deadbeef"
+				d.BuildNumber = 12
 				d.Hybrid = true
 				d.Fiab.Name = "fiab1"
 				d.Fiab.IP = "0.0.0.0"
@@ -73,7 +75,8 @@ func Test_DynamicEnvironment_JSON_Marshaller(t *testing.T) {
     "ip": "0.0.0.0",
     "name": "fiab1"
   },
-  "terraHelmfileRef": "deadbeef"
+  "terraHelmfileRef": "deadbeef",
+  "buildNumber": 12
 }`,
 		},
 	}
@@ -111,7 +114,7 @@ func Test_DynamicEnvironment_JSON_Marshaller_ReplacesNilOverrides(t *testing.T) 
 
 	assert.Nil(t, d.Overrides)
 
-	expected := `{"name":"","template":"","overrides":{},"hybrid":false,"fiab":{"ip":"","name":""},"terraHelmfileRef":""}`
+	expected := `{"name":"","template":"","overrides":{},"hybrid":false,"fiab":{"ip":"","name":""},"terraHelmfileRef":"","buildNumber":0}`
 
 	data, err := json.Marshal(d)
 	require.NoError(t, err)
@@ -126,7 +129,7 @@ func Test_DynamicEnvironment_JSON_Marshaller_ReplacesNilOverrides(t *testing.T) 
 func Test_DynamicEnvironment_JSON_Unmarshaller_ReplacesNilOverrides(t *testing.T) {
 	var d DynamicEnvironment
 
-	input := `{"name":"","template":"","overrides":null,"hybrid":false,"fiab":{"ip":"","name":""},"terraHelmfileRef":""}`
+	input := `{"name":"","template":"","overrides":null,"hybrid":false,"fiab":{"ip":"","name":""},"terraHelmfileRef":"","buildNumber":0}`
 	err := json.Unmarshal([]byte(input), &d)
 	require.NoError(t, err)
 

--- a/internal/thelma/state/providers/gitops/statebucket/schema_verifier.go
+++ b/internal/thelma/state/providers/gitops/statebucket/schema_verifier.go
@@ -43,7 +43,7 @@ func (s *schemaVerifier) update(fn transformFn) error {
 func (s *schemaVerifier) checkSchemaVersion(state StateFile) error {
 	if state.SchemaVersion > s.schemaVersion {
 		return fmt.Errorf("statefile schema version %d is greater than %d, the latest "+
-			"schema support by this version of Thelma. Upgrade Thelma to use features that interact with the "+
+			"schema supported by this version of Thelma. Upgrade Thelma to use features that interact with the "+
 			"state file", state.SchemaVersion, s.schemaVersion)
 	}
 	return nil

--- a/internal/thelma/state/providers/gitops/statebucket/statebucket_smoke_test.go
+++ b/internal/thelma/state/providers/gitops/statebucket/statebucket_smoke_test.go
@@ -177,6 +177,18 @@ func TestStateBucket_Overrides(t *testing.T) {
 			assert.Equal(t, "", versions["sam"].TerraHelmfileRef)
 			assert.Equal(t, "my-fc-branch", versions["sam"].FirecloudDevelopRef)
 
+			// set build number
+			assert.Equal(t, 0, envs[0].BuildNumber)
+			oldNumber, err := sb.SetBuildNumber(envs[0].Name, 123)
+			require.NoError(t, err)
+			assert.Equal(t, 0, oldNumber)
+			oldNumber, err = sb.SetBuildNumber(envs[0].Name, 456)
+			require.NoError(t, err)
+			assert.Equal(t, 123, oldNumber)
+			oldNumber, err = sb.UnsetBuildNumber(envs[0].Name)
+			require.NoError(t, err)
+			assert.Equal(t, 456, oldNumber)
+
 			// reload environments
 			envs, err = sb.Environments()
 			require.NoError(t, err)
@@ -192,6 +204,9 @@ func TestStateBucket_Overrides(t *testing.T) {
 			assert.True(t, envs[0].Overrides["sam"].IsEnabled())
 			assert.True(t, envs[0].Overrides["leonardo"].HasEnableOverride())
 			assert.False(t, envs[0].Overrides["leonardo"].IsEnabled())
+
+			// make sure build number is 0
+			assert.Equal(t, 0, envs[0].BuildNumber)
 		})
 	}
 }

--- a/internal/thelma/state/providers/gitops/statefixtures/fixtures/default/statebucket/state.json
+++ b/internal/thelma/state/providers/gitops/statefixtures/fixtures/default/statebucket/state.json
@@ -8,7 +8,8 @@
       "fiab": {
         "name": "fiab-automation-swirly-rabbit",
         "ip": "10.0.0.1"
-      }
+      },
+      "buildNumber": 123
     },
     "fiab-funky-chipmunk": {
       "name": "fiab-funky-chipmunk",

--- a/internal/thelma/state/providers/gitops/statefixtures/fixtures/default/statebucket/state.json
+++ b/internal/thelma/state/providers/gitops/statefixtures/fixtures/default/statebucket/state.json
@@ -27,6 +27,7 @@
           }
         }
       },
+      "buildNumber": 456,
       "hybrid": true,
       "fiab": {
         "name": "fiab-automation-funky-chipmunk",

--- a/internal/thelma/state/providers/gitops/statefixtures/tests/state_loader_test.go
+++ b/internal/thelma/state/providers/gitops/statefixtures/tests/state_loader_test.go
@@ -206,6 +206,11 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 	))
 	require.NoError(t, err)
 	assert.Equal(t, "completely-different-pr", paniniRawls[0].TerraHelmfileRef())
+
+	// test build number is loaded correctly
+	swirlyRabbit, err := state.Environments().Get("fiab-swirly-rabbit")
+	require.NoError(t, err)
+	assert.Equal(t, 123, swirlyRabbit.BuildNumber())
 }
 
 func TestUpdateState(t *testing.T) {


### PR DESCRIPTION
This PR makes it possible to inject the "currently running CI build number" into Helm config, in order to replicate legacy firecloud-develop behavior: https://github.com/broadinstitute/firecloud-develop/blob/dev/jenkins/jenkins-start-fiab.sh#L134

See [this Slack thread](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1657120915595579?thread_ts=1654883676.570769&cid=CQ6SL4N5T) for background.

### Changes
* Add `--build-number` flag to `thelma bee pin`
* Update `thelma bee unpin` to unset build number when it is run
* Make `.Values.Environment.BuildNumber` available in values file templates (it defaults to 0 if not set)