### PR TITLE
DDO-2219 Implement tripperware to automatically mask secrets pulled from Vault

### DIFF
--- a/internal/thelma/app/app.go
+++ b/internal/thelma/app/app.go
@@ -4,7 +4,7 @@ package app
 import (
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
 	"github.com/broadinstitute/thelma/internal/thelma/app/credentials"
-	"github.com/broadinstitute/thelma/internal/thelma/app/logging"
+	_ "github.com/broadinstitute/thelma/internal/thelma/app/logging" // import logging for side effects (trigger bootstrapping)
 	"github.com/broadinstitute/thelma/internal/thelma/app/paths"
 	"github.com/broadinstitute/thelma/internal/thelma/app/scratch"
 	"github.com/broadinstitute/thelma/internal/thelma/app/seed"
@@ -20,7 +20,6 @@ type Options struct {
 }
 
 func init() {
-	logging.Bootstrap()
 	seed.Rand()
 }
 

--- a/internal/thelma/app/logging/logging.go
+++ b/internal/thelma/app/logging/logging.go
@@ -40,6 +40,10 @@ type logConfig struct {
 	}
 }
 
+func init() {
+	Bootstrap()
+}
+
 // Bootstrap configure global zerolog logger with a basic console logger
 // to catch any messages that are logged before full Thelma initialization
 func Bootstrap() {

--- a/internal/thelma/clients/vault/masking_round_tripper.go
+++ b/internal/thelma/clients/vault/masking_round_tripper.go
@@ -12,8 +12,8 @@ import (
 
 // MaskingRoundTripper implements the http.RoundTripper interface, automatically masking any secrets returned from the Vault API
 type MaskingRoundTripper struct {
-	inner  http.RoundTripper
-	maskFn func(secrets ...string)
+	inner  http.RoundTripper       // inner round tripper to delegate to (this should actually makes the request)
+	maskFn func(secrets ...string) // maskFn custom masking function (should only be used in unit tests)
 }
 
 func (m MaskingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/thelma/clients/vault/masking_round_tripper.go
+++ b/internal/thelma/clients/vault/masking_round_tripper.go
@@ -1,0 +1,78 @@
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/broadinstitute/thelma/internal/thelma/app/logging"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/rs/zerolog/log"
+	"io/ioutil"
+	"net/http"
+)
+
+// MaskingRoundTripper implements the http.RoundTripper interface, automatically masking any secrets returned from the Vault API
+type MaskingRoundTripper struct {
+	inner  http.RoundTripper
+	maskFn func(secrets ...string)
+}
+
+func (m MaskingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	logger := log.With().Str("method", req.Method).Str("path", req.URL.Path).Logger()
+
+	// Send the request, get the response (or the error)
+	resp, err := m.inner.RoundTrip(req)
+
+	if err != nil {
+		return resp, err
+	}
+
+	// if non-2xx status code, return response without attempting to auto-mask
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		logger.Debug().Msg("received non-2xx response from Vault server, won't attempt to mask")
+		return resp, err
+	}
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logger.Warn().Err(err).Msg("error reading response from Vault")
+		return resp, err
+	}
+
+	// make fresh io.Reader with body content and add it to the response body so Vault client can still read it when we're done
+	resp.Body = ioutil.NopCloser(bytes.NewReader(content))
+
+	var secret vaultapi.Secret
+	if err := json.Unmarshal(content, &secret); err != nil {
+		// there may be some Vault API calls that don't neatly deserialize into a Secret; log a warning & move on
+		logger.Warn().Err(err).Msg("error unmarshalling response from Vault")
+		return resp, nil
+	}
+
+	if secret.Auth != nil && len(secret.Auth.ClientToken) > 0 {
+		m.maskSecrets(secret.Auth.ClientToken)
+		log.Debug().Msgf("automatically masked Vault token")
+	}
+
+	// mask every string field in the secret
+	if len(secret.Data) > 0 {
+		count := 0
+		for _, value := range secret.Data {
+			asString, ok := value.(string)
+			if ok {
+				m.maskSecrets(asString)
+				count++
+			}
+		}
+		log.Debug().Msgf("automatically masked %d fields in Vault response", count)
+	}
+
+	return resp, nil
+}
+
+func (m MaskingRoundTripper) maskSecrets(secrets ...string) {
+	if m.maskFn != nil {
+		m.maskFn(secrets...)
+	} else {
+		logging.MaskSecret(secrets...)
+	}
+}

--- a/internal/thelma/clients/vault/masking_round_tripper_test.go
+++ b/internal/thelma/clients/vault/masking_round_tripper_test.go
@@ -1,0 +1,31 @@
+package vault
+
+import (
+	vaulthelper "github.com/broadinstitute/thelma/internal/thelma/clients/vault/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_MaskingRoundTripper(t *testing.T) {
+	fakeVaultServer := vaulthelper.NewFakeVaultServer(t)
+	fakeVaultServer.SetSecret("secret/foo/bar", map[string]interface{}{"abc": "xyz"})
+
+	client := fakeVaultServer.Server().Client()
+
+	maskFnCalled := false
+
+	maskingTransport := MaskingRoundTripper{
+		inner: client.Transport,
+		maskFn: func(secrets ...string) {
+			assert.Len(t, secrets, 1)
+			assert.Equal(t, "xyz", secrets[0])
+			maskFnCalled = true
+		},
+	}
+	client.Transport = maskingTransport
+
+	_, err := client.Get(fakeVaultServer.Server().URL + "/v1/secret/foo/bar")
+	require.NoError(t, err)
+	assert.True(t, maskFnCalled)
+}

--- a/internal/thelma/clients/vault/masking_round_tripper_test.go
+++ b/internal/thelma/clients/vault/masking_round_tripper_test.go
@@ -8,24 +8,36 @@ import (
 )
 
 func Test_MaskingRoundTripper(t *testing.T) {
+	// Set up a fake Vault http server
 	fakeVaultServer := vaulthelper.NewFakeVaultServer(t)
+	// Add a fake secret to the vault server -- our test will retrieve it
 	fakeVaultServer.SetSecret("secret/foo/bar", map[string]interface{}{"abc": "xyz"})
 
+	// Get an HTTP client configured to talk to the fake Vault http server
 	client := fakeVaultServer.Server().Client()
 
+	// By default, the round tripper calls logging.MaskSeret to mask secrets.
+	// We supply a custom fake masking function here, so we can verify we're calling with the right parameters.
 	maskFnCalled := false
-
-	maskingTransport := MaskingRoundTripper{
-		inner: client.Transport,
-		maskFn: func(secrets ...string) {
-			assert.Len(t, secrets, 1)
-			assert.Equal(t, "xyz", secrets[0])
-			maskFnCalled = true
-		},
+	maskFn := func(secrets ...string) {
+		assert.Len(t, secrets, 1)
+		assert.Equal(t, "xyz", secrets[0])
+		maskFnCalled = true
 	}
+
+	// create a new MaskingRoundTripper that wraps the client's default transport
+	maskingTransport := newMaskingRoundTripper(client.Transport)
+	// configure it to use our custom masking function
+	maskingTransport.maskFn = maskFn
 	client.Transport = maskingTransport
 
+	// And now, the test!
+	// Let's retrieve the secret
 	_, err := client.Get(fakeVaultServer.Server().URL + "/v1/secret/foo/bar")
+
+	// Make sure there were no errors
 	require.NoError(t, err)
+
+	// Make sure our fake masking function was called
 	assert.True(t, maskFnCalled)
 }

--- a/internal/thelma/clients/vault/testing/testing.go
+++ b/internal/thelma/clients/vault/testing/testing.go
@@ -55,10 +55,15 @@ type state struct {
 	}
 }
 
-// ConfigureClient can be used to configure a vault client to talk to this fake server instance
+// ConfigureClient can be used to configure a vault client to talk to this fake vault server instance
 func (s *FakeVaultServer) ConfigureClient(clientConfig *vaultapi.Config) {
 	clientConfig.HttpClient = s.server.Client()
 	clientConfig.Address = s.server.URL
+}
+
+// Server returns the underlying httptest.Server associated with this fake vault server instance
+func (s *FakeVaultServer) Server() *httptest.Server {
+	return s.server
 }
 
 // ExpectGithubLogin configures the server to expect a github login with a specific Github token (by default any token is expected)

--- a/internal/thelma/clients/vault/vault.go
+++ b/internal/thelma/clients/vault/vault.go
@@ -133,6 +133,12 @@ func newUnauthenticatedClient(thelmaConfig config.Config, options *ClientOptions
 		optionFn(clientCfg)
 	}
 
+	// wrap default transport in a MaskingRoundTripper, which automatically masks values in Secrets
+	transport := MaskingRoundTripper{
+		inner: clientCfg.HttpClient.Transport,
+	}
+	clientCfg.HttpClient.Transport = transport
+
 	return vaultapi.NewClient(clientCfg)
 }
 

--- a/internal/thelma/clients/vault/vault.go
+++ b/internal/thelma/clients/vault/vault.go
@@ -134,9 +134,7 @@ func newUnauthenticatedClient(thelmaConfig config.Config, options *ClientOptions
 	}
 
 	// wrap default transport in a MaskingRoundTripper, which automatically masks values in Secrets
-	transport := MaskingRoundTripper{
-		inner: clientCfg.HttpClient.Transport,
-	}
+	transport := newMaskingRoundTripper(clientCfg.HttpClient.Transport)
 	clientCfg.HttpClient.Transport = transport
 
 	return vaultapi.NewClient(clientCfg)


### PR DESCRIPTION
Implement a [tripperware](https://github.com/improbable-eng/go-httpwares) to automatically mask secrets that are retrieved from Vault.

### Why?

Thelma has a number of runtime-dependencies on Vault. (The legacy-migrated `bee seed` command, for example, loads a bunch of service account credentials from Vault and uses them to issue requests to Terra.) Now that we are working on making it possible to run Thelma from GitHub actions on DSP's public repos, we need some protection in place to prevent these Vault secrets from leaking in public GHA logs.

We have two choices -- either (1) migrate all those secrets to GitHub secrets (heavy lift) or (2) add leak protection to Thelma itself. This PR implements option 2.

### Limitations
This tripperware is intended for use with the [KV Secret backend](https://www.vaultproject.io/docs/secrets/kv) we use in DSP. Note that it:
* Only masks secret values, not keys or paths (keys frequently contain common words and we don't want to obfuscate random Thelma log messages that could contain important information)
* Only masks string values. Eg. if it encounters a secret with a map-typed value, it won't attempt to mask it.
* Only masks secret data that is embedded in 2xx responses (secret data that is embedded in Vault error messages will not be masked).
* Does not mask secret data in requests (so if Thelma *writes* a value to Vault, that value will not be masked).
