### PR TITLE
[DDO-2461] `thelma bee provision`

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -19,6 +19,7 @@ const generatorArgoApp = "terra-bee-generator"
 type Bees interface {
 	DeleteWith(name string, options DeleteOptions) (terra.Environment, error)
 	CreateWith(options CreateOptions) (terra.Environment, error)
+	ProvisionWith(name string, options ProvisionOptions) (terra.Environment, error)
 	GetBee(name string) (terra.Environment, error)
 	GetTemplate(templateName string) (terra.Environment, error)
 	Seeder() seed.Seeder
@@ -36,11 +37,17 @@ type DeleteOptions struct {
 }
 
 type CreateOptions struct {
+	NamePrefix   string
+	Owner        string
+	GenerateName bool
+	Template     string
+	ProvisionOptions
+}
+
+type ProvisionOptions struct {
+	// Name within the context of ProvisionOptions is just the name of the environment.
+	// In the context of CreateOptions, it means the name of the environment *to create*.
 	Name              string
-	NamePrefix        string
-	Owner             string
-	GenerateName      bool
-	Template          string
 	SyncGeneratorOnly bool
 	WaitHealthy       bool
 	PinOptions        PinOptions
@@ -109,13 +116,17 @@ func (b *bees) CreateWith(options CreateOptions) (terra.Environment, error) {
 	if err = b.reloadState(); err != nil {
 		return nil, err
 	}
-	env, err := b.state.Environments().Get(envName)
+	return b.ProvisionWith(envName, options.ProvisionOptions)
+}
+
+func (b *bees) ProvisionWith(name string, options ProvisionOptions) (terra.Environment, error) {
+	env, err := b.state.Environments().Get(name)
 	if err != nil {
 		return nil, err
 	}
 	if env == nil {
 		// don't think this could ever happen, but let's provide a useful error anyway
-		return nil, fmt.Errorf("error creating environment %q: missing from state after creation", env.Name())
+		return nil, fmt.Errorf("error provisioning environment %q: missing from state", env.Name())
 	}
 
 	err = b.kubectl.CreateNamespace(env)

--- a/internal/thelma/cli/commands/bee/provision/provision_command.go
+++ b/internal/thelma/cli/commands/bee/provision/provision_command.go
@@ -1,0 +1,92 @@
+package provision
+
+import (
+	"fmt"
+	"github.com/broadinstitute/thelma/internal/thelma/app"
+	"github.com/broadinstitute/thelma/internal/thelma/bee"
+	"github.com/broadinstitute/thelma/internal/thelma/cli"
+	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
+	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/pinflags"
+	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/seedflags"
+	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+const helpMessage = `Provision the resources for a newly created BEE (Branch Engineering Environment)
+
+Examples:
+
+thelma bee provision --name=bee-swat-ecstatic-spider
+`
+
+var flagNames = struct {
+	name          string
+	generatorOnly string
+	waitHealthy   string
+	seed          string
+}{
+	name:          "name",
+	generatorOnly: "generator-only",
+	waitHealthy:   "wait-healthy",
+	seed:          "seed",
+}
+
+type provisionCommand struct {
+	options   bee.ProvisionOptions
+	pinFlags  pinflags.PinFlags
+	seedFlags seedflags.SeedFlags
+}
+
+func NewBeeProvisionCommand() cli.ThelmaCommand {
+	return &provisionCommand{
+		pinFlags: pinflags.NewPinFlags(),
+		seedFlags: seedflags.NewSeedFlags(func(options *seedflags.Options) {
+			options.Prefix = "seed-"
+			options.NoShortHand = true
+			options.Hidden = false
+		}),
+	}
+}
+
+func (cmd *provisionCommand) ConfigureCobra(cobraCommand *cobra.Command) {
+	cobraCommand.Use = "provision"
+	cobraCommand.Short = "Provision and sync the resources for a newly-created BEE"
+	cobraCommand.Long = helpMessage
+
+	cobraCommand.Flags().StringVarP(&cmd.options.Name, flagNames.name, "n", "NAME", "Name of the newly-created BEE to provision")
+	cobraCommand.Flags().BoolVar(&cmd.options.SyncGeneratorOnly, flagNames.generatorOnly, false, "Sync the BEE generator but not the BEE's Argo apps")
+	cobraCommand.Flags().BoolVar(&cmd.options.WaitHealthy, flagNames.waitHealthy, true, "Wait for BEE's Argo apps to become healthy after syncing")
+	cobraCommand.Flags().BoolVar(&cmd.options.Seed, flagNames.seed, true, `Seed BEE after creation (run "thelma bee seed -h" for more info)`)
+
+	cmd.pinFlags.AddFlags(cobraCommand)
+	cmd.seedFlags.AddFlags(cobraCommand)
+}
+
+func (cmd *provisionCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
+	if !ctx.CobraCommand().Flags().Changed(flagNames.name) {
+		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+	}
+	if strings.TrimSpace(cmd.options.Name) == "" {
+		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
+		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+	}
+	return nil
+}
+
+func (cmd *provisionCommand) Run(thelmaApp app.ThelmaApp, ctx cli.RunContext) error {
+	bees, err := builders.NewBees(thelmaApp)
+	if err != nil {
+		return err
+	}
+	env, err := bees.ProvisionWith(cmd.options.Name, cmd.options)
+	if env != nil {
+		ctx.SetOutput(views.DescribeBee(env))
+	}
+	return err
+}
+
+func (cmd *provisionCommand) PostRun(_ app.ThelmaApp, _ cli.RunContext) error {
+	return nil
+}

--- a/internal/thelma/cli/commands/bee/provision/provision_command_test.go
+++ b/internal/thelma/cli/commands/bee/provision/provision_command_test.go
@@ -1,0 +1,21 @@
+package provision
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app/builder"
+	"github.com/broadinstitute/thelma/internal/thelma/cli"
+	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_ProvisionHelp(t *testing.T) {
+	_cli := cli.New(func(options *cli.Options) {
+		options.AddCommand("bee", bee.NewBeeCommand())
+		options.AddCommand("bee create", NewBeeProvisionCommand())
+		options.ConfigureThelma(func(thelmaBuilder builder.ThelmaBuilder) {
+			thelmaBuilder.WithTestDefaults(t)
+		})
+		options.SetArgs([]string{"bee", "provision", "--help"})
+	})
+	assert.NoError(t, _cli.Execute(), "--help should execute successfully")
+}

--- a/internal/thelma/cli/entrypoint/entrypoint.go
+++ b/internal/thelma/cli/entrypoint/entrypoint.go
@@ -16,6 +16,7 @@ import (
 	bee_describe "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/describe"
 	bee_list "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/list"
 	bee_pin "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/pin"
+	bee_provision "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/provision"
 	bee_reset "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/reset"
 	bee_seed "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/seed/seed"
 	bee_unseed "github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/seed/unseed"
@@ -54,6 +55,7 @@ func withCommands(opts *cli.Options) {
 
 	opts.AddCommand("bee", bee.NewBeeCommand())
 	opts.AddCommand("bee create", bee_create.NewBeeCreateCommand())
+	opts.AddCommand("bee provision", bee_provision.NewBeeProvisionCommand())
 	opts.AddCommand("bee delete", bee_delete.NewBeeDeleteCommand())
 	opts.AddCommand("bee describe", bee_describe.NewBeeDescribeCommand())
 	opts.AddCommand("bee list", bee_list.NewBeeListCommand())


### PR DESCRIPTION
It's like `thelma bee create` except it doesn't do the create part. The implementation is just splitting the existing internal create function in two and adding a new CLI command that shortcuts to the second part.