### PR TITLE
[DDO-2449] Use a lower-permissioned Vault token check

### DIFF
--- a/internal/thelma/clients/vault/testing/testing.go
+++ b/internal/thelma/clients/vault/testing/testing.go
@@ -24,7 +24,7 @@ func NewFakeVaultServer(t *testing.T) *FakeVaultServer {
 	mux := http.NewServeMux()
 
 	mux.Handle("/v1/auth/github/login", toHttpHandler(_state.handleGithubLogin))
-	mux.Handle("/v1/auth/token/lookup", toHttpHandler(_state.handleTokenLookup))
+	mux.Handle("/v1/auth/token/lookup-self", toHttpHandler(_state.handleTokenLookup))
 	mux.Handle("/v1/secret/", toHttpHandler(_state.handleSecret))
 	mux.Handle("/", toHttpHandler(_state.handleUnmatchedRequest))
 

--- a/internal/thelma/clients/vault/vault.go
+++ b/internal/thelma/clients/vault/vault.go
@@ -16,7 +16,7 @@ const vaultTokenCredentialKey = "vault-token"
 
 const githubLoginPath = "/auth/github/login"
 const approleLoginPath = "/auth/approle/login"
-const tokenLookupPath = "/auth/token/lookup"
+const tokenLookupPath = "/auth/token/lookup-self"
 
 const approleRoleIdEnvVar = "VAULT_ROLE_ID"
 const approleSecretIdEnvVar = "VAULT_SECRET_ID"


### PR DESCRIPTION
When we generate a Vault token, we quickly call `/auth/token/lookup`, ignoring the response, just to see if Vault recognized us. That works fine when the authentication is coming from some high-permissioned account, like one of us, or BroadBot, etc, but if we generate a token directly from an approle like I just implemented in #69, that fails because that entire endpoint isn't allowed.

So what are you supposed to do if you want to check your own token? There's a separate endpoint--`/auth/token/lookup-self`--that does that and only that, and _it_ can be called by the approle we have set up with Argo (I replicated locally). It is otherwise equivalent so I'm just replacing it everywhere.