### PR TITLE
DDO-2477 Fix panic in bee unseed

### DIFF
--- a/internal/thelma/clients/google/terraapi/terra.go
+++ b/internal/thelma/clients/google/terraapi/terra.go
@@ -55,12 +55,12 @@ func (c *terraClient) doJsonRequest(method string, url string, body io.Reader) (
 	}
 	token.SetAuthHeader(req)
 	response, err := c.httpClient.Do(req)
-	defer func(body io.ReadCloser) {
-		_ = body.Close()
-	}(response.Body)
 	if err != nil {
 		return response, "", err
 	}
+	defer func(body io.ReadCloser) {
+		_ = body.Close()
+	}(response.Body)
 	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return response, "", err


### PR DESCRIPTION
This panic showed up in GHA earlier today: https://broadinstitute.slack.com/archives/C029LTN5L80/p1669053559481829

```
6:00PM INF unregistering lavender.brown@quality.firecloud.org
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xc476b1]

goroutine 1 [running]:
github.com/broadinstitute/thelma/internal/thelma/clients/google/terraapi.(*terraClient).doJsonRequest(0xc000a59040, ***0x226f27b?, 0xc000698f10?***, ***0xc00096aa80, 0x58***, ***0x2681600?, 0xc000cf8d80?***)
	/home/runner/work/thelma/thelma/internal/thelma/clients/google/terraapi/terra.go:60 +0x1d1
github.com/broadinstitute/thelma/internal/thelma/clients/google/terraapi.(*samClient).UnregisterUser(0xc0005f05b8, ***0xc0006a4570, 0x15***)
	/home/runner/work/thelma/thelma/internal/thelma/clients/google/terraapi/sam.go:48 +0xee
github.com/broadinstitute/thelma/internal/thelma/bee/seed.(*seeder).unseedStep1UnregisterAllUsers(0xc0008b70c0, 0xc0000cf760?, ***0x1d?, ***0x0?, 0x0?***)
	/home/runner/work/thelma/thelma/internal/thelma/bee/seed/unseed_step_1_unregister_all_users.go:109 +0x1404
github.com/broadinstitute/thelma/internal/thelma/bee/seed.(*seeder).Unseed(0xc000410ba0?, ***0x26b0d10?, 0xc0000cf760?***, ***0x0?, ***0x0?, 0x0?***)
	/home/runner/work/thelma/thelma/internal/thelma/bee/seed/seeder.go:95 +0x65
github.com/broadinstitute/thelma/internal/thelma/bee.(*bees).DeleteWith(0xc00074e0e0, ***0x7ffd9ae7fb4e, 0x14***, ***0x0?, 0x0?***)
	/home/runner/work/thelma/thelma/internal/thelma/bee/bee.go:231 +0x1af
github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/delete.(*deleteCommand).Run(0xc0005312f0, ***0x26ac288?, 0xc00074f730?***, ***0x26a8520, 0xc000373900***)
	/home/runner/work/thelma/thelma/internal/thelma/cli/commands/bee/delete/delete_command.go:69 +0x8e
github.com/broadinstitute/thelma/internal/thelma/cli.(*execution).run(0xc0007d4960)
	/home/runner/work/thelma/thelma/internal/thelma/cli/execution.go:76 +0x83
github.com/broadinstitute/thelma/internal/thelma/cli.(*execution).execute(0xc0007d4960)
	/home/runner/work/thelma/thelma/internal/thelma/cli/execution.go:42 +0x28
github.com/broadinstitute/thelma/internal/thelma/cli.NewWithOptions.func1.1(0xc00075e300?, ***0xc00074b730?, 0x1?, 0x1?***)
	/home/runner/work/thelma/thelma/internal/thelma/cli/cli.go:56 +0x5f
github.com/spf13/cobra.(*Command).execute(0xc00075e300, ***0xc00074b710, 0x1, 0x1***)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000351500)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:1040 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:968
github.com/broadinstitute/thelma/internal/thelma/cli.(*thelmaCLI).Execute(0xc00078ff48?)
	/home/runner/work/thelma/thelma/internal/thelma/cli/cli.go:21 +0x25
github.com/broadinstitute/thelma/internal/thelma/cli/entrypoint.Execute()
	/home/runner/work/thelma/thelma/internal/thelma/cli/entrypoint/entrypoint.go:43 +0x48
main.main()
	/home/runner/work/thelma/thelma/cmd/thelma/main.go:8 +0x17
```

Looks like an out-of-order error check.
