### PR TITLE
[DDO-2449] Allow Thelma to short-circuit IAP client if an environment variable is set

### DIFF
--- a/internal/thelma/clients/clients.go
+++ b/internal/thelma/clients/clients.go
@@ -63,6 +63,10 @@ func (c *clients) GoogleUsingADC(allowNonBroad bool) google.Clients {
 }
 
 func (c *clients) IAPToken() (string, error) {
+	if outOfBandToken := iap.CheckEnvironmentShortCircuit(); outOfBandToken != "" {
+		return outOfBandToken, nil
+	}
+
 	vaultClient, err := c.Vault()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Turns out that basically every GHA that runs Thelma needs to talk to Sherlock, who would have predicted. Me, I should've predicted that lol and I did not. I don't exactly want to mount a Vault token into every GHA in terra-helmfile so I'm just going to kinda productionalize my little workaround that I did for chart publishing.