### PR TITLE
DDO-2474 Fix for BEE seed not running during provisioning

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -193,7 +193,7 @@ func (b *bees) ProvisionWith(name string, options ProvisionOptions) (*Bee, error
 
 	if err != nil && options.ExportLogsOnFailure {
 		_, logErr := b.exportLogs(env)
-		if err != nil {
+		if logErr != nil {
 			log.Error().Err(logErr).Msgf("error exporting logs from %s: %v", env.Name(), logErr)
 		}
 		bee.ContainerLogsURL = artifacts.DefaultArtifactsURL(env)

--- a/internal/thelma/cli/commands/bee/provision/provision_command.go
+++ b/internal/thelma/cli/commands/bee/provision/provision_command.go
@@ -70,7 +70,7 @@ func (cmd *provisionCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 	cmd.seedFlags.AddFlags(cobraCommand)
 }
 
-func (cmd *provisionCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
+func (cmd *provisionCommand) PreRun(app app.ThelmaApp, ctx cli.RunContext) error {
 	if !ctx.CobraCommand().Flags().Changed(flagNames.name) {
 		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
@@ -78,6 +78,19 @@ func (cmd *provisionCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
 		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
+	// validate/load pin and seed options
+	pinOptions, err := cmd.pinFlags.GetPinOptions(app, ctx)
+	if err != nil {
+		return err
+	}
+	cmd.options.PinOptions = pinOptions
+
+	seedOptions, err := cmd.seedFlags.GetOptions(ctx.CobraCommand())
+	if err != nil {
+		return err
+	}
+	cmd.options.SeedOptions = seedOptions
+
 	return nil
 }
 


### PR DESCRIPTION
Seed options weren't being parsed on the `bee provision` command.

Also fixes an edge case  issue where Thelma would incorrectly report a container log export error when there really wasn't one.