### PR TITLE
[DDO-2222] Remove limit on parallel ArgoCD syncs

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -150,7 +150,7 @@ func (b *bees) SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOptio
 	if err != nil {
 		return err
 	}
-	return b.argocd.SyncReleases(releases, 15, options...)
+	return b.argocd.SyncReleases(releases, len(releases), options...)
 }
 
 func (b *bees) RefreshBeeGenerator() error {


### PR DESCRIPTION
We're running 24 services in BEEs, so limiting concurrent syncs to 15 doubles the amount of time we spend waiting for Argo to sync in BEE starts and stops.

If this ends up overwhelming ArgoCD, then we'll look into beefing it up.