### PR TITLE
[DDO-2166] Sign and notarize macOS releases + extras!

### DIFF
--- a/.github/actions/make/action.yaml
+++ b/.github/actions/make/action.yaml
@@ -24,9 +24,15 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Cache go deps across builds
     - uses: actions/setup-go@v3
       with:
         go-version: '1.17'
         cache: true
-    - run: make ${{ inputs.target }} OUTPUT_DIR=${{ inputs.output-dir }} OS=${{ inputs.os }} ARCH=${{ inputs.arch }} VERSION=${{ inputs.version }}
+    - run: |
+        make ${{ inputs.target }} \
+          OUTPUT_DIR=${{ inputs.output-dir }} \
+          OS=${{ inputs.os }}
+          ARCH=${{ inputs.arch }} \
+          VERSION=${{ inputs.version }}
       shell: bash

--- a/.github/actions/make/action.yaml
+++ b/.github/actions/make/action.yaml
@@ -22,12 +22,10 @@ inputs:
     default: unknown
     required: false
 runs:
-  using: 'docker'
-  image: golang:1.17-bullseye
-  args:
-    - make
-    - ${{ inputs.target }}
-    - OUTPUT_DIR=${{ inputs.output-dir }}
-    - OS=${{ inputs.os }}
-    - ARCH=${{ inputs.arch }}
-    - VERSION=${{ inputs.version }}
+  using: 'composite'
+  steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.17'
+        cache: true
+    - run: make ${{ inputs.target }} OUTPUT_DIR=${{ inputs.output-dir }} OS=${{ inputs.os }} ARCH=${{ inputs.arch }} VERSION=${{ inputs.version }}

--- a/.github/actions/make/action.yaml
+++ b/.github/actions/make/action.yaml
@@ -21,6 +21,10 @@ inputs:
     description: 'Semantic version string to use when generating artifacts'
     default: unknown
     required: false
+  rel-dir:
+    description: 'Release output directory, used to parallelize builds when using actions/cache'
+    default: ./output/releases
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -33,5 +37,6 @@ runs:
           OUTPUT_DIR=${{ inputs.output-dir }} \
           OS=${{ inputs.os }} \
           ARCH=${{ inputs.arch }} \
-          VERSION=${{ inputs.version }}
+          VERSION=${{ inputs.version }} \
+          RELEASE_ARCHIVE_DIR=${{ inputs.rel-dir }}
       shell: bash

--- a/.github/actions/make/action.yaml
+++ b/.github/actions/make/action.yaml
@@ -29,3 +29,4 @@ runs:
         go-version: '1.17'
         cache: true
     - run: make ${{ inputs.target }} OUTPUT_DIR=${{ inputs.output-dir }} OS=${{ inputs.os }} ARCH=${{ inputs.arch }} VERSION=${{ inputs.version }}
+      shell: bash

--- a/.github/actions/make/action.yaml
+++ b/.github/actions/make/action.yaml
@@ -28,11 +28,10 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: '1.17'
-        cache: true
     - run: |
         make ${{ inputs.target }} \
           OUTPUT_DIR=${{ inputs.output-dir }} \
-          OS=${{ inputs.os }}
+          OS=${{ inputs.os }} \
           ARCH=${{ inputs.arch }} \
           VERSION=${{ inputs.version }}
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
           version: ${{ needs.checkout-and-bump.outputs.version }}
 
   sign-and-notarize-amd64:
-    runs-on: macos-11
+    runs-on: macos-latest
     needs: bump-and-build1
     steps:
       - name: Checkout current code
@@ -110,8 +110,6 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          pwd
-          ls
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
@@ -146,7 +144,7 @@ jobs:
           version: ${{ needs.checkout-and-bump.outputs.version }}
 
   sign-and-notarize-arm64:
-    runs-on: macos-11
+    runs-on: macos-latest
     needs: build2
     steps:
       - name: Checkout current code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,8 +44,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -80,14 +78,15 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ needs.build.outputs.version }}
+          version: ${{ steps.tag.outputs.tag }}
+
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
-          version: ${{ needs.build.outputs.version }}
+          version: ${{ steps.tag.outputs.tag }}
 
       - name: Build arm64 M1 darwin binary distribution
         uses: ./.github/actions/make
@@ -95,12 +94,12 @@ jobs:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ needs.build.outputs.version }}
+          version: ${{ steps.tag.outputs.tag }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ needs.build.outputs.version }}
+          version: ${{ steps.tag.outputs.tag }}
 
   sign-and-notarize:
     runs-on: macos-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@ name: Bump, Tag, and Publish
 #  1. Bump the version number and tag the release if not a PR
 #  2. Build docker image and publish to GCR
 #
+# This workflow uses caching and parallel builds for speedup as follows:
+# 1. The `cache-go-deps` job caches ~/go just for this workflow
+# 2. `
+#
 # When run on merge to main, it tags and bumps the patch version by default. You can
 # bump other parts of the version by putting #major, #minor, or #patch in your commit
 # message.
@@ -42,7 +46,7 @@ env:
   # Apple Developer application password
   THELMA_MACOS_APP_PWD: ${{ secrets.THELMA_MACOS_APP_PWD }}
 jobs:
-  build:
+  bump:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.tag }}
@@ -51,15 +55,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}
-
-      - name: Cache build directory
-        id: cache-build
-        uses: actions/cache@v3
-        env:
-          cache-name: build-dir-cache
-        with:
-          path: ./output
-          key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Bump tag to new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
@@ -70,8 +65,55 @@ jobs:
           RELEASE_BRANCHES: main
           WITH_V: true
 
+  cache-go-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Cache Go deps
+        id: go-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-cache
+        with:
+          path: ~/go
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-go-cache
+
+      - run: go mod download -x
+        shell: bash
+
+  build-linux-amd64:
+    runs-on: ubuntu-latest
+    needs: [bump, cache-go-deps]
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull Go deps cache
+        id: go-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-cache
+        with:
+          path: ~/go
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-go-cache
+
+      - name: Cache Linux amd64 build directories
+        id: cache-build-linux-amd64
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache-linux-amd64
+        with:
+          path: ./output/releases
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-linux-amd64
+
       #
-      # Build binary artifacts for Darwin and Linux
+      # Build binary artifacts for amd64 Linux
       #
       - name: Build linux binary distribution
         uses: ./.github/actions/make
@@ -79,40 +121,137 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ steps.tag.outputs.tag }}
-      - name: Build amd64 darwin binary distribution
-        uses: ./.github/actions/make
-        with:
-          target: "release"
-          os: darwin
-          arch: amd64
-          version: ${{ steps.tag.outputs.tag }}
+          version: ${{ needs.bump.outputs.version }}
 
-      - name: Build arm64 M1 darwin binary distribution
-        uses: ./.github/actions/make
-        with:
-          target: "release"
-          os: darwin
-          arch: arm64
-          version: ${{ steps.tag.outputs.tag }}
-
-  sign-and-notarize:
-    runs-on: macos-latest
-    needs: build
+  build-darwin-amd64:
+    runs-on: ubuntu-latest
+    needs: [bump, cache-go-deps]
+    outputs:
+      rel-dir: ${{ steps.rel-dir-name.outputs.rel-dir }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}
 
-      - name: Pull cache
-        id: pull-cache
+      - name: Pull Go deps cache
+        id: go-cache
         uses: actions/cache@v3
         env:
-          cache-name: build-dir-cache
+          cache-name: go-cache
         with:
-          path: ./output
-          key: commit-${{ github.sha }}-job-${{ github.run_id }}
+          path: ~/go
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-go-cache
+
+      - name: Set release output directory
+        id: rel-dir-name
+        run: |
+          REL_DIR_PATH=./output/releases/darwin-amd64
+          echo ::set-output "name=rel-dir::${REL_DIR_PATH}"
+
+      - name: Cache release directory
+        id: cache-release-darwin-amd64
+        uses: actions/cache@v3
+        env:
+          cache-name: release-dir-cache-darwin-amd64
+        with:
+          path: ${{ steps.rel-dir-name.outputs.rel-dir }}
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-darwin-amd64
+
+      #
+      # Build binary artifacts for amd64 Darwin
+      #
+      - name: Build amd64 darwin binary distribution
+        uses: ./.github/actions/make
+        with:
+          target: "release"
+          os: darwin
+          arch: amd64
+          version: ${{ needs.bump.outputs.version }}
+          rel-dir: ${{ steps.rel-dir-name.outputs.rel-dir }}
+
+  build-darwin-arm64:
+    runs-on: ubuntu-latest
+    needs: [bump, cache-go-deps]
+    outputs:
+      rel-dir: ${{ steps.rel-dir-name.outputs.rel-dir }}
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull Go deps cache
+        id: go-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-cache
+        with:
+          path: ~/go
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-go-cache
+
+      - name: Set release output directory
+        id: rel-dir-name
+        run: |
+          REL_DIR_PATH=./output/releases/darwin-arm64
+          echo ::set-output "name=rel-dir::${REL_DIR_PATH}"
+
+      - name: Cache release directory
+        id: cache-release-darwin-arm64
+        uses: actions/cache@v3
+        env:
+          cache-name: release-dir-cache-darwin-arm64
+        with:
+          path: ${{ steps.rel-dir-name.outputs.rel-dir }}
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-darwin-arm64
+
+      #
+      # Build binary artifacts for arm64 Darwin
+      #
+      - name: Build arm64 darwin binary distribution
+        uses: ./.github/actions/make
+        with:
+          target: "release"
+          os: darwin
+          arch: arm64
+          version: ${{ needs.bump.outputs.version }}
+          rel-dir: ${{ steps.rel-dir-name.outputs.rel-dir }}
+
+  sign-and-notarize:
+    runs-on: macos-latest
+    needs: [bump, build-linux-amd64, build-darwin-amd64, build-darwin-arm64]
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull Linux amd64 build directories
+        id: cache-build-linux-amd64
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache-linux-amd64
+        with:
+          path: ./output/releases
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-linux-amd64
+
+      - name: Pull Darwin amd64 release directory
+        id: cache-release-darwin-amd64
+        uses: actions/cache@v3
+        env:
+          cache-name: release-dir-cache-darwin-amd64
+        with:
+          path: ${{ needs.build-darwin-amd64.outputs.rel-dir }}
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-darwin-amd64
+
+      - name: Pull Darwin arm64 release directory
+        id: cache-release-darwin-arm64
+        uses: actions/cache@v3
+        env:
+          cache-name: release-dir-cache-darwin-arm64
+        with:
+          path: ${{ needs.build-darwin-arm64.outputs.rel-dir }}
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-darwin-arm64
 
       # A second cache is needed to force GH to upload the new macOS tarballs,
       # since the existing cache already exists and therefore changes made during this step
@@ -141,12 +280,12 @@ jobs:
       - name: Sign and notarize macOS releases and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz
-          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-amd64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-arm64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
-    needs: [build, sign-and-notarize]
+    needs: [bump, build-linux-amd64, build-darwin-amd64, build-darwin-arm64, sign-and-notarize]
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -166,7 +305,7 @@ jobs:
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ needs.build.outputs.version }}
+          version: ${{ needs.bump.outputs.version }}
 
       #
       # Build Docker image
@@ -177,7 +316,7 @@ jobs:
         id: image-name
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ needs.build.outputs.version }}"
+          DOCKER_TAG="${{ needs.bump.outputs.version }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
@@ -186,7 +325,7 @@ jobs:
       - name: Build image
         run: |
           docker build \
-            --build-arg THELMA_LINUX_RELEASE=thelma_${{ needs.build.outputs.version }}_linux_amd64.tar.gz \
+            --build-arg THELMA_LINUX_RELEASE=thelma_${{ needs.bump.outputs.version }}_linux_amd64.tar.gz \
             -t ${{ steps.image-name.outputs.tagged }} .
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
@@ -203,14 +342,14 @@ jobs:
           service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
       - name: Upload release files to bucket
         run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.build.outputs.version }}/
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump.outputs.version }}/
       - name: Update tags.json
         # TODO: we can make this more sophisticated at some point, but the goal right now
         # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
         if: github.event_name != 'pull_request'
         run: |
           cat <<EOF > tags.json
-          {"latest":"${{ needs.build.outputs.version }}"}
+          {"latest":"${{ needs.bump.outputs.version }}"}
           EOF
           gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,6 +123,10 @@ jobs:
           path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
+      # A second cache is needed to force GH to upload the new macOS tarballs,
+      # since the existing cache already exists and therefore changes made during this step
+      # are not saved for some reason. This new cache will be used during the final job
+      # where the docker image is made and the release artifacts are uploaded.
       - name: Create release cache
         id: release-cache
         uses: actions/cache@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: .
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Bump tag to new version
@@ -93,13 +93,18 @@ jobs:
     runs-on: macos-latest
     needs: bump-and-build1
     steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
       - name: Pull cache
         id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
         with:
-          path: .
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Sign and notarize macOS release and create tarball
@@ -113,13 +118,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: sign-and-notarize-amd64
     steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
       - name: Pull cache
         id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
         with:
-          path: .
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Build arm64 M1 darwin binary distribution
@@ -139,13 +149,18 @@ jobs:
     runs-on: macos-latest
     needs: build2
     steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
       - name: Pull cache
         id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
         with:
-          path: .
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Sign and notarize macOS release and create tarball
@@ -163,7 +178,7 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: .
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id}}
 
       #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,7 +174,7 @@ jobs:
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build --build-arg THELMA_VERSION=${{ needs.build.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
+        run: "docker build -t ${{ steps.image-name.outputs.tagged }} ."
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ env:
   # Apple Developer application password
   THELMA_MACOS_APP_PWD: ${{ secrets.THELMA_MACOS_APP_PWD }}
 jobs:
-  checkout-and-bump:
+  bump-and-build1:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ needs.checkout-and-bump.outputs.version }}
@@ -58,8 +58,8 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ~/output
-          key: commit-${{ github.sha }}-job-${{ github.job}}
+          path: ${GITHUB_WORKSPACE}/output
+          key: commit-${{ github.sha }}-job-${{ github.job }}
 
       - name: Bump tag to new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
@@ -69,24 +69,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           RELEASE_BRANCHES: main
           WITH_V: true
-
-  build:
-    runs-on: macos-11
-    needs: checkout-and-bump
-    steps:
-      - name: Checkout current code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
-      - name: Cache build directory
-        id: cache-build
-        uses: actions/cache@v3
-        env:
-          cache-name: build-dir-cache
-        with:
-          path: ~/output
-          key: commit-${{ github.sha }}-job-${{ github.job}}
 
       #
       # Build binary artifacts for Darwin and Linux
@@ -99,14 +81,45 @@ jobs:
           os: linux
           arch: amd64
           version: ${{ needs.checkout-and-bump.outputs.version }}
-      - name: Build darwin binary distribution
+      - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
           version: ${{ needs.checkout-and-bump.outputs.version }}
-      - name: Build M1 darwin binary distribution
+
+  sign-and-notarize-amd64:
+    runs-on: macos-11
+    needs: bump-and-build1
+    steps:
+      - name: Cache build directory
+        id: cache-build
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache
+        with:
+          path: ${GITHUB_WORKSPACE}/output
+          key: commit-${{ github.sha }}-job-${{ github.job }}
+
+      - name: Sign and notarize macOS release and create tarball
+        id: san-tarball
+        run: |
+          ${GITHUB_WORKSPACE}/scripts/sign-and-notarize.sh ${GITHUB_WORKSPACE}/output/release-assembly ${GITHUB_WORKSPACE}/output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
+
+  build2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache build directory
+        id: cache-build
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache
+        with:
+          path: ${GITHUB_WORKSPACE}/output
+          key: commit-${{ github.sha }}-job-${{ github.job }}
+
+      - name: Build arm64 M1 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
@@ -119,9 +132,9 @@ jobs:
           target: "checksum"
           version: ${{ needs.checkout-and-bump.outputs.version }}
 
-  dockerize-and-push:
-    runs-on: ubuntu-latest
-    needs: build
+  sign-and-notarize-arm64:
+    runs-on: macos-11
+    needs: build2
     steps:
       - name: Cache build directory
         id: cache-build
@@ -129,7 +142,25 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ~/output
+          path: ${GITHUB_WORKSPACE}/output
+          key: commit-${{ github.sha }}-job-${{ github.job }}
+
+      - name: Sign and notarize macOS release and create tarball
+        id: san-tarball
+        run: |
+          ${GITHUB_WORKSPACE}/scripts/sign-and-notarize.sh ${GITHUB_WORKSPACE}/output/release-assembly ${GITHUB_WORKSPACE}/output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
+
+  dockerize-and-push:
+    runs-on: ubuntu-latest
+    needs: sign-and-notarize-arm64
+    steps:
+      - name: Cache build directory
+        id: cache-build
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache
+        with:
+          path: ${GITHUB_WORKSPACE}/output
           key: commit-${{ github.sha }}-job-${{ github.job}}
 
       #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,7 +127,7 @@ jobs:
         id: create-kc
         run: |
           mkdir -p ./output/kc
-          echo ${THELMA_MACOS_CERT} | base64 —decode > ./output/kc/certificate.p12
+          echo ${THELMA_MACOS_CERT} | base64 --decode > ./output/kc/certificate.p12
           security create-keychain -p temp-kc-pwd ./output/kc/certificate.p12
           security default-keychain -s ./output/kc/release.keychain
           security unlock-keychain -p temp-kc-pwd ./output/kc/release.keychain

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,12 +146,6 @@ jobs:
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_arm64.tar.gz
 
-      - name: Generate checksum file
-        uses: ./.github/actions/make
-        with:
-          target: "checksum"
-          version: ${{ steps.tag.outputs.tag }}
-
   dockerize-and-push:
     runs-on: ubuntu-latest
     needs: [build, sign-and-notarize]
@@ -169,6 +163,12 @@ jobs:
         with:
           path: ./output/releases
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
+      - name: Generate checksum file
+        uses: ./.github/actions/make
+        with:
+          target: "checksum"
+          version: ${{ steps.tag.outputs.tag }}
+
       #
       # Build Docker image
       #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,8 +93,13 @@ jobs:
     runs-on: macos-11
     needs: bump-and-build1
     steps:
-      - name: Cache build directory
-        id: cache-build
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull cache
+        id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
@@ -113,8 +118,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: sign-and-notarize-amd64
     steps:
-      - name: Cache build directory
-        id: cache-build
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull cache
+        id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
@@ -139,8 +149,13 @@ jobs:
     runs-on: macos-11
     needs: build2
     steps:
-      - name: Cache build directory
-        id: cache-build
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull cache
+        id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
+        shell: zsh {0}
         run: |
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
@@ -163,6 +164,7 @@ jobs:
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
+        shell: zsh {0}
         run: |
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,14 +80,14 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
 
       - name: Build arm64 M1 darwin binary distribution
         uses: ./.github/actions/make
@@ -95,12 +95,12 @@ jobs:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
 
   sign-and-notarize:
     runs-on: macos-latest
@@ -123,8 +123,8 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
-          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
@@ -153,14 +153,14 @@ jobs:
         id: image-name
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ needs.bump-and-build1.outputs.version }}"
+          DOCKER_TAG="${{ needs.build.outputs.version }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build --build-arg THELMA_VERSION=${{ needs.bump-and-build1.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
+        run: "docker build --build-arg THELMA_VERSION=${{ needs.build.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1
@@ -176,14 +176,14 @@ jobs:
           service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
       - name: Upload release files to bucket
         run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump-and-build1.outputs.version }}/
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.build.outputs.version }}/
       - name: Update tags.json
         # TODO: we can make this more sophisticated at some point, but the goal right now
         # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
         if: github.event_name != 'pull_request'
         run: |
           cat <<EOF > tags.json
-          {"latest":"${{ needs.bump-and-build1.outputs.version }}"}
+          {"latest":"${{ needs.build.outputs.version }}"}
           EOF
           gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,7 +132,7 @@ jobs:
         env:
           cache-name: release-cache
         with:
-          path: ./output
+          path: ./output/releases
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
 
       - name: Create temp keychain
@@ -167,7 +167,7 @@ jobs:
         env:
           cache-name: release-cache
         with:
-          path: ./output
+          path: ./output/releases
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
 
       #
@@ -186,7 +186,10 @@ jobs:
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build -t ${{ steps.image-name.outputs.tagged }} ."
+        run: |
+          docker build \
+            --build-arg THELMA_LINUX_RELEASE=thelma_${{ needs.build.outputs.version }}_linux_amd64.tar.gz \
+            -t ${{ steps.image-name.outputs.tagged }} .
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,13 @@ jobs:
       #
       # Build binary artifacts for Darwin and Linux
       #
+      - name: Build linux binary distribution
+        uses: ./.github/actions/make
+        with:
+          target: "release"
+          os: linux
+          arch: amd64
+          version: ${{ steps.tag.outputs.tag }}
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
@@ -87,15 +94,6 @@ jobs:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ steps.tag.outputs.tag }}
-
-      # This build must go last in order to reuse build artifacts for making the docker image
-      - name: Build linux binary distribution
-        uses: ./.github/actions/make
-        with:
-          target: "release"
-          os: linux
-          arch: amd64
           version: ${{ steps.tag.outputs.tag }}
 
   sign-and-notarize:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,6 +123,17 @@ jobs:
           path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
+      - name: Create temp keychain
+        id: create-kc
+        run: |
+          mkdir -p ./output/kc
+          echo ${THELMA_MACOS_CERT} | base64 —decode > ./output/kc/certificate.p12
+          security create-keychain -p temp-kc-pwd ./output/kc/certificate.p12
+          security default-keychain -s ./output/kc/release.keychain
+          security unlock-keychain -p temp-kc-pwd ./output/kc/release.keychain
+          security import ./output/kc/certificate.p12 -k ./output/kc/release.keychain -P ${THELMA_MACOS_CERT_PWD} -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k temp-kc-pwd ./output/kc/release.keychain
+
       - name: Sign and notarize macOS releases and create tarball
         id: san-tarball
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,6 +123,15 @@ jobs:
           path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
+      - name: Create release cache
+        id: release-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: release-dir-cache
+        with:
+          path: ./output/releases
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
+
       - name: Create temp keychain
         id: create-kc
         run: |
@@ -137,6 +146,7 @@ jobs:
       - name: Sign and notarize macOS releases and create tarball
         id: san-tarball
         run: |
+          mkdir -p 
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_arm64.tar.gz
 
@@ -149,14 +159,14 @@ jobs:
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}
 
-      - name: Pull cache
-        id: pull-cache
+      - name: Pull release cache
+        id: release-cache
         uses: actions/cache@v3
         env:
-          cache-name: build-dir-cache
+          cache-name: release-dir-cache
         with:
-          path: ./output
-          key: commit-${{ github.sha }}-job-${{ github.run_id}}
+          path: ./output/releases
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
 
       #
       # Build Docker image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,6 +105,8 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
+          pwd
+          ls
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
 
   build2:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -119,7 +121,7 @@ jobs:
           path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
-      - name: Sign and notarize macOS release and create tarball
+      - name: Sign and notarize macOS releases and create tarball
         id: san-tarball
         run: |
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,6 +110,7 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
+          brew install bash
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
@@ -164,6 +165,7 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
+          brew install bash
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,29 @@ jobs:
           RELEASE_BRANCHES: main
           WITH_V: true
 
+      # Get values for cache paths to be used in later steps
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Cache go build cache, used to speedup go test
+      - name: Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      # Cache go mod cache, used to speedup builds
+      - name: Go Mod Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       #
       # Build binary artifacts for Darwin and Linux
       #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
 
   dockerize-and-push:
     runs-on: ubuntu-latest
-    needs: [build, sign-and-notarize-arm64]
+    needs: [build, sign-and-notarize]
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,12 @@ env:
   THELMA_RELEASE_BUCKET: thelma-releases
   # Version of gcloud to use for workflow steps that require it
   SETUP_GCLOUD_VERSION: '0.3.0'
+  # macOS release signing cert
+  THELMA_MACOS_CERT: ${{ secrets.THELMA_MACOS_CERT}}
+  # macOS release signing cert password
+  THELMA_MACOS_CERT_PWD: ${{ secrets.THELMA_MACOS_CERT_PWD }}
+  # Apple Developer application password
+  THELMA_MACOS_APP_PWD: ${{ secrets.THELMA_MACOS_APP_PWD }}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -52,29 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           RELEASE_BRANCHES: main
           WITH_V: true
-
-      # Get values for cache paths to be used in later steps
-      - id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # Cache go build cache, used to speedup go test
-      - name: Go Build Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      # Cache go mod cache, used to speedup builds
-      - name: Go Mod Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       #
       # Build binary artifacts for Darwin and Linux

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,12 +98,6 @@ jobs:
           arch: amd64
           version: ${{ steps.tag.outputs.tag }}
 
-      - name: Generate checksum file
-        uses: ./.github/actions/make
-        with:
-          target: "checksum"
-          version: ${{ steps.tag.outputs.tag }}
-
   sign-and-notarize:
     runs-on: macos-latest
     needs: build
@@ -152,6 +146,12 @@ jobs:
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_arm64.tar.gz
 
+      - name: Generate checksum file
+        uses: ./.github/actions/make
+        with:
+          target: "checksum"
+          version: ${{ steps.tag.outputs.tag }}
+
   dockerize-and-push:
     runs-on: ubuntu-latest
     needs: [build, sign-and-notarize]
@@ -169,7 +169,6 @@ jobs:
         with:
           path: ./output/releases
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
-
       #
       # Build Docker image
       #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
   bump-and-build1:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ needs.checkout-and-bump.outputs.version }}
+      version: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ./output
+          path: .
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Bump tag to new version
@@ -80,54 +80,44 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ needs.checkout-and-bump.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
-          version: ${{ needs.checkout-and-bump.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
 
   sign-and-notarize-amd64:
     runs-on: macos-latest
     needs: bump-and-build1
     steps:
-      - name: Checkout current code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
       - name: Pull cache
         id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
         with:
-          path: ./output
+          path: .
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
     runs-on: ubuntu-latest
     needs: sign-and-notarize-amd64
     steps:
-      - name: Checkout current code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
       - name: Pull cache
         id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
         with:
-          path: ./output
+          path: .
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Build arm64 M1 darwin binary distribution
@@ -136,35 +126,30 @@ jobs:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ needs.checkout-and-bump.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ needs.checkout-and-bump.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
 
   sign-and-notarize-arm64:
     runs-on: macos-latest
     needs: build2
     steps:
-      - name: Checkout current code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
       - name: Pull cache
         id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache
         with:
-          path: ./output
+          path: .
           key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
@@ -176,7 +161,7 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ./output
+          path: .
           key: commit-${{ github.sha }}-job-${{ github.run_id}}
 
       #
@@ -188,14 +173,14 @@ jobs:
         id: image-name
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ needs.checkout-and-bump.outputs.version }}"
+          DOCKER_TAG="${{ needs.bump-and-build1.outputs.version }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build --build-arg THELMA_VERSION=${{ needs.checkout-and-bump.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
+        run: "docker build --build-arg THELMA_VERSION=${{ needs.bump-and-build1.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1
@@ -211,14 +196,14 @@ jobs:
           service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
       - name: Upload release files to bucket
         run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.checkout-and-bump.outputs.version }}/
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump-and-build1.outputs.version }}/
       - name: Update tags.json
         # TODO: we can make this more sophisticated at some point, but the goal right now
         # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
         if: github.event_name != 'pull_request'
         run: |
           cat <<EOF > tags.json
-          {"latest":"${{ needs.checkout-and-bump.outputs.version }}"}
+          {"latest":"${{ needs.bump-and-build1.outputs.version }}"}
           EOF
           gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,6 +109,7 @@ jobs:
 
   build2:
     runs-on: ubuntu-latest
+    needs: sign-and-notarize-amd64
     steps:
       - name: Cache build directory
         id: cache-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,13 +42,24 @@ env:
   # Apple Developer application password
   THELMA_MACOS_APP_PWD: ${{ secrets.THELMA_MACOS_APP_PWD }}
 jobs:
-  build:
+  checkout-and-bump:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ needs.checkout-and-bump.outputs.version }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Cache build directory
+        id: cache-build
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache
+        with:
+          path: ~/output
+          key: commit-${{ github.sha }}-job-${{ github.job}}
 
       - name: Bump tag to new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
@@ -58,6 +69,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           RELEASE_BRANCHES: main
           WITH_V: true
+
+  build:
+    runs-on: macos-11
+    needs: checkout-and-bump
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Cache build directory
+        id: cache-build
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache
+        with:
+          path: ~/output
+          key: commit-${{ github.sha }}-job-${{ github.job}}
 
       #
       # Build binary artifacts for Darwin and Linux
@@ -69,26 +98,39 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ steps.tag.outputs.tag }}
+          version: ${{ needs.checkout-and-bump.outputs.version }}
       - name: Build darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
-          version: ${{ steps.tag.outputs.tag }}
+          version: ${{ needs.checkout-and-bump.outputs.version }}
       - name: Build M1 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ steps.tag.outputs.tag }}
+          version: ${{ needs.checkout-and-bump.outputs.version }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ steps.tag.outputs.tag }}
+          version: ${{ needs.checkout-and-bump.outputs.version }}
+
+  dockerize-and-push:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Cache build directory
+        id: cache-build
+        uses: actions/cache@v3
+        env:
+          cache-name: build-dir-cache
+        with:
+          path: ~/output
+          key: commit-${{ github.sha }}-job-${{ github.job}}
 
       #
       # Build Docker image
@@ -99,14 +141,14 @@ jobs:
         id: image-name
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ steps.tag.outputs.tag }}"
+          DOCKER_TAG="${{ needs.checkout-and-bump.outputs.version }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build --build-arg THELMA_VERSION=${{ steps.tag.outputs.tag }} -t ${{ steps.image-name.outputs.tagged }} ."
+        run: "docker build --build-arg THELMA_VERSION=${{ needs.checkout-and-bump.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1
@@ -122,14 +164,14 @@ jobs:
           service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
       - name: Upload release files to bucket
         run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ steps.tag.outputs.tag }}/
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.checkout-and-bump.outputs.version }}/
       - name: Update tags.json
         # TODO: we can make this more sophisticated at some point, but the goal right now
         # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
         if: github.event_name != 'pull_request'
         run: |
           cat <<EOF > tags.json
-          {"latest":"${{ steps.tag.outputs.tag }}"}
+          {"latest":"${{ needs.checkout-and-bump.outputs.version }}"}
           EOF
           gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,22 @@ name: Bump, Tag, and Publish
 #  2. Build docker image and publish to GCR
 #
 # This workflow uses caching and parallel builds for speedup as follows:
-# 1. The `cache-go-deps` job caches ~/go just for this workflow
-# 2. `
+# 1. The `cache-go-deps` job caches ~/go just for this workflow.
+# Then, in parallel:
+# 2a. The `build-linux-amd64` job pulls the Go cache and creates its own cache
+#    for `./output/releases`.
+# 2b. The `build-darwin-amd64` job pulls the Go cache and creates its own cache
+#    for `./output/releases/darwin-amd64`.
+# 2c. The `build-darwin-arm64` job pulls the Go cache and creates its own cache
+#    for `./output/releases/darwin-arm64`.
+# Afterwards:
+# 3. The `sign-and-notarize` job pulls the above release caches, signs and notarizes
+#    the darwin release tarballs, puts the output in `./output/releases`, and creates
+#    a new cache for `./output/releases`. This is necessary because the existing cache
+#    won't be uploaded for that directory as it already exists.
+# 4. The `dockerize-and-push` job pulls the new release cache from the previous job,
+#    builds the docker image, pushes it, and uploads the tarballs in `./output/releases`
+#    to the Thelma release GCS bucket.
 #
 # When run on merge to main, it tags and bumps the patch version by default. You can
 # bump other parts of the version by putting #major, #minor, or #patch in your commit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,6 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          brew install bash
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
@@ -165,7 +164,6 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          brew install bash
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -163,11 +163,12 @@ jobs:
         with:
           path: ./output/releases
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
+
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ steps.tag.outputs.tag }}
+          version: ${{ needs.build.outputs.version }}
 
       #
       # Build Docker image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ env:
   # Apple Developer application password
   THELMA_MACOS_APP_PWD: ${{ secrets.THELMA_MACOS_APP_PWD }}
 jobs:
-  bump-and-build1:
+  build:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.tag }}
@@ -89,49 +89,6 @@ jobs:
           arch: amd64
           version: ${{ needs.bump-and-build1.outputs.version }}
 
-  sign-and-notarize-amd64:
-    runs-on: macos-latest
-    needs: bump-and-build1
-    steps:
-      - name: Checkout current code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
-      - name: Pull cache
-        id: pull-cache
-        uses: actions/cache@v3
-        env:
-          cache-name: build-dir-cache
-        with:
-          path: ./output
-          key: commit-${{ github.sha }}-job-${{ github.run_id }}
-
-      - name: Sign and notarize macOS release and create tarball
-        id: san-tarball
-        run: |
-          pwd
-          ls
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
-
-  build2:
-    runs-on: ubuntu-latest
-    needs: [bump-and-build1, sign-and-notarize-amd64]
-    steps:
-      - name: Checkout current code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
-      - name: Pull cache
-        id: pull-cache
-        uses: actions/cache@v3
-        env:
-          cache-name: build-dir-cache
-        with:
-          path: ./output
-          key: commit-${{ github.sha }}-job-${{ github.run_id }}
-
       - name: Build arm64 M1 darwin binary distribution
         uses: ./.github/actions/make
         with:
@@ -145,9 +102,9 @@ jobs:
           target: "checksum"
           version: ${{ needs.bump-and-build1.outputs.version }}
 
-  sign-and-notarize-arm64:
+  sign-and-notarize:
     runs-on: macos-latest
-    needs: [bump-and-build1, build2]
+    needs: build
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -166,14 +123,20 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
-    needs: [bump-and-build1, sign-and-notarize-arm64]
+    needs: [build, sign-and-notarize-arm64]
     steps:
-      - name: Cache build directory
-        id: cache-build
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Pull cache
+        id: pull-cache
         uses: actions/cache@v3
         env:
           cache-name: build-dir-cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,8 +58,8 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ${GITHUB_WORKSPACE}/output
-          key: commit-${{ github.sha }}-job-${{ github.job }}
+          path: ./output
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Bump tag to new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
@@ -99,13 +99,13 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ${GITHUB_WORKSPACE}/output
-          key: commit-${{ github.sha }}-job-${{ github.job }}
+          path: ./output
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ${GITHUB_WORKSPACE}/scripts/sign-and-notarize.sh ${GITHUB_WORKSPACE}/output/release-assembly ${GITHUB_WORKSPACE}/output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
     runs-on: ubuntu-latest
@@ -117,8 +117,8 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ${GITHUB_WORKSPACE}/output
-          key: commit-${{ github.sha }}-job-${{ github.job }}
+          path: ./output
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Build arm64 M1 darwin binary distribution
         uses: ./.github/actions/make
@@ -143,13 +143,13 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ${GITHUB_WORKSPACE}/output
-          key: commit-${{ github.sha }}-job-${{ github.job }}
+          path: ./output
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ${GITHUB_WORKSPACE}/scripts/sign-and-notarize.sh ${GITHUB_WORKSPACE}/output/release-assembly ${GITHUB_WORKSPACE}/output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
@@ -161,8 +161,8 @@ jobs:
         env:
           cache-name: build-dir-cache
         with:
-          path: ${GITHUB_WORKSPACE}/output
-          key: commit-${{ github.sha }}-job-${{ github.job}}
+          path: ./output
+          key: commit-${{ github.sha }}-job-${{ github.run_id}}
 
       #
       # Build Docker image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,6 @@ jobs:
       #
       # Build binary artifacts for Darwin and Linux
       #
-      # TODO: would save time if we could cache go module dependencies across build steps
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,14 +80,14 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ jobs.bump-and-build1.outputs.version }}
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ jobs.bump-and-build1.outputs.version }}
 
   sign-and-notarize-amd64:
     runs-on: macos-latest
@@ -112,7 +112,7 @@ jobs:
         run: |
           pwd
           ls
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ jobs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
     runs-on: ubuntu-latest
@@ -138,12 +138,12 @@ jobs:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ jobs.bump-and-build1.outputs.version }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ needs.bump-and-build1.outputs.version }}
+          version: ${{ jobs.bump-and-build1.outputs.version }}
 
   sign-and-notarize-arm64:
     runs-on: macos-latest
@@ -166,7 +166,7 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ jobs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
@@ -190,14 +190,14 @@ jobs:
         id: image-name
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ needs.bump-and-build1.outputs.version }}"
+          DOCKER_TAG="${{ jobs.bump-and-build1.outputs.version }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build --build-arg THELMA_VERSION=${{ needs.bump-and-build1.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
+        run: "docker build --build-arg THELMA_VERSION=${{ jobs.bump-and-build1.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1
@@ -213,14 +213,14 @@ jobs:
           service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
       - name: Upload release files to bucket
         run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump-and-build1.outputs.version }}/
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ jobs.bump-and-build1.outputs.version }}/
       - name: Update tags.json
         # TODO: we can make this more sophisticated at some point, but the goal right now
         # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
         if: github.event_name != 'pull_request'
         run: |
           cat <<EOF > tags.json
-          {"latest":"${{ needs.bump-and-build1.outputs.version }}"}
+          {"latest":"${{ jobs.bump-and-build1.outputs.version }}"}
           EOF
           gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,14 +74,6 @@ jobs:
       # Build binary artifacts for Darwin and Linux
       #
       # TODO: would save time if we could cache go module dependencies across build steps
-      - name: Build linux binary distribution
-        uses: ./.github/actions/make
-        with:
-          target: "release"
-          os: linux
-          arch: amd64
-          version: ${{ steps.tag.outputs.tag }}
-
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
@@ -97,6 +89,16 @@ jobs:
           os: darwin
           arch: arm64
           version: ${{ steps.tag.outputs.tag }}
+
+      # This build must go last in order to reuse build artifacts for making the docker image
+      - name: Build linux binary distribution
+        uses: ./.github/actions/make
+        with:
+          target: "release"
+          os: linux
+          arch: amd64
+          version: ${{ steps.tag.outputs.tag }}
+
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,9 +127,9 @@ jobs:
         id: release-cache
         uses: actions/cache@v3
         env:
-          cache-name: release-dir-cache
+          cache-name: release-cache
         with:
-          path: ./output/releases
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
 
       - name: Create temp keychain
@@ -163,9 +163,9 @@ jobs:
         id: release-cache
         uses: actions/cache@v3
         env:
-          cache-name: release-dir-cache
+          cache-name: release-cache
         with:
-          path: ./output/releases
+          path: ./output
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
 
       #

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,14 +80,14 @@ jobs:
           target: "release"
           os: linux
           arch: amd64
-          version: ${{ jobs.bump-and-build1.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
       - name: Build amd64 darwin binary distribution
         uses: ./.github/actions/make
         with:
           target: "release"
           os: darwin
           arch: amd64
-          version: ${{ jobs.bump-and-build1.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
 
   sign-and-notarize-amd64:
     runs-on: macos-latest
@@ -112,11 +112,11 @@ jobs:
         run: |
           pwd
           ls
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ jobs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_amd64.tar.gz
 
   build2:
     runs-on: ubuntu-latest
-    needs: sign-and-notarize-amd64
+    needs: [bump-and-build1, sign-and-notarize-amd64]
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -138,16 +138,16 @@ jobs:
           target: "release"
           os: darwin
           arch: arm64
-          version: ${{ jobs.bump-and-build1.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
       - name: Generate checksum file
         uses: ./.github/actions/make
         with:
           target: "checksum"
-          version: ${{ jobs.bump-and-build1.outputs.version }}
+          version: ${{ needs.bump-and-build1.outputs.version }}
 
   sign-and-notarize-arm64:
     runs-on: macos-latest
-    needs: build2
+    needs: [bump-and-build1, build2]
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -166,11 +166,11 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ jobs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.bump-and-build1.outputs.version }}_darwin_arm64.tar.gz
 
   dockerize-and-push:
     runs-on: ubuntu-latest
-    needs: sign-and-notarize-arm64
+    needs: [bump-and-build1, sign-and-notarize-arm64]
     steps:
       - name: Cache build directory
         id: cache-build
@@ -190,14 +190,14 @@ jobs:
         id: image-name
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ jobs.bump-and-build1.outputs.version }}"
+          DOCKER_TAG="${{ needs.bump-and-build1.outputs.version }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
           echo ::set-output "name=name::${NAME}"
           echo ::set-output "name=tagged::${TAGGED}"
       - name: Build image
-        run: "docker build --build-arg THELMA_VERSION=${{ jobs.bump-and-build1.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
+        run: "docker build --build-arg THELMA_VERSION=${{ needs.bump-and-build1.outputs.version }} -t ${{ steps.image-name.outputs.tagged }} ."
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action
         uses: broadinstitute/dsp-appsec-trivy-action@v1
@@ -213,14 +213,14 @@ jobs:
           service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
       - name: Upload release files to bucket
         run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ jobs.bump-and-build1.outputs.version }}/
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump-and-build1.outputs.version }}/
       - name: Update tags.json
         # TODO: we can make this more sophisticated at some point, but the goal right now
         # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
         if: github.event_name != 'pull_request'
         run: |
           cat <<EOF > tags.json
-          {"latest":"${{ jobs.bump-and-build1.outputs.version }}"}
+          {"latest":"${{ needs.bump-and-build1.outputs.version }}"}
           EOF
           gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,6 +105,8 @@ jobs:
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
         run: |
+          pwd
+          ls
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
   build2:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,7 +146,6 @@ jobs:
       - name: Sign and notarize macOS releases and create tarball
         id: san-tarball
         run: |
-          mkdir -p 
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_amd64.tar.gz
           ./scripts/sign-and-notarize.sh ./output ./output/releases/thelma_${{ needs.build.outputs.version }}_darwin_arm64.tar.gz
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
         run: |
           mkdir -p ./output/kc
           echo ${THELMA_MACOS_CERT} | base64 --decode > ./output/kc/certificate.p12
-          security create-keychain -p temp-kc-pwd ./output/kc/certificate.p12
+          security create-keychain -p temp-kc-pwd ./output/kc/release.keychain
           security default-keychain -s ./output/kc/release.keychain
           security unlock-keychain -p temp-kc-pwd ./output/kc/release.keychain
           security import ./output/kc/certificate.p12 -k ./output/kc/release.keychain -P ${THELMA_MACOS_CERT_PWD} -T /usr/bin/codesign

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,6 @@ jobs:
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
-        shell: zsh {0}
         run: |
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_amd64.tar.gz
 
@@ -164,7 +163,6 @@ jobs:
 
       - name: Sign and notarize macOS release and create tarball
         id: san-tarball
-        shell: zsh {0}
         run: |
           ./scripts/sign-and-notarize.sh ./output/release-assembly ./output/releases/thelma_${{ needs.checkout-and-bump.outputs.version }}_darwin_arm64.tar.gz
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,10 +20,11 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up GCP auth
+      id: setup-gcp-auth
       run: |
+        GCP_CREDS_PATH=$(pwd)/service_account.json
         echo '${{ secrets.THELMA_CI_KEY }}' > service_account.json
-        pwd
-        ls
+        echo ::set-output "name=gcp-creds-path::${GCP_CREDS_PATH}"
 
     - name: Run tests
       uses: ./.github/actions/make
@@ -32,7 +33,7 @@ jobs:
       env:
         # full path is needed because go tests switch into package directories,
         # and some smoke tests use GCP credentials
-        GOOGLE_APPLICATION_CREDENTIALS: service_account.json
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.setup-gcp-auth.outputs.gcp-creds-path }}
 
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up GCP auth
-      run: echo '${{ secrets.THELMA_CI_KEY }}' > service_account.json
+      run: echo '${{ secrets.THELMA_CI_KEY }}' > /github/workspace/service_account.json
 
     - name: Run tests
       uses: ./.github/actions/make

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up GCP auth
-      run: echo '${{ secrets.THELMA_CI_KEY }}' > /github/workspace/service_account.json
+      run: |
+        pwd
+        ls
+        echo '${{ secrets.THELMA_CI_KEY }}' > service_account.json
 
     - name: Run tests
       uses: ./.github/actions/make

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,9 @@ jobs:
 
     - name: Set up GCP auth
       run: |
+        echo '${{ secrets.THELMA_CI_KEY }}' > service_account.json
         pwd
         ls
-        echo '${{ secrets.THELMA_CI_KEY }}' > service_account.json
 
     - name: Run tests
       uses: ./.github/actions/make
@@ -32,7 +32,7 @@ jobs:
       env:
         # full path is needed because go tests switch into package directories,
         # and some smoke tests use GCP credentials
-        GOOGLE_APPLICATION_CREDENTIALS: /github/workspace/service_account.json
+        GOOGLE_APPLICATION_CREDENTIALS: service_account.json
 
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,19 @@ ARG ALPINE_IMAGE_VERSION='3.14'
 #
 FROM alpine:${ALPINE_IMAGE_VERSION}
 
+ARG THELMA_LINUX_RELEASE
+
+COPY output/releases/${THELMA_LINUX_RELEASE} .
+
 # OS updates for security
 RUN apk update
 RUN apk upgrade
 
-# Copy Thelma into runtime image
-COPY output/release-assembly /thelma
+# Unpack Thelma into runtime image
+RUN mkdir /thelma && tar -xvf ${THELMA_LINUX_RELEASE} -C /thelma
+
+# Remove the copied tarball
+RUN rm ${THELMA_LINUX_RELEASE}
 
 ENV PATH="/thelma/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,16 @@
-#
-# Compile Go tools and install to /tools/bin
-#
-ARG GO_IMAGE_VERSION='1.17'
 ARG ALPINE_IMAGE_VERSION='3.14'
-
-FROM golang:${GO_IMAGE_VERSION}-bullseye as build
-
-ARG THELMA_VERSION='development'
-
-WORKDIR /build
-COPY . .
-
-# Compile & install runtime dependencies into output/release-assembly
-RUN make release VERSION=${THELMA_VERSION}
 
 #
 # Copy dist into runtime image
 #
-FROM alpine:${ALPINE_IMAGE_VERSION} as runtime
+FROM alpine:${ALPINE_IMAGE_VERSION}
 
 # OS updates for security
 RUN apk update
 RUN apk upgrade
 
 # Copy Thelma into runtime image
-COPY --from=build /build/output/release-assembly /thelma
+COPY output/release-assembly /thelma
 
 ENV PATH="/thelma/bin:${PATH}"
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ endif
 #                          i.e. when locally testing updates to the release process without
 #                          having the certs and other creds on your local machine.
 MACOS_SIGN_AND_NOTARIZE=true
+ifeq ($(LOCAL_OS)-$(TARGET_OS),darwin-darwin)
+	MACOS_SIGN_AND_NOTARIZE=true
+else
+	MACOS_SIGN_AND_NOTARIZE=false
+endif
 
 # OUTPUT_DIR root directory for all build output
 OUTPUT_DIR=./output
@@ -146,6 +151,9 @@ release: runtime-deps build ## Assemble thelma binary + runtime dependencies int
 		fi; \
 	elif [ ${MACOS_SIGN_AND_NOTARIZE} = false ]; then \
 		tar -C ${RELEASE_STAGING_DIR} -czf ${RELEASE_ARCHIVE_DIR}/${RELEASE_ARCHIVE_NAME} .; \
+	else \
+		echo "ERROR: Bad value (${MACOS_SIGN_AND_NOTARIZE}) given for MACOS_SIGN_AND_NOTARIZE. Options are true and false. Exiting."; \
+		exit 1; \
 	fi;
 
 checksum: # Generate sha256sum file for tarball archives in the release archive directory

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ else
 	RUNTIME_DEPS_TESTEXEC=true
 endif
 
-# MACOS_SIGN_AND_NOTARIZE: When a macOS host and target are selected, default to signing
-#                          and notarizing by default. This value can be manually set to
-#                          false in cases where you want to generate a macOS release tarball
-#                          from a macOS host without performing any signing and notarizing,
+# MACOS_SIGN_AND_NOTARIZE: When a macOS host and target are selected, default to sign and
+#                          notarize releases. This value can be manually set to false in
+#                          cases where you want to generate a macOS release tarball from
+#                          a macOS host without performing any signing and notarizing,
 #                          i.e. when locally testing updates to the release process without
 #                          having the certs and other creds on your local machine.
 MACOS_SIGN_AND_NOTARIZE=true

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -eo pipefail
 

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -25,14 +25,15 @@ RELEASE_DIR=${1}
 RELEASE_TARBALL=${2}
 WORKING_DIR=$(dirname "$(readlink -f "${RELEASE_DIR}")")/san
 
-# XCode command stuff
+# XCode signing info - doesn't contain secrets
 APPLE_ID=appledev@broadinstitute.org
 TEAM_ID=R787A9V6VV
+SECURITY_ID=5784A30A5BFD511E8636B9F6BBE7EE36D0F0A726
 CMD_AUTH_FLAGS="--apple-id ${APPLE_ID} --password ${APP_PWD} --team-id ${TEAM_ID}"
 
 # Sign one file
 sign() {
-	codesign -f -o runtime,library --timestamp -s "5784A30A5BFD511E8636B9F6BBE7EE36D0F0A726" "${1}"
+	codesign -f -o runtime,library --timestamp -s "${SECURITY_ID}" "${1}"
 }
 
 # Zip the given directory into the working dir

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -2,17 +2,23 @@
 
 set -eo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <release dir> <release tarball>" >&2
-  exit 1
-fi
-
 # This script signs and notarizes release binaries as follows:
 # * sign each file in the ${RELEASE_DIR}/bin/ directory
 # * zip up the whole provided directory (.tar.gz is not supported by Apple)
 # * submit the zip to Apple for notarizing
 # * verify that all files were notarized
 # * create the release tarball
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <release dir> <release tarball>" >&2
+  exit 1
+fi
+
+# Check for required env vars
+if [ -z "${APP_PWD}" ]; then
+	echo "ERROR: Apple Developer application password env var APP_PWD unset but required. Exiting."
+	exit 1
+fi
 
 # Files and dirs
 RELEASE_DIR=${1}

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -59,7 +59,7 @@ create_keychain() {
 	security create-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
 
 	# Setting default keychain
-	security default-keychain -s build.keychain "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
+	security default-keychain -s "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
 
 	# Unlock the keychain
 	echo "Unlocking keychain ${KEYCHAIN_FILE}"

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -58,6 +58,9 @@ create_keychain() {
 	echo "Creating keychain ${KEYCHAIN_FILE}"
 	security create-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
 
+	# Setting default keychain
+	security default-keychain -s build.keychain "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
+
 	# Unlock the keychain
 	echo "Unlocking keychain ${KEYCHAIN_FILE}"
 	security unlock-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
@@ -75,7 +78,7 @@ create_keychain() {
 
 # Sign one file
 sign() {
-	codesign --keychain "${1}" -f -o runtime,library --timestamp -s "${SECURITY_ID}" "${2}"
+	codesign -f -o runtime,library --timestamp -s "${SECURITY_ID}" "${1}"
 }
 
 # Zip the given directory into the working dir
@@ -207,7 +210,7 @@ create_keychain
 echo -n "Signing binaries..."
 for bin in "${RELEASE_DIR}"/bin/*
 do
-	sign "${KEYCHAIN_FILE}" "${bin}"
+	sign "${bin}"
 done
 echo "done"
 

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -11,8 +11,8 @@ set -eo pipefail
 # * verify that all files were notarized
 # * create the release tarball
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <release dir> <release tarball>" >&2
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <release dir> <release tarball> <output tarball>" >&2
   exit 1
 fi
 
@@ -37,6 +37,7 @@ readlinkf(){
 # Files and dirs
 TEMP_DIR=${1}
 RELEASE_TARBALL=${2}
+OUTPUT_TARBALL=${3}
 WORKING_DIR=$(readlinkf "${TEMP_DIR}")/san
 
 # XCode signing info - doesn't contain secrets
@@ -179,10 +180,6 @@ echo "Unpacking input tarball to ${untar_dir}"
 mkdir -p "${untar_dir}"
 tar -xf "${RELEASE_TARBALL}" -C "${untar_dir}"
 
-# Remove current release tarball
-echo "Removing input tarball ${RELEASE_TARBALL} so it can be replaced"
-rm "${RELEASE_TARBALL}"
-
 # Sign each binary
 echo -n "Signing binaries..."
 for bin in "${untar_dir}"/bin/*
@@ -211,8 +208,8 @@ do
 done
 
 # Create SaN release tarball
-echo -n "Creating release tarball ${RELEASE_TARBALL}..."
-tar -C "${untar_dir}" -czf "${RELEASE_TARBALL}" .
+echo -n "Creating release tarball ${OUTPUT_TARBALL}..."
+tar -C "${untar_dir}" -czf "${OUTPUT_TARBALL}" .
 echo "done"
 
 # Remove working dir

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -17,15 +17,11 @@ APPLE_ID=appledev@broadinstitute.org
 TEAM_ID=R787A9V6VV
 CMD_AUTH_FLAGS="--apple-id ${APPLE_ID} --password ${APP_PWD} --team-id ${TEAM_ID}"
 
-_tar() {
-	tar -C "${1}" -czf "${2}" .
-}
-
 sign() {
 	codesign -f -o runtime --timestamp -s "5784A30A5BFD511E8636B9F6BBE7EE36D0F0A726" "${1}"
 }
 
-_zip() {
+archive() {
 	# Get the absolute path to the input path
 	local _absdir="$(readlink -f "${1}")"
 
@@ -153,7 +149,7 @@ do
 done
 
 # Submit the release to Apple for notarization
-notarize "$(_zip "${RELEASE_DIR}")"
+notarize "$(archive "${RELEASE_DIR}")"
 
 # Verify all files were notarized
 for bin in "${RELEASE_DIR}"/bin/*

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 set -eo pipefail
 

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -177,6 +177,9 @@ untar_dir="${WORKING_DIR}"/release-files
 mkdir -p "${untar_dir}"
 tar -xf "${RELEASE_TARBALL}" -C "${untar_dir}"
 
+# Remove current release tarball
+rm "${RELEASE_TARBALL}"
+
 # Sign each binary
 echo -n "Signing binaries..."
 for bin in "${untar_dir}"/bin/*

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -32,7 +32,7 @@ CMD_AUTH_FLAGS="--apple-id ${APPLE_ID} --password ${APP_PWD} --team-id ${TEAM_ID
 
 # Sign one file
 sign() {
-	codesign -f -o runtime --timestamp -s "5784A30A5BFD511E8636B9F6BBE7EE36D0F0A726" "${1}"
+	codesign -f -o runtime,library --timestamp -s "5784A30A5BFD511E8636B9F6BBE7EE36D0F0A726" "${1}"
 }
 
 # Zip the given directory into the working dir

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+set -eo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <release dir> <release tarball>" >&2
+  exit 1
+fi
+
 # This script signs and notarizes release binaries as follows:
 # * sign each file in the ${RELEASE_DIR}/bin/ directory
 # * zip up the whole provided directory (.tar.gz is not supported by Apple)

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -56,19 +56,19 @@ create_keychain() {
 	local KEYCHAIN_FILE="${WORKING_DIR}"/release.keychain
 	local _temp_keychain_pwd=temp-kc-pwd
 	echo "Creating keychain ${KEYCHAIN_FILE}"
-	security create-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" 2>&1 > /dev/null
+	security create-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
 
 	# Unlock the keychain
 	echo "Unlocking keychain ${KEYCHAIN_FILE}"
-	security unlock-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" 2>&1 > /dev/null
+	security unlock-keychain -p ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
 
 	# Add the cert to the keychain
 	echo "Importing cert"
-	security import "${_cert_file}" -k "${KEYCHAIN_FILE}" -P "${THELMA_MACOS_CERT_PWD}" -T /usr/bin/codesign 2>&1 > /dev/null
+	security import "${_cert_file}" -k "${KEYCHAIN_FILE}" -P "${THELMA_MACOS_CERT_PWD}" -T /usr/bin/codesign # 2>&1 > /dev/null
 
 	# Allow codesign to use the keychain without a password prompt
 	echo "Setting partition list"
-	security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" 2>&1 > /dev/null
+	security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${_temp_keychain_pwd} "${KEYCHAIN_FILE}" # 2>&1 > /dev/null
 
 	echo "${KEYCHAIN_FILE}"
 }

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -28,10 +28,14 @@ if [ -z "${THELMA_MACOS_CERT_PWD}" ]; then
 	exit 1
 fi
 
+readlinkf(){
+	perl -MCwd -e 'print Cwd::abs_path shift' "$1"
+}
+
 # Files and dirs
 RELEASE_DIR=${1}
 RELEASE_TARBALL=${2}
-WORKING_DIR=$(dirname "$(readlink -f "${RELEASE_DIR}")")/san
+WORKING_DIR=$(dirname "$(readlinkf "${RELEASE_DIR}")")/san
 
 # XCode signing info - doesn't contain secrets
 APPLE_ID=appledev@broadinstitute.org
@@ -70,7 +74,7 @@ sign() {
 # Zip the given directory into the working dir
 archive() {
 	# Get the absolute path to the input path
-	local _absdir="$(readlink -f "${1}")"
+	local _absdir="$(readlinkf "${1}")"
 
 	# Extract just the name of the directory to zip
 	local _bname="$(basename ${_absdir})"

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -26,7 +26,7 @@ if [ -z "${THELMA_MACOS_CERT}" ]; then
 	exit 1
 fi
 if [ -z "${THELMA_MACOS_CERT_PWD}" ]; then
-	echo "ERROR: Signing cert password env var THELMA_MACOS_CERT unset but required. Exiting."
+	echo "ERROR: Signing cert password env var THELMA_MACOS_CERT_PWD unset but required. Exiting."
 	exit 1
 fi
 

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -170,14 +170,17 @@ verify() {
 }
 
 # Make working dir
+echo "Make working dir ${WORKING_DIR}"
 mkdir -p "${WORKING_DIR}"
 
 # Make untar dir
 untar_dir="${WORKING_DIR}"/release-files
+echo "Unpacking input tarball to ${untar_dir}"
 mkdir -p "${untar_dir}"
 tar -xf "${RELEASE_TARBALL}" -C "${untar_dir}"
 
 # Remove current release tarball
+echo "Removing input tarball ${RELEASE_TARBALL} so it can be replaced"
 rm "${RELEASE_TARBALL}"
 
 # Sign each binary


### PR DESCRIPTION
This PR adds signing and notarizing for macOS builds. It also adds the following goodies:
* Go deps are now cached between builds
* Builds are parellelized
* The docker build uses the linux release artifact instead of doing another build

Overall this speeds up builds a lot and minimizes the time impact that adding signing/notarizing would otherwise have.

Some notes on time improvements/speed ups, using [this](https://github.com/broadinstitute/thelma/runs/7362013023?check_suite_focus=true) before example and [this](https://github.com/broadinstitute/thelma/actions/runs/2707986760) after example:
* Build times
  * Before: 5m 53s
  * **After: 1m59s**
* Signing and notarizing:
  * Before: N/A
  * After: 4m 35s
* Image gen + push + release push:
  * Before: 3m 43s
  * **After: 1m 47s**
* Total build GHA run times:
  * Before: 10m 0s
  * After: 10m 0s

TL;DR: Signing and notarizing for macOS releases now works and it adds basically no time to the build workflow despite adding a step that takes 4.5mins.