### PR TITLE
DDO-2355 Update Thelma to run on go 1.19

### DIFF
--- a/.github/actions/make/action.yaml
+++ b/.github/actions/make/action.yaml
@@ -31,7 +31,7 @@ runs:
     # Cache go deps across builds
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.19'
     - run: |
         make ${{ inputs.target }} \
           OUTPUT_DIR=${{ inputs.output-dir }} \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/broadinstitute/thelma
 
-go 1.17
+go 1.19
 
 require (
 	cloud.google.com/go/container v1.2.0


### PR DESCRIPTION
Updates Thelma to run on the latest go version (1.19). Mainly so we can get access to the new generics features for Thelma