### PR TITLE
DDO-2220 Ignore 409 conflicts when registering service accounts

### DIFF
--- a/internal/thelma/cli/commands/bee/seed/seed/seed_command_test.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/seed_command_test.go
@@ -1,0 +1,15 @@
+package seed
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_ignore409Conflict(t *testing.T) {
+	err := errors.New("409 Conflict from https://firecloudorch.bee.envs-terra.bio/register/profile ({\"causes\":[{\"causes\":[],\"message\":\"user rawls-qa@broad-dsde-qa.iam.gserviceaccount.com already exists\",\"source\":\"sam\",\"stackTrace\":[],\"statusCode\":409}],\"message\":\"user rawls-qa@broad-dsde-qa.iam.gserviceaccount.com already exists\",\"source\":\"Sam\",\"stackTrace\":[],\"statusCode\":409})")
+	assert.Nil(t, ignore409Conflict(err), "should suppress 409 Conflict errors")
+
+	err = errors.New("a completely unexpected error")
+	assert.Error(t, ignore409Conflict(err), "should not ignore other errors")
+}

--- a/internal/thelma/cli/commands/bee/seed/seed/seed_command_test.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/seed_command_test.go
@@ -7,7 +7,24 @@ import (
 )
 
 func Test_ignore409Conflict(t *testing.T) {
-	err := errors.New("409 Conflict from https://firecloudorch.bee.envs-terra.bio/register/profile ({\"causes\":[{\"causes\":[],\"message\":\"user rawls-qa@broad-dsde-qa.iam.gserviceaccount.com already exists\",\"source\":\"sam\",\"stackTrace\":[],\"statusCode\":409}],\"message\":\"user rawls-qa@broad-dsde-qa.iam.gserviceaccount.com already exists\",\"source\":\"Sam\",\"stackTrace\":[],\"statusCode\":409})")
+	err := errors.New(`
+409 Conflict from https://firecloudorch.bee.envs-terra.bio/register/profile
+({
+  "causes": [
+    {
+      "causes": [],
+      "message": "user rawls-qa@broad-dsde-qa.iam.gserviceaccount.com already exists",
+      "source": "sam",
+      "stackTrace": [],
+      "statusCode": 409
+    }
+  ],
+  "message": "user rawls-qa@broad-dsde-qa.iam.gserviceaccount.com already exists",
+  "source": "Sam",
+  "stackTrace": [],
+  "statusCode": 409
+})`)
+
 	assert.Nil(t, ignore409Conflict(err), "should suppress 409 Conflict errors")
 
 	err = errors.New("a completely unexpected error")

--- a/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
@@ -99,7 +99,7 @@ func ignore409Conflict(maybe409Err error) error {
 	matches, err := regexp.MatchString(pattern, maybe409Err.Error())
 
 	if err != nil {
-		panic(fmt.Errorf("invalid regular expression %q: %v", pattern, maybe409Err))
+		panic(fmt.Errorf("invalid regular expression %q: %v", pattern, err))
 	}
 
 	if !matches {

--- a/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
@@ -95,7 +95,7 @@ func ignore409Conflict(maybe409Err error) error {
 		return nil
 	}
 
-	pattern := "409 [Cc]onflict.*[Uu]ser.*already exists"
+	pattern := "(?s)409 [Cc]onflict.*[Uu]ser.*already exists"
 	matches, err := regexp.MatchString(pattern, maybe409Err.Error())
 
 	if err != nil {

--- a/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
@@ -90,22 +90,22 @@ func _registerSaProfile(thelma app.ThelmaApp, appRelease terra.AppRelease, orch 
 	return ignore409Conflict(err)
 }
 
-func ignore409Conflict(err error) error {
-	if err == nil {
+func ignore409Conflict(maybe409Err error) error {
+	if maybe409Err == nil {
 		return nil
 	}
 
 	pattern := "409 [Cc]onflict.*[Uu]ser.*already exists"
-	matches, err := regexp.MatchString(pattern, err.Error())
+	matches, err := regexp.MatchString(pattern, maybe409Err.Error())
 
 	if err != nil {
-		panic(fmt.Errorf("invalid regular expression %q: %v", pattern, err))
+		panic(fmt.Errorf("invalid regular expression %q: %v", pattern, maybe409Err))
 	}
 
 	if !matches {
-		return err
+		return maybe409Err
 	}
 
-	log.Warn().Err(err).Msgf("409 conflict encountered while registering user; ignoring")
+	log.Warn().Err(maybe409Err).Msgf("409 conflict encountered while registering user; ignoring")
 	return nil
 }

--- a/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/step_2_register_sa_profiles.go
@@ -1,10 +1,12 @@
 package seed
 
 import (
+	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/seed"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/rs/zerolog/log"
+	"regexp"
 )
 
 func (cmd *seedCommand) step2RegisterSaProfiles(thelma app.ThelmaApp, appReleases map[string]terra.AppRelease) error {
@@ -84,8 +86,26 @@ func _registerSaProfile(thelma app.ThelmaApp, appRelease terra.AppRelease, orch 
 		return err
 	}
 	_, _, err = terraClient.FirecloudOrch(orch).RegisterProfile("None", "None", "None", terraClient.GoogleUserInfo().Email, "None", "None", "None", "None", "None", "None", "None")
+
+	return ignore409Conflict(err)
+}
+
+func ignore409Conflict(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	pattern := "409 [Cc]onflict.*[Uu]ser.*already exists"
+	matches, err := regexp.MatchString(pattern, err.Error())
+
 	if err != nil {
+		panic(fmt.Errorf("invalid regular expression %q: %v", pattern, err))
+	}
+
+	if !matches {
 		return err
 	}
+
+	log.Warn().Err(err).Msgf("409 conflict encountered while registering user; ignoring")
 	return nil
 }


### PR DESCRIPTION
Ever since we fixed the GCS_NAME_PREFIX, we've been encountering 409 errors during `thelma bee seed`. It turns out some services register their own service accounts (but not super-consistently? Like rawls-qa sometimes appears and sometimes doesn't).

This extremely lazy PR just ignores the 409 errors, which seems to be in line with how the old fiab seeding used to work.

(We could also use Jack's handy `--force` flag, but in that case we're ignoring ALL errors in the entire seeding process)