### PR TITLE
[DDO-2190] Go is apparently strict with format strings

### DIFF
--- a/internal/thelma/cli/commands/bee/seed/config.go
+++ b/internal/thelma/cli/commands/bee/seed/config.go
@@ -127,8 +127,11 @@ func GoogleAuthAs(thelma app.ThelmaApp, appRelease terra.AppRelease) (google.Cli
 	default:
 		return nil, fmt.Errorf("thelma doesn't know how to authenticate as %s", appRelease.Name())
 	}
+	if strings.ContainsRune(vaultPath, '%') {
+		vaultPath = fmt.Sprintf(vaultPath, appRelease.Cluster().ProjectSuffix())
+	}
 	return thelma.Clients().GoogleUsingVaultSA(
-		fmt.Sprintf(vaultPath, appRelease.Cluster().ProjectSuffix()),
+		vaultPath,
 		vaultKey,
 	), nil
 }


### PR DESCRIPTION
I thought Go would work similarly to every other language, but this is not the case. Can't run a format string with more varargs then you have insertion points, it will just intentionally botch your string.