### PR TITLE
DDO-2398 Fix for swat pipeline breakage

### DIFF
--- a/internal/thelma/cli/commands/bee/common/pinflags/parsing.go
+++ b/internal/thelma/cli/commands/bee/common/pinflags/parsing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
+	"regexp"
 	"strings"
 )
 
@@ -27,7 +28,11 @@ func parseVersions(format string, input []byte) (map[string]terra.VersionOverrid
 	if !exists {
 		return nil, fmt.Errorf("--%s: invalid format %q (valid formats are: %s)", flagNames.versionsFormat, format, utils.QuoteJoin(versionFormats()))
 	}
-	return parser(input)
+	overrides, err := parser(input)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeImageTags(overrides), nil
 }
 
 func versionFormats() []string {
@@ -36,6 +41,32 @@ func versionFormats() []string {
 		result = append(result, name)
 	}
 	return result
+}
+
+var imageNameIllegalChars = regexp.MustCompile(`[^a-zA-Z0-9_.\-]`)
+var imageNameStartsWithDotOrDash = regexp.MustCompile(`^[.\-]`)
+
+func normalizeImageTags(input map[string]terra.VersionOverride) map[string]terra.VersionOverride {
+	result := make(map[string]terra.VersionOverride)
+	for key, override := range input {
+		override.AppVersion = normalizeImageTag(override.AppVersion)
+		result[key] = override
+	}
+	return result
+}
+
+// this is needed for backwards-compatibility with old/legacy Jenkins pipelines. Original code:
+//
+//    BRANCH_NAME=$(get_image_name $CONFIG)
+//    REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES="s/[^a-zA-Z0-9_.\-]/-/g"
+//    REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING="s/^[.\-]*//g"
+//    IMAGE=$(echo $BRANCH_NAME | sed -e $REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES -e $REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
+//
+// https://github.com/broadinstitute/firecloud-develop/blob/a8573a38698890031444166320db1a857f8a0834/run-context/fiab/scripts/FiaB_configs.sh#L125
+func normalizeImageTag(imageTag string) string {
+	imageTag = imageNameIllegalChars.ReplaceAllString(imageTag, "-")
+	imageTag = imageNameStartsWithDotOrDash.ReplaceAllString(imageTag, "")
+	return imageTag
 }
 
 func parseYaml(input []byte) (map[string]terra.VersionOverride, error) {

--- a/internal/thelma/cli/commands/bee/common/pinflags/parsing.go
+++ b/internal/thelma/cli/commands/bee/common/pinflags/parsing.go
@@ -64,9 +64,12 @@ func normalizeImageTags(input map[string]terra.VersionOverride) map[string]terra
 //
 // https://github.com/broadinstitute/firecloud-develop/blob/a8573a38698890031444166320db1a857f8a0834/run-context/fiab/scripts/FiaB_configs.sh#L125
 func normalizeImageTag(imageTag string) string {
-	imageTag = imageNameIllegalChars.ReplaceAllString(imageTag, "-")
-	imageTag = imageNameStartsWithDotOrDash.ReplaceAllString(imageTag, "")
-	return imageTag
+	normalized := imageNameIllegalChars.ReplaceAllString(imageTag, "-")
+	normalized = imageNameStartsWithDotOrDash.ReplaceAllString(normalized, "")
+	if normalized != imageTag {
+		log.Info().Msgf("Rewriting illegal image tag %q to %q", imageTag, normalized)
+	}
+	return normalized
 }
 
 func parseYaml(input []byte) (map[string]terra.VersionOverride, error) {

--- a/internal/thelma/cli/commands/bee/common/pinflags/parsing_test.go
+++ b/internal/thelma/cli/commands/bee/common/pinflags/parsing_test.go
@@ -1,0 +1,73 @@
+package pinflags
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_NormalizeImageTag(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "",
+			expected: "",
+		},
+		{
+			input:    "foo",
+			expected: "foo",
+		},
+		{
+			input:    ".",
+			expected: "",
+		},
+		{
+			input:    "-",
+			expected: "",
+		},
+		{
+			input:    "a.",
+			expected: "a.",
+		},
+		{
+			input:    "a-",
+			expected: "a-",
+		},
+		{
+			input:    "/with/slashes/",
+			expected: "with-slashes-",
+		},
+		{
+			input:    "has?ill*egal)chars",
+			expected: "has-ill-egal-chars",
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, normalizeImageTag(tc.input))
+	}
+}
+
+func Test_NormalizeImageTags(t *testing.T) {
+	input := map[string]terra.VersionOverride{
+		"sam": {
+			AppVersion:          "/with/sl(ash)es/",
+			ChartVersion:        "1.2.3",
+			TerraHelmfileRef:    "master",
+			FirecloudDevelopRef: "dev",
+		},
+	}
+
+	expected := map[string]terra.VersionOverride{
+		"sam": {
+			AppVersion:          "with-sl-ash-es-",
+			ChartVersion:        "1.2.3",
+			TerraHelmfileRef:    "master",
+			FirecloudDevelopRef: "dev",
+		},
+	}
+
+	assert.Equal(t, expected, normalizeImageTags(input))
+}


### PR DESCRIPTION
The swatomation pipeline had [some magic](https://github.com/broadinstitute/firecloud-develop/blob/a8573a38698890031444166320db1a857f8a0834/run-context/fiab/scripts/FiaB_configs.sh#L125) for converting git branch names into legal Docker image tags.

This exact same logic is duplicated in the various services' [build.sh scripts](https://github.com/broadinstitute/firecloud-orchestration/blob/dc5fc4549864db255703a514b45ac427c58f24a7/script/build.sh#L30).

The simplest path forward is to replicate this logic in Thelma, so that's what this PR does.

Slack thread for context: https://broadinstitute.slack.com/archives/C029LTN5L80/p1665502394560979

(Yes, yes, this conversion should happen in the build/publish pipelines, but this is much easier)