### PR TITLE
DDO-2403 Clean up pubsub topics when BEEs are deleted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/container v1.2.0
+	cloud.google.com/go/pubsub v1.3.1
 	cloud.google.com/go/storage v1.18.2
 	github.com/alecthomas/chroma v0.10.0
 	github.com/broadinstitute/sherlock v0.0.55
@@ -39,6 +40,7 @@ require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.3.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
+	cloud.google.com/go/kms v1.4.0 // indirect
 	github.com/armon/go-metrics v0.3.9 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
@@ -118,6 +120,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ cloud.google.com/go v0.93.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+Y
 cloud.google.com/go v0.94.1/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW4=
 cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Udc=
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
+cloud.google.com/go v0.100.1/go.mod h1:fs4QogzfH5n2pBXBP9vRiU+eCny7lD2vmFZy79Iuw1U=
 cloud.google.com/go v0.100.2 h1:t9Iw5QH5v4XtlEQaCtUY7x6sCABps8sW0acw7e2WQ6Y=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
@@ -42,11 +43,15 @@ cloud.google.com/go/container v1.2.0/go.mod h1:Cj2AgMsCUfMVfbGh0Fx7u5Ah/qeC0ajLr
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
+cloud.google.com/go/iam v0.1.0/go.mod h1:vcUNEa0pEm0qRVpmWepWaFMIAI8/hjB9mO8rNCJtF6c=
 cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
+cloud.google.com/go/kms v1.4.0 h1:iElbfoE61VeLhnZcGOltqL8HIly8Nhbe5t6JlH9GXjo=
+cloud.google.com/go/kms v1.4.0/go.mod h1:fajBHndQ+6ubNw6Ss2sSd+SWvjL26RNo/dr7uxsnnOA=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
+cloud.google.com/go/pubsub v1.3.1 h1:ukjixP1wl0LpnZ6LWtZJ0mX5tBmjp1f8Sqer8Z2OMUU=
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
@@ -894,6 +899,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/thelma/bee/cleanup/cleanup.go
+++ b/internal/thelma/bee/cleanup/cleanup.go
@@ -1,0 +1,96 @@
+// Package cleanup contains logic for cleaning up Bee cloud resources when BEEs are deleted
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"github.com/broadinstitute/thelma/internal/thelma/clients/google"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/rs/zerolog/log"
+)
+
+// topicIdFormats list of pubsub topics created by services running in BEEs that should be deleted
+// when the BEE is deleted (%s is substituted with environment name).
+// I HATE HATE HATE that we need to keep this list, but the go pubsub client apparently has no way of filtering
+// topic ids by regular expression. If we wanted to just match by environment name, we'd be iterating
+// through thousands of topic names client-side. :skull:
+var topicIdFormats = []string{
+	"leonardo-pubsub-%s",
+	"rawls-async-import-topic-%s",
+	"sam-group-sync-%s",
+	"terra-%s-stairwaycluster-workqueue",
+	"workbench-notifications-%s",
+}
+
+type Cleanup interface {
+	Cleanup(bee terra.Environment) error
+}
+
+func NewCleanup(googleClients google.Clients) Cleanup {
+	return &cleanup{
+		googleClients: googleClients,
+	}
+}
+
+type cleanup struct {
+	googleClients google.Clients
+}
+
+func (c *cleanup) Cleanup(bee terra.Environment) error {
+	if !bee.Lifecycle().IsDynamic() {
+		panic(fmt.Errorf("%s is not a dynamic environment, won't attempt to cleanup its resources", bee.Name()))
+	}
+
+	return c.cleanupPubsubTopics(bee)
+}
+
+func (c *cleanup) cleanupPubsubTopics(env terra.Environment) error {
+	projects := projectIds(env)
+	for _, projectId := range projects {
+		if err := c.cleanupPubsubTopicsInProject(env, projectId); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// clean up pubsub topics in the project
+func (c *cleanup) cleanupPubsubTopicsInProject(env terra.Environment, projectId string) error {
+	client, err := c.googleClients.PubSub(projectId)
+	if err != nil {
+		return err
+	}
+
+	for _, topicId := range pubsubTopicIds(env) {
+		if err = client.Topic(topicId).Delete(context.Background()); err != nil {
+			// If the environment was never created successfully, the pubsub topic might not exist, so just log a warning and exit
+			log.Warn().Err(err).Msgf("Failed to delete pubsub topic %s in project %s", topicId, projectId)
+		} else {
+			log.Info().Msgf("Deleted pubsub topic %s in project %s", topicId, projectId)
+		}
+	}
+
+	return nil
+}
+
+// return the list of topic ids that should be cleaned up for this environment
+func pubsubTopicIds(env terra.Environment) []string {
+	topicIds := set.NewStringSet()
+
+	for _, topicId := range topicIdFormats {
+		topicIds.Add(fmt.Sprintf(topicId, env.Name()))
+	}
+
+	return topicIds.Elements()
+}
+
+// return the list of projects this terra.Environment is distributed across
+// in 99% of cases this will be a single project
+func projectIds(env terra.Environment) []string {
+	projects := set.NewStringSet()
+	for _, r := range env.Releases() {
+		projects.Add(r.Cluster().Project())
+	}
+	return projects.Elements()
+}

--- a/internal/thelma/bee/cleanup/cleanup.go
+++ b/internal/thelma/bee/cleanup/cleanup.go
@@ -65,9 +65,9 @@ func (c *cleanup) cleanupPubsubTopicsInProject(env terra.Environment, projectId 
 	for _, topicId := range pubsubTopicIds(env) {
 		if err = client.Topic(topicId).Delete(context.Background()); err != nil {
 			// If the environment was never created successfully, the pubsub topic might not exist, so just log a warning and exit
-			log.Warn().Err(err).Msgf("Failed to delete pubsub topic %s in project %s", topicId, projectId)
+			log.Warn().Err(err).Msgf("Failed to delete pubsub topic %s/%s", projectId, topicId)
 		} else {
-			log.Info().Msgf("Deleted pubsub topic %s in project %s", topicId, projectId)
+			log.Info().Msgf("Deleted pubsub topic %s/%s", projectId, topicId)
 		}
 	}
 

--- a/internal/thelma/bee/cleanup/cleanup_test.go
+++ b/internal/thelma/bee/cleanup/cleanup_test.go
@@ -1,0 +1,30 @@
+package cleanup
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/state/providers/gitops/statefixtures"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_pubsubTopicIds(t *testing.T) {
+	fixture := statefixtures.LoadFixture(statefixtures.Default, t)
+
+	dynamic := fixture.Environment("fiab-funky-chipmunk")
+	assert.ElementsMatch(t, []string{
+		"leonardo-pubsub-fiab-funky-chipmunk",
+		"rawls-async-import-topic-fiab-funky-chipmunk",
+		"sam-group-sync-fiab-funky-chipmunk",
+		"terra-fiab-funky-chipmunk-stairwaycluster-workqueue",
+		"workbench-notifications-fiab-funky-chipmunk",
+	}, pubsubTopicIds(dynamic))
+}
+
+func Test_projectIds(t *testing.T) {
+	fixture := statefixtures.LoadFixture(statefixtures.Default, t)
+
+	static := fixture.Environment("staging")
+	assert.ElementsMatch(t, []string{"broad-dsde-staging", "terra-datarepo-staging"}, projectIds(static))
+
+	dynamic := fixture.Environment("fiab-funky-chipmunk")
+	assert.ElementsMatch(t, []string{"broad-dsde-qa"}, projectIds(dynamic))
+}

--- a/internal/thelma/cli/commands/bee/common/builders/builders.go
+++ b/internal/thelma/cli/commands/bee/common/builders/builders.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
+	"github.com/broadinstitute/thelma/internal/thelma/bee/cleanup"
 	"github.com/broadinstitute/thelma/internal/thelma/bee/seed"
 )
 
@@ -18,12 +19,14 @@ func NewBees(thelmaApp app.ThelmaApp) (bee.Bees, error) {
 		return nil, err
 	}
 
+	_cleanup := cleanup.NewCleanup(thelmaApp.Clients().Google())
+
 	kubectl, err := thelmaApp.Clients().Google().Kubectl()
 	if err != nil {
 		return nil, err
 	}
 
-	return bee.NewBees(_argocd, thelmaApp.StateLoader(), seeder, kubectl)
+	return bee.NewBees(_argocd, thelmaApp.StateLoader(), seeder, _cleanup, kubectl)
 }
 
 func newSeeder(thelma app.ThelmaApp) (seed.Seeder, error) {

--- a/internal/thelma/clients/google/google.go
+++ b/internal/thelma/clients/google/google.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/pubsub"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -43,6 +44,8 @@ type Clients interface {
 	// SetSubject allows usage of domain-wide delegation privileges, to authenticate as a user via
 	// a different account.
 	SetSubject(subject string) Clients
+	// PubSub returns a new google pubsub client
+	PubSub(projectId string) (*pubsub.Client, error)
 }
 
 type googleConfig struct {
@@ -170,6 +173,14 @@ func (g *google) Terra() (terraapi.TerraClient, error) {
 func (g *google) SetSubject(subject string) Clients {
 	g.subject = subject
 	return g
+}
+
+func (g *google) PubSub(projectId string) (*pubsub.Client, error) {
+	clientOpts, err := g.clientOptions()
+	if err != nil {
+		return nil, err
+	}
+	return pubsub.NewClient(context.Background(), projectId, clientOpts...)
 }
 
 func (g *google) clientOptions() ([]option.ClientOption, error) {


### PR DESCRIPTION
This change updates Thelma to automatically delete a [hardcoded list](https://github.com/broadinstitute/thelma/blob/edb58b5a4a7e540a3ea9fde4c8cac1b740aa44ba/internal/thelma/bee/cleanup/cleanup.go#L18) of pubsub topics when a BEE is deleted.

This also updates the vault auto-masker to be less aggressive -- we should stop seeing project names like `broad-dsde-qa` masked in logs.

Context: https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1665586880611919