### PR TITLE
[DDO-2449] Use GET for Vault /auth/token/lookup-self

### DIFF
--- a/internal/thelma/clients/vault/vault.go
+++ b/internal/thelma/clients/vault/vault.go
@@ -214,7 +214,7 @@ func tokenLookup(client *vaultapi.Client, vaultToken string) error {
 	_client.SetToken(vaultToken)
 
 	// we don't actually care about any data in the response, just that the token lookup succeeds
-	_, err = _client.Logical().Write(tokenLookupPath, nil)
+	_, err = _client.Logical().Read(tokenLookupPath)
 
 	return err
 }


### PR DESCRIPTION
Oversight on my part because I was always doing GET requests locally. Apparently both PUT and GET work for /lookup but only get works for /lookup-self.