### PR TITLE
[DDO-2166] Exclude temp release dirs from GCS uploads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -296,6 +296,7 @@ jobs:
         run: |
           ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-amd64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz
           ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-arm64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz
+          rm -rf ${{ needs.build-darwin-amd64.outputs.rel-dir}} ${{ needs.build-darwin-arm64.outputs.rel-dir}}
 
   dockerize-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out caching is hard. Don't release intermediary tarballs.