### PR TITLE
DDO-2247 Kitchen sink BEE fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -240,6 +240,7 @@ jobs:
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}
 
+      # Pull binaries compiled in previous steps
       - name: Pull Linux amd64 build directories
         id: cache-build-linux-amd64
         uses: actions/cache@v3
@@ -267,19 +268,7 @@ jobs:
           path: ${{ needs.build-darwin-arm64.outputs.rel-dir }}
           key: commit-${{ github.sha }}-job-${{ github.run_id }}-darwin-arm64
 
-      # A second cache is needed to force GH to upload the new macOS tarballs,
-      # since the existing cache already exists and therefore changes made during this step
-      # are not saved for some reason. This new cache will be used during the final job
-      # where the docker image is made and the release artifacts are uploaded.
-      - name: Create release cache
-        id: release-cache
-        uses: actions/cache@v3
-        env:
-          cache-name: release-cache
-        with:
-          path: ./output/releases
-          key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
-
+      # Sign OSX binaries
       - name: Create temp keychain
         id: create-kc
         run: |
@@ -298,35 +287,44 @@ jobs:
           ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-arm64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz >&2
           rm -rf ${{ needs.build-darwin-amd64.outputs.rel-dir}} ${{ needs.build-darwin-arm64.outputs.rel-dir}}
 
+      # Upload binaries to GCS bucket
+      - name: Generate checksum file
+        uses: ./.github/actions/make
+        with:
+          target: "checksum"
+          version: ${{ needs.bump.outputs.version }}
+      - name: Auth to GCP
+        uses: ./.github/actions/setup-gcloud
+        with:
+          service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
+      - name: Upload release files to bucket
+        run: |
+          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump.outputs.version }}/
+
   dockerize-and-push:
     runs-on: ubuntu-latest
-    needs: [bump, build-linux-amd64, build-darwin-amd64, build-darwin-arm64, sign-and-notarize]
+    needs: [bump, build-linux-amd64]
+    outputs:
+      image-name: ${{ steps.image-name.outputs.name }}
+      image-name-with-tag: ${{ steps.image-name.outputs.tagged }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}
 
-      - name: Pull release cache
-        id: release-cache
+      - name: Pull Linux amd64 build directories
+        id: cache-build-linux-amd64
         uses: actions/cache@v3
         env:
-          cache-name: release-cache
+          cache-name: build-dir-cache-linux-amd64
         with:
           path: ./output/releases
-          key: commit-${{ github.sha }}-job-${{ github.run_id }}-release
-
-      - name: Generate checksum file
-        uses: ./.github/actions/make
-        with:
-          target: "checksum"
-          version: ${{ needs.bump.outputs.version }}
+          key: commit-${{ github.sha }}-job-${{ github.run_id }}-linux-amd64
 
       #
       # Build Docker image
       #
-      # TODO: the Dockerfile currently rebuilds thelma from scratch, would save time if we could copy the build
-      # artifacts from earlier steps into the Docker image
       - name: Construct docker image name and tag
         id: image-name
         run: |
@@ -347,26 +345,6 @@ jobs:
         uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           image: ${{ steps.image-name.outputs.tagged }}
-
-      #
-      # Upload binaries to release bucket
-      #
-      - name: Auth to GCP
-        uses: ./.github/actions/setup-gcloud
-        with:
-          service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
-      - name: Upload release files to bucket
-        run: |
-          gsutil cp -r output/releases/* gs://${{ env.THELMA_RELEASE_BUCKET }}/releases/${{ needs.bump.outputs.version }}/
-      - name: Update tags.json
-        # TODO: we can make this more sophisticated at some point, but the goal right now
-        # is to minimally simulate Docker's "latest" tag for thelma releases, to support auto-update.
-        if: github.event_name != 'pull_request'
-        run: |
-          cat <<EOF > tags.json
-          {"latest":"${{ needs.bump.outputs.version }}"}
-          EOF
-          gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
 
       #
       # Push Docker image
@@ -394,3 +372,38 @@ jobs:
           gcloud artifacts docker tags add \
             "${{ steps.image-name.outputs.tagged }}" \
             "${{ steps.image-name.outputs.name }}:latest"
+
+  update-latest-tag:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [bump, dockerize-and-push, sign-and-notarize]
+    steps:
+      #
+      # Update tags.json
+      #
+      - name: Auth to GCP
+        uses: ./.github/actions/setup-gcloud
+        with:
+          service-account-key: ${{ secrets.THELMA_RELEASES_KEY_B64 }}
+      - name: Update tags.json
+        # TODO: we can make this more sophisticated at some point, but the goal right now
+        # is to minimally simulate Docker's "latest" tag for thelma binary releases, to support auto-update.
+        run: |
+          cat <<EOF > tags.json
+          {"latest":"${{ needs.bump.outputs.version }}"}
+          EOF
+          gsutil cp tags.json gs://${{ env.THELMA_RELEASE_BUCKET }}/tags.json
+
+      #
+      # Update Docker image tag
+      #
+      - name: Auth to GCP
+        uses: ./.github/actions/setup-gcloud
+        with:
+          version: '345.0.0'
+          service-account-key: ${{ secrets.GCP_PUBLISH_KEY_B64 }}
+      - name: Add latest tag to Docker image
+        run: |
+          gcloud artifacts docker tags add \
+            "${{ needs.dockerize-and-push.outputs.image-name-with-tag }}" \
+            "${{ needs.dockerize-and-push.outputs.image-name }}:latest"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -294,8 +294,8 @@ jobs:
       - name: Sign and notarize macOS releases and create tarball
         id: san-tarball
         run: |
-          ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-amd64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz
-          ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-arm64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz
+          ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-amd64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_amd64.tar.gz >&2
+          ./scripts/sign-and-notarize.sh ./output ${{ needs.build-darwin-arm64.outputs.rel-dir}}/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz ./output/releases/thelma_${{ needs.bump.outputs.version }}_darwin_arm64.tar.gz >&2
           rm -rf ${{ needs.build-darwin-amd64.outputs.rel-dir}} ${{ needs.build-darwin-arm64.outputs.rel-dir}}
 
   dockerize-and-push:

--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -96,6 +96,10 @@ func (b *bees) CreateWith(name string, options CreateOptions) (terra.Environment
 	if err = b.RefreshBeeGenerator(); err != nil {
 		return env, err
 	}
+
+	if err = b.argocd.WaitExist(argocd.GeneratorName(env)); err != nil {
+		return nil, err
+	}
 	if err = b.SyncEnvironmentGenerator(env); err != nil {
 		return env, err
 	}
@@ -142,7 +146,8 @@ func (b *bees) DeleteWith(name string, options DeleteOptions) (terra.Environment
 func (b *bees) SyncEnvironmentGenerator(env terra.Environment) error {
 	appName := argocd.GeneratorName(env)
 	log.Info().Msgf("Syncing generator %s for %s", appName, env.Name())
-	return b.argocd.SyncApp(appName)
+	_, err := b.argocd.SyncApp(appName)
+	return err
 }
 
 func (b *bees) SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOption) error {

--- a/internal/thelma/charts/source/chart.go
+++ b/internal/thelma/charts/source/chart.go
@@ -8,7 +8,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 )
@@ -236,7 +236,7 @@ func (c *chart) reloadManifest() error {
 func loadManifest(manifestFile string) (ChartManifest, error) {
 	var manifest ChartManifest
 
-	content, err := ioutil.ReadFile(manifestFile)
+	content, err := os.ReadFile(manifestFile)
 	if err != nil {
 		return manifest, fmt.Errorf("error reading chart manifest %s: %v", manifestFile, err)
 	}

--- a/internal/thelma/cli/commands/bee/seed/config.go
+++ b/internal/thelma/cli/commands/bee/seed/config.go
@@ -314,6 +314,10 @@ workflow test {
 				User: "sirius.owner@quality.firecloud.org",
 				Role: "OWNER",
 			},
+			{
+				User: "hermione.owner@quality.firecloud.org",
+				Role: "OWNER",
+			},
 		}
 	}
 	return config, nil

--- a/internal/thelma/cli/commands/bee/seed/config.go
+++ b/internal/thelma/cli/commands/bee/seed/config.go
@@ -315,7 +315,7 @@ workflow test {
 				Role: "OWNER",
 			},
 			{
-				User: "hermione.owner@quality.firecloud.org",
+				User: "hermione.owner@quality.firecloud.org", // note - rawls and orch tests depend on Hermione being an owner
 				Role: "OWNER",
 			},
 		}

--- a/internal/thelma/cli/commands/bee/seed/seed/step_1_create_elasticsearch.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/step_1_create_elasticsearch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/seed"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -57,7 +57,7 @@ func _createIndex(client http.Client, protocol string, localElasticsearchPort in
 	if err != nil {
 		return fmt.Errorf("error creating %s: %v", index, err)
 	}
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func _setElasticsearchReplicas(client http.Client, protocol string, localElastic
 	if err != nil {
 		return fmt.Errorf("error setting replica count: %v", err)
 	}
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return err

--- a/internal/thelma/cli/commands/bee/unpin/unpin_command.go
+++ b/internal/thelma/cli/commands/bee/unpin/unpin_command.go
@@ -45,7 +45,7 @@ func (cmd *unpinCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 	cobraCommand.Short = "Remove version overrides from a BEE"
 	cobraCommand.Long = helpMessage
 
-	cobraCommand.Flags().StringVarP(&cmd.options.name, flagNames.name, "n", "", "Required. Name of the BEE to delete")
+	cobraCommand.Flags().StringVarP(&cmd.options.name, flagNames.name, "n", "", "Required. Name of the BEE to unpin")
 	cobraCommand.Flags().BoolVar(&cmd.options.ifExists, flagNames.ifExists, false, "Do not return an error if the BEE does not exist")
 }
 

--- a/internal/thelma/clients/google/terraapi/terra.go
+++ b/internal/thelma/clients/google/terraapi/terra.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/oauth2"
 	googleoauth "google.golang.org/api/oauth2/v2"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -62,7 +61,7 @@ func (c *terraClient) doJsonRequest(method string, url string, body io.Reader) (
 	if err != nil {
 		return response, "", err
 	}
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return response, "", err
 	}

--- a/internal/thelma/clients/vault/masking_round_tripper.go
+++ b/internal/thelma/clients/vault/masking_round_tripper.go
@@ -6,7 +6,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/app/logging"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -40,14 +40,14 @@ func (m MaskingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	}
 
 	// Read response body
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Warn().Err(err).Msg("error reading response from Vault")
 		return resp, err
 	}
 
 	// Copy response body to a fresh io.Reader so the Vault client can still read it when we're done
-	resp.Body = ioutil.NopCloser(bytes.NewReader(content))
+	resp.Body = io.NopCloser(bytes.NewReader(content))
 
 	// Deserialize response body
 	var secret vaultapi.Secret

--- a/internal/thelma/clients/vault/testing/testing.go
+++ b/internal/thelma/clients/vault/testing/testing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -194,7 +194,7 @@ func toHttpHandler(handler vaultApiHandler) http.Handler {
 }
 
 func parseJsonRequestBody(r *http.Request, into interface{}) error {
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(fmt.Errorf("error reading request body: %v", err))
 	}

--- a/internal/thelma/render/helmfile/helmfile.go
+++ b/internal/thelma/render/helmfile/helmfile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -95,7 +94,7 @@ func (r *ConfigRepo) CleanOutputDirectoryIfEnabled() error {
 	// output directory itself, but in some cases the output directory is a volume
 	// mount in a Docker container, and trying to remove it throws an error.
 	// So we remove all its contents instead.
-	dir, err := ioutil.ReadDir(r.outputDir)
+	dir, err := os.ReadDir(r.outputDir)
 	if err != nil {
 		return err
 	}

--- a/internal/thelma/render/resolver/remote_resolver.go
+++ b/internal/thelma/render/resolver/remote_resolver.go
@@ -5,7 +5,6 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/tools/helm"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -66,14 +65,14 @@ func (r *remoteResolverImpl) resolverFn(chartRelease ChartRelease) (ResolvedChar
 	// ${tmpDir}/${chart} -> ${cacheDir}/${repo}/${chart}-${version}
 	cachePath := r.cachePath(chartRelease)
 
-	files, err := ioutil.ReadDir(tmpDir)
+	entries, err := os.ReadDir(tmpDir)
 	if err != nil {
 		return nil, err
 	}
-	if len(files) != 1 {
-		return nil, fmt.Errorf("expected exactly one file in %s, got: %v", tmpDir, files)
+	if len(entries) != 1 {
+		return nil, fmt.Errorf("expected exactly one file in %s, got: %v", tmpDir, entries)
 	}
-	tmpChartPath := path.Join(tmpDir, files[0].Name())
+	tmpChartPath := path.Join(tmpDir, entries[0].Name())
 
 	log.Debug().Msgf("Rename %s to %s", tmpChartPath, cachePath)
 	if err = os.MkdirAll(path.Dir(cachePath), 0775); err != nil {

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -361,6 +361,7 @@ func (a *argocd) WaitExist(appName string, options ...WaitExistOption) error {
 				}); err == nil {
 					log.Debug().Msgf("%s exists", appName)
 					doneCh <- true
+					return
 				}
 				log.Debug().Msgf("%s does not exist, will check again in %s", appName, pollInterval)
 				time.Sleep(pollInterval)

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -50,6 +50,16 @@ type SyncOptions struct {
 
 type SyncOption func(options *SyncOptions)
 
+type WaitExistOptions struct {
+	// WaitExistTimeoutSeconds how long to wait for an application to exist before timing out
+	WaitExistTimeoutSeconds int `default:"300"`
+
+	// WaitExistPollIntervalSeconds how long to wait between polling attempts while waiting for an app to exist
+	WaitExistPollIntervalSeconds int `default:"5"`
+}
+
+type WaitExistOption func(options *WaitExistOptions)
+
 type argocdConfig struct {
 	// Host hostname of the ArgoCD server
 	Host string `valid:"hostname" default:"ap-argocd.dsp-devops.broadinstitute.org"`
@@ -87,6 +97,14 @@ type argocdConfig struct {
 
 	// WaitHealthyTimeoutSeconds how long to wait for an application to become healthy after syncing
 	WaitHealthyTimeoutSeconds int `default:"600"`
+
+	*WaitExistOptions
+}
+
+// SyncResult stores information about the outcome of a Sync operation
+type SyncResult struct {
+	// Synced true if the app was actually synced, false if not
+	Synced bool
 }
 
 // ArgoCD is for running `argocd` commands.
@@ -94,11 +112,13 @@ type argocdConfig struct {
 // As a result it is extremely complicated to do things that are trivial via the CLI.
 type ArgoCD interface {
 	// SyncApp will sync an ArgoCD app
-	SyncApp(appName string, options ...SyncOption) error
+	SyncApp(appName string, options ...SyncOption) (SyncResult, error)
 	// HardRefresh will hard refresh an ArgoCD app (force a manifest re-render without a corresponding git change)
 	HardRefresh(appName string) error
-	// WaitHealthy will wait for an ArgoCD app to become healthy
+	// WaitHealthy will wait for an ArgoCD app to become healthy (but not necessarily synced)
 	WaitHealthy(appName string) error
+	// WaitExist will wait for an ArgoCD app to exist
+	WaitExist(appName string, options ...WaitExistOption) error
 	// SyncRelease will sync a Terra release's ArgoCD app(s), including the legacy configs app if there is one
 	SyncRelease(release terra.Release, options ...SyncOption) error
 	// SyncReleases will sync the ArgoCD apps for multiple Terra releases in parallel
@@ -170,49 +190,43 @@ type argocd struct {
 	iapToken string
 }
 
-func (a *argocd) defaultSyncOptions() SyncOptions {
-	return SyncOptions{
-		HardRefresh:  true,
-		SyncIfNoDiff: true,
-		WaitHealthy:  true,
-	}
-}
+func (a *argocd) SyncApp(appName string, options ...SyncOption) (SyncResult, error) {
+	opts := a.asSyncOptions(options...)
 
-func (a *argocd) SyncApp(appName string, options ...SyncOption) error {
-	opts := a.defaultSyncOptions()
-	for _, option := range options {
-		option(&opts)
-	}
+	var result SyncResult
 
 	// refresh the app, using hard refresh if needed
 	hasDifferences, err := a.diffWithRetries(appName, opts)
 	if err != nil {
-		return err
+		return result, err
 	}
 	if !hasDifferences {
 		if opts.SyncIfNoDiff {
-			log.Debug().Msgf("%s is in sync, will sync anyway for side-effects", appName)
+			log.Debug().Msgf("%s is in sync, will sync anyway", appName)
 		} else {
 			log.Debug().Msgf("%s is in sync, won't trigger a new sync", appName)
-			return nil
+			return result, err
 		}
 	}
 
 	if err := a.waitForInProgressSyncToComplete(appName); err != nil {
-		return err
+		return result, err
 	}
+
+	// we're about to sync, so update result to indicate we made an attempt
+	result.Synced = true
 	if err := a.sync(appName, opts); err != nil {
-		return err
+		return result, err
 	}
 
 	if opts.WaitHealthy {
 		if err := a.WaitHealthy(appName); err != nil {
-			return err
+			return result, err
 		}
 	}
 
 	log.Debug().Msgf("Successfully synced %s", appName)
-	return nil
+	return result, nil
 }
 
 func (a *argocd) SyncRelease(release terra.Release, options ...SyncOption) error {
@@ -224,21 +238,35 @@ func (a *argocd) SyncRelease(release terra.Release, options ...SyncOption) error
 	legacyConfigsApp := LegacyConfigsApplicationName(release)
 	primaryApp := ApplicationName(release)
 
+	// Sync the legacy configs app, if one exists
+	legacyConfigsWereSynced := false
 	if hasLegacyConfigsApp {
-		if err := a.SyncApp(legacyConfigsApp, options...); err != nil {
+		syncResult, err := a.SyncApp(legacyConfigsApp, options...)
+		if err != nil {
 			return err
 		}
+		legacyConfigsWereSynced = syncResult.Synced
 	}
 
-	if err := a.SyncApp(primaryApp, options...); err != nil {
+	// Sync primary app without waiting for it to become healthy
+	optionsNoWait := append(options, func(options *SyncOptions) {
+		options.WaitHealthy = false
+	})
+	if _, err := a.SyncApp(primaryApp, optionsNoWait...); err != nil {
 		return err
 	}
 
-	if hasLegacyConfigsApp {
+	// If we had a legacy configs app, and it was synced, then restart deployments in the primary app in order to pick up any changes
+	if hasLegacyConfigsApp && legacyConfigsWereSynced {
 		log.Info().Msgf("Restarting deployments in %s to pick up potential firecloud-develop config changes", primaryApp)
 		return a.restartDeployments(primaryApp)
 	}
 
+	// Now wait for the primary app to become healthy
+	opts := a.asSyncOptions(options...)
+	if opts.WaitHealthy {
+		return a.WaitHealthy(primaryApp)
+	}
 	return nil
 }
 
@@ -276,7 +304,71 @@ func (a *argocd) WaitHealthy(appName string) error {
 		appName,
 		"--timeout",
 		fmt.Sprintf("%d", a.cfg.WaitHealthyTimeoutSeconds),
+		"--health",
 	})
+}
+
+func (a *argocd) WaitExist(appName string, options ...WaitExistOption) error {
+	var opts WaitExistOptions
+	opts.WaitExistTimeoutSeconds = a.cfg.WaitExistTimeoutSeconds
+	opts.WaitExistPollIntervalSeconds = a.cfg.WaitExistPollIntervalSeconds
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	logger := log.With().Str("argo-app", appName).Logger()
+
+	timeout := time.Second * (time.Duration(opts.WaitExistTimeoutSeconds))
+	pollInterval := time.Second * (time.Duration(opts.WaitExistPollIntervalSeconds))
+
+	logger.Info().Msgf("Waiting up to %s for %s to exist", timeout, appName)
+
+	doneCh := make(chan bool, 1)
+	timeoutCh := make(chan bool, 1)
+
+	go func() {
+		for {
+			select {
+			case <-timeoutCh:
+				logger.Debug().Msgf("Timeout reached, exiting polling")
+				return
+			default:
+				if err := a.runCommand([]string{
+					"app",
+					"get",
+					appName,
+				}); err != nil {
+					log.Debug().Msgf("%s exists", appName)
+					doneCh <- true
+				}
+				time.Sleep(pollInterval)
+			}
+		}
+	}()
+
+	select {
+	case <-doneCh:
+		return nil
+	case <-time.After(timeout):
+		timeoutCh <- true
+		return fmt.Errorf("timed out after %s waiting for Argo application %s to exist", timeout, appName)
+	}
+}
+
+func (a *argocd) defaultSyncOptions() SyncOptions {
+	return SyncOptions{
+		HardRefresh:  true,
+		SyncIfNoDiff: true,
+		WaitHealthy:  true,
+	}
+}
+
+func (a *argocd) asSyncOptions(options ...SyncOption) SyncOptions {
+	opts := a.defaultSyncOptions()
+	for _, option := range options {
+		option(&opts)
+	}
+	return opts
 }
 
 func (a *argocd) restartDeployments(appName string) error {

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -358,10 +358,11 @@ func (a *argocd) WaitExist(appName string, options ...WaitExistOption) error {
 					"app",
 					"get",
 					appName,
-				}); err != nil {
+				}); err == nil {
 					log.Debug().Msgf("%s exists", appName)
 					doneCh <- true
 				}
+				log.Debug().Msgf("%s does not exist, will check again in %s", appName, pollInterval)
 				time.Sleep(pollInterval)
 			}
 		}

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -285,8 +285,7 @@ func (a *argocd) SyncRelease(release terra.Release, options ...SyncOption) error
 	}
 
 	// Now wait for the primary app to become healthy
-	opts := a.asSyncOptions(options...)
-	if opts.WaitHealthy {
+	if syncOpts.WaitHealthy {
 		return a.WaitHealthy(primaryApp)
 	}
 	return nil
@@ -380,7 +379,7 @@ func (a *argocd) WaitExist(appName string, options ...WaitExistOption) error {
 func (a *argocd) defaultSyncOptions() SyncOptions {
 	return SyncOptions{
 		HardRefresh:  true,
-		SyncIfNoDiff: true,
+		SyncIfNoDiff: false,
 		WaitHealthy:  true,
 	}
 }

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -105,7 +105,7 @@ type argocdConfig struct {
 	// WaitHealthyTimeoutSeconds how long to wait for an application to become healthy after syncing
 	WaitHealthyTimeoutSeconds int `default:"600"`
 
-	*WaitExistOptions
+	WaitExistOptions
 }
 
 // SyncResult stores information about the outcome of a Sync operation

--- a/scripts/checksum.sh
+++ b/scripts/checksum.sh
@@ -11,6 +11,16 @@ VERSION=${VERSION:-development}
 RELEASE_DIR=$1
 OUTFILE="thelma_${VERSION}_SHA256SUMS"
 
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OS="$( ${SCRIPT_DIR}/get-os.sh )"
+
 mkdir -p $RELEASE_DIR
 cd $RELEASE_DIR
-sha256sum *.tar.gz > ${OUTFILE}
+
+if [[ "${OS}" == "darwin" ]]; then
+  # Use native OSX shasum utility
+  shasum -a 256 *.tar.gz > ${OUTFILE}
+else
+  # Use Linux sha256sum utility
+  sha256sum *.tar.gz > ${OUTFILE}
+fi

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -94,7 +94,7 @@ notarize() {
 		return 1
 	fi
 
-	echo -n "Checking notarization status for ${_sub_id}"
+	echo "Checking notarization status for ${_sub_id}"
 
 	local _resp=""
 	local _cont=0
@@ -110,10 +110,12 @@ notarize() {
 		#	"id": "<UUID>",
 		#	"message": "Submission log is not yet available or submissionId does not exist"
 		# }
+		echo "Response from Apple (${_wait_total}s)"
+		echo "-------------------------------------------------"
+		echo "${_resp}"
+    echo "-------------------------------------------------"
+
 		if echo "${_resp}" | grep -q 'not yet available\|does not exist'; then
-			if [[ ${_wait_total} > 0 ]]; then
-				echo -n "...${_wait_total}"
-			fi
 			_wait_total=$((_wait_total + _sleep_inc))
 			sleep ${_sleep_inc}
 		# Eventually the job should complete


### PR DESCRIPTION
### Changes
* [DDO-2247] Explicitly add hermione as a project owner in Agora as part of seed logic (fix broken Rawls & Orch tests)
* [DDO-2138] Stop waiting for terra-bee-generator to become healthy on BEE create, because multiple concurrent bee creates/deletes can prevent this from ever happening. As an alternative, we now wait for the BEE's generator to exist.
* [DDO-2255] Wait for deployments to become healthy after a restart to pick up firecloud-develop changes. We also now only trigger syncs if a hard-refresh diff shows the app as out of sync
* Address linting failures related to [deprecation of `ioutils`](https://www.srcbeat.com/2021/01/golang-ioutil-deprecated/)
* Make Docker image build run in parallel with code signing instead of in serial (image testing was blocked earlier due to a notary service outage)


[DDO-2247]: https://broadworkbench.atlassian.net/browse/DDO-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDO-2138]: https://broadworkbench.atlassian.net/browse/DDO-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDO-2255]: https://broadworkbench.atlassian.net/browse/DDO-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ