### PR TITLE
[DDO-2457] Add `--exact-release` as a full name alternative to `--release`

### DIFF
--- a/internal/thelma/cli/commands/argocd/sync/sync_command.go
+++ b/internal/thelma/cli/commands/argocd/sync/sync_command.go
@@ -26,7 +26,7 @@ func NewArgoCDSyncCommand() cli.ThelmaCommand {
 	return &syncCommand{
 		selector: selector.NewSelector(func(options *selector.Options) {
 			options.IncludeBulkFlags = false
-			options.RequireDestination = true
+			options.RequireDestinationOrExact = true
 		}),
 	}
 }

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -178,6 +178,11 @@ func TestRenderArgParsing(t *testing.T) {
 			expectedError: regexp.MustCompile("--app-version cannot be used for cluster releases"),
 		},
 		{
+			description:   "--exact-release ALL invalid",
+			arguments:     Args("render --exact-release ALL"),
+			expectedError: regexp.MustCompile("--exact-release cannot be used with ALL"),
+		},
+		{
 			description: "config repo path must be set",
 			arguments:   []string{"render"},
 			setupFn: func(tc *testConfig) error {
@@ -414,6 +419,17 @@ func TestRenderArgParsing(t *testing.T) {
 			arguments:   Args("render --argocd ALL"),
 			setupFn: func(tc *testConfig) error {
 				tc.expected.helmfileArgs.ArgocdMode = true
+				return nil
+			},
+		},
+		{
+			description: "--exact-release should match full name",
+			arguments:   Args("render --exact-release leonardo-dev"),
+			setupFn: func(tc *testConfig) error {
+				tc.expected.renderOptions.Scope = scope.Release
+				tc.expected.renderOptions.Releases = []terra.Release{
+					fixture.Release("leonardo", "dev"),
+				}
 				return nil
 			},
 		},

--- a/internal/thelma/cli/selector/flags.go
+++ b/internal/thelma/cli/selector/flags.go
@@ -55,7 +55,7 @@ func newExactReleasesFlag() *enumFlag {
 	return &enumFlag{
 		flagName:     flagNames.exactRelease,
 		usageMessage: "Run for specific release(s), via globally-unique destination-suffixed names like are stored in Sherlock",
-		preProcessHook: func(flagValues []string, args []string, pflags *pflag.FlagSet) (normalizedValues []string, err error) {
+		preProcessHook: func(flagValues []string, _ []string, _ *pflag.FlagSet) (normalizedValues []string, err error) {
 			if len(flagValues) == 0 {
 				// If there's no exact releases specified, act as if this flag had been set to ALL so we don't filter on it.
 				// Note that we do this in a hook rather than with defaultValues so we can identify when a user passes ALL

--- a/internal/thelma/cli/selector/flags_test.go
+++ b/internal/thelma/cli/selector/flags_test.go
@@ -1,0 +1,91 @@
+package selector
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_newReleasesFlag(t *testing.T) {
+	t.Run("just flag", func(t *testing.T) {
+		flag := newReleasesFlag()
+		pflags := &pflag.FlagSet{}
+		pflags.AddFlag(&pflag.Flag{
+			Name:    flag.flagName,
+			Changed: true,
+		})
+		out, err := flag.preProcessHook([]string{allSelector}, []string{}, pflags)
+		assert.Equal(t, []string{allSelector}, out)
+		assert.NoError(t, err)
+	})
+	t.Run("just arg", func(t *testing.T) {
+		flag := newReleasesFlag()
+		pflags := &pflag.FlagSet{}
+		pflags.AddFlag(&pflag.Flag{
+			Name:    flag.flagName,
+			Changed: false,
+		})
+		out, err := flag.preProcessHook([]string{}, []string{allSelector}, pflags)
+		assert.Equal(t, []string{allSelector}, out)
+		assert.NoError(t, err)
+	})
+	t.Run("not both flag and arg", func(t *testing.T) {
+		flag := newReleasesFlag()
+		pflags := &pflag.FlagSet{}
+		pflags.AddFlag(&pflag.Flag{
+			Name:    flag.flagName,
+			Changed: true,
+		})
+		_, err := flag.preProcessHook([]string{allSelector}, []string{allSelector}, pflags)
+		assert.ErrorContains(t, err, "not both")
+	})
+	t.Run("disallow empty normally", func(t *testing.T) {
+		flag := newReleasesFlag()
+		pflags := &pflag.FlagSet{}
+		pflags.AddFlag(&pflag.Flag{
+			Name:    flag.flagName,
+			Changed: false,
+		})
+		_, err := flag.preProcessHook([]string{}, []string{}, pflags)
+		assert.ErrorContains(t, err, "at least one")
+	})
+	t.Run("allow empty if exact set", func(t *testing.T) {
+		flag := newReleasesFlag()
+		pflags := &pflag.FlagSet{}
+		pflags.AddFlag(&pflag.Flag{
+			Name:    flag.flagName,
+			Changed: false,
+		})
+		pflags.AddFlag(&pflag.Flag{
+			Name:    flagNames.exactRelease,
+			Changed: true,
+		})
+		out, err := flag.preProcessHook([]string{}, []string{}, pflags)
+		assert.Equal(t, []string{allSelector}, out)
+		assert.NoError(t, err)
+	})
+}
+
+func Test_newExactReleasesFlag(t *testing.T) {
+	t.Run("empty = all", func(t *testing.T) {
+		flag := newExactReleasesFlag()
+		pflags := &pflag.FlagSet{} // not used by function
+		out, err := flag.preProcessHook([]string{}, []string{}, pflags)
+		assert.Equal(t, []string{allSelector}, out)
+		assert.NoError(t, err)
+	})
+	t.Run("specifying all fails", func(t *testing.T) {
+		flag := newExactReleasesFlag()
+		pflags := &pflag.FlagSet{} // not used by function
+		_, err := flag.preProcessHook([]string{allSelector}, []string{}, pflags)
+		assert.ErrorContains(t, err, "cannot be used")
+	})
+	t.Run("flag values passed unprocessed", func(t *testing.T) {
+		flag := newExactReleasesFlag()
+		pflags := &pflag.FlagSet{} // not used by function
+		flagValues := []string{"foo", "bar"}
+		out, err := flag.preProcessHook(flagValues, []string{}, pflags)
+		assert.Equal(t, flagValues, out)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/thelma/state/api/terra/destination.go
+++ b/internal/thelma/state/api/terra/destination.go
@@ -2,9 +2,9 @@ package terra
 
 // Destination is the location where a release is deployed (environment or cluster)
 type Destination interface {
+	Named                     // Named provides the name of the environment or cluster
 	Type() DestinationType    // Type is the name of the destination type, either "environment" or "cluster"
 	Base() string             // Base is the base of the environment or cluster
-	Name() string             // Name is the name of the environment or cluster
 	ReleaseType() ReleaseType // ReleaseType returns the types of releases that can be deployed to this destination
 	Releases() []Release      // Releases returns the set of releases configured for this destination
 	TerraHelmfileRef() string // TerraHelmfileRef this destination's generator should be pinned to

--- a/internal/thelma/state/api/terra/filter/release_filters.go
+++ b/internal/thelma/state/api/terra/filter/release_filters.go
@@ -11,6 +11,8 @@ type ReleaseFilters interface {
 	Any() terra.ReleaseFilter
 	// HasName returns a filter that matches releases with the given name(s)
 	HasName(releaseName ...string) terra.ReleaseFilter
+	// HasFullName returns a filter that matches release with the given full name(s)
+	HasFullName(releaseFullName ...string) terra.ReleaseFilter
 	// HasDestinationName returns a filter that matches releases with the given destination
 	HasDestinationName(destinationName string) terra.ReleaseFilter
 	// DestinationMatches returns a filter that matches releases with matching destinations
@@ -46,6 +48,20 @@ func (r releaseFilters) HasName(releaseNames ...string) terra.ReleaseFilter {
 		matcher: func(r terra.Release) bool {
 			for _, name := range releaseNames {
 				if r.Name() == name {
+					return true
+				}
+			}
+			return false
+		},
+	}
+}
+
+func (r releaseFilters) HasFullName(releaseFullNames ...string) terra.ReleaseFilter {
+	return releaseFilter{
+		string: fmt.Sprintf("hasFullName(%s)", join(quote(releaseFullNames)...)),
+		matcher: func(r terra.Release) bool {
+			for _, fullName := range releaseFullNames {
+				if r.FullName() == fullName {
 					return true
 				}
 			}

--- a/internal/thelma/state/api/terra/named.go
+++ b/internal/thelma/state/api/terra/named.go
@@ -1,0 +1,7 @@
+package terra
+
+// Named is a top-level interface pulled into Release and Destination types. Having a separate interface representing
+// this method means we can iterate over Release and Destination types the same.
+type Named interface {
+	Name() string
+}

--- a/internal/thelma/state/api/terra/release.go
+++ b/internal/thelma/state/api/terra/release.go
@@ -1,9 +1,9 @@
 package terra
 
 // Release represents a deployed instance of a Helm chart, running in a Kubernetes cluster. The term comes from Helm.
-//
 type Release interface {
-	Name() string
+	Named
+	FullName() string
 	Type() ReleaseType
 	IsAppRelease() bool
 	IsClusterRelease() bool

--- a/internal/thelma/state/providers/gitops/release.go
+++ b/internal/thelma/state/providers/gitops/release.go
@@ -1,6 +1,7 @@
 package gitops
 
 import (
+	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 )
 
@@ -16,6 +17,13 @@ type release struct {
 	destination         terra.Destination
 	terraHelmfileRef    string
 	firecloudDevelopRef string
+}
+
+// FullName is meant to be globally unique, since it is meant to expose Sherlock's full globally-unique names, which
+// are destination-suffixed. Gitops-based releases don't include that, so to provide a method returning the same thing
+// we just append the destination ourselves.
+func (r *release) FullName() string {
+	return fmt.Sprintf("%s-%s", r.name, r.destination.Name())
 }
 
 func (r *release) Name() string {

--- a/internal/thelma/state/providers/sherlock/release.go
+++ b/internal/thelma/state/providers/sherlock/release.go
@@ -21,6 +21,12 @@ type release struct {
 	firecloudDevelopRef string
 }
 
+// FullName provides the entire name of the chart release, globally unique as enforced by Sherlock. Name provides
+// a truncated name used by Thelma for brevity that is only unique across a destination.
+func (r *release) FullName() string {
+	return r.name
+}
+
 func (r *release) Name() string {
 	// sherlock requires unique release names so they are of the from RELEASE_NAME-(ENV_NAME | CLUSTER_NAME)
 	// depending on release type. For compatibility with terra-helmfile values file structure and mimicking behavior in the


### PR DESCRIPTION
User story: “I would like to be able to run thelma argocd sync --exact-release beehive-dev-dsp-tools”. 

It’s me, I’m the user. 🪄 #makeitso

Basically, passing --exact-release:
1. Acts as if you passed --release ALL
2. Lets you not pass -e/-c even for things like `argocd sync`, because it isn't necessary for uniqueness
3. Filters against the "full name" of the release

For Sherlock state provider, full name is the raw exact name stored in Sherlock. For Gitops, it is `fmt.Sprintf("%s-%s", r.name, r.destination.Name())` to achieve the same effect in all current cases.

Why is this so useful? The entirety of the heavy-lifting of [terra-github-workflows/sync-release.yaml](https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/sync-release.yaml#L99) can literally just become a single Thelma call with no processing. Simpler code and it'll run way faster for cluster releases and multi-environment syncs because it can do them all in parallel.

I didn't see tests for this since it is basically pflag mucking-around but I was able to pretty thoroughly test the new and old behavior locally (not just for `argocd sync`, I checked `render ALL` and other stuff too)