### PR TITLE
DDO-2365 Cosmetic adjustments to error reporting and logging

### DIFF
--- a/internal/thelma/clients/vault/masking_round_tripper_test.go
+++ b/internal/thelma/clients/vault/masking_round_tripper_test.go
@@ -18,6 +18,7 @@ func Test_MaskingRoundTripper(t *testing.T) {
 			"field2":     "mask-me-2",
 			"project_id": "should-not-be-masked-1",
 			"user":       "should-not-be-masked-2",
+			"too-short":  "abcd", // should not be masked
 		},
 	)
 

--- a/internal/thelma/utils/pool/summarizer.go
+++ b/internal/thelma/utils/pool/summarizer.go
@@ -149,7 +149,7 @@ func (s *summarizer) logSummary() {
 		}
 		if phase != Queued {
 			// optimizing for humans reading the logs
-			event.Str(elapsedTimeField, fmt.Sprintf("%s", item.duration().Round(time.Second)))
+			event.Str(elapsedTimeField, string(item.duration().Round(time.Second)))
 		}
 		if item.hasErr() {
 			event.Err(item.getErr())

--- a/internal/thelma/utils/pool/summarizer.go
+++ b/internal/thelma/utils/pool/summarizer.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+const elapsedTimeField = "time"
+
 type SummarizerOptions struct {
 	// Enabled if true, print a periodic summary of pool status while items are being processed. For example:
 	//
@@ -133,11 +135,21 @@ func (s *summarizer) logSummary() {
 
 		event := s.log()
 
-		if item.status() != nil {
-			event.Dict("status", item.status().Dict())
+		status := item.status()
+		if status != nil {
+			if status.Message != "" {
+				event.Str("status", status.Message)
+			}
+			event.Str("status", status.Message)
+			if len(status.Context) > 0 {
+				for k, v := range status.Context {
+					event.Interface(k, v)
+				}
+			}
 		}
 		if phase != Queued {
-			event.Dur("duration", item.duration())
+			// optimizing for humans reading the logs
+			event.Str(elapsedTimeField, fmt.Sprintf("%s", item.duration().Round(time.Second)))
 		}
 		if item.hasErr() {
 			event.Err(item.getErr())

--- a/internal/thelma/utils/pool/summarizer_test.go
+++ b/internal/thelma/utils/pool/summarizer_test.go
@@ -120,17 +120,13 @@ func Test_Summarizer(t *testing.T) {
 		{
 			"level":   "warn",
 			"message": "carrot: running",
-			"status": map[string]interface{}{
-				"message": "rabbit gnawing",
-				"name":    "peter",
-			},
+			"status":  "rabbit gnawing",
+			"name":    "peter",
 		},
 		{
 			"level":   "warn",
 			"message": "celery: running",
-			"status": map[string]interface{}{
-				"message": "12% complete",
-			},
+			"status":  "12% complete",
 		},
 		{
 			"level":   "warn",
@@ -151,24 +147,18 @@ func Test_Summarizer(t *testing.T) {
 		{
 			"level":   "warn",
 			"message": "carrot: success",
-			"status": map[string]interface{}{
-				"message": "rabbit full",
-				"name":    "peter",
-			},
+			"status":  "rabbit full",
+			"name":    "peter",
 		},
 		{
 			"level":   "warn",
 			"message": "celery: running",
-			"status": map[string]interface{}{
-				"message": "67% complete",
-			},
+			"status":  "67% complete",
 		},
 		{
 			"level":   "warn",
 			"message": "onion:  running",
-			"status": map[string]interface{}{
-				"message": "onion pending",
-			},
+			"status":  "onion pending",
 		},
 		{
 			"level":   "warn",
@@ -185,25 +175,19 @@ func Test_Summarizer(t *testing.T) {
 		{
 			"level":   "warn",
 			"message": "carrot: success",
-			"status": map[string]interface{}{
-				"message": "rabbit full",
-				"name":    "peter",
-			},
+			"status":  "rabbit full",
+			"name":    "peter",
 		},
 		{
 			"level":   "warn",
 			"message": "celery: success",
-			"status": map[string]interface{}{
-				"message": "100% complete",
-			},
+			"status":  "100% complete",
 		},
 		{
 			"level":   "warn",
 			"message": "onion:  error",
 			"error":   "whoopsies",
-			"status": map[string]interface{}{
-				"message": "onion pending",
-			},
+			"status":  "onion pending",
 		},
 		{
 			"level":   "warn",
@@ -235,7 +219,7 @@ func parseMessages(t *testing.T, file string) []map[string]interface{} {
 		}
 
 		// remove duration field because it's unpredictable so we can't assert on it
-		delete(msg, "duration")
+		delete(msg, elapsedTimeField)
 
 		messages = append(messages, msg)
 	}


### PR DESCRIPTION
* Don't auto-mask secrets that are < 5 characters long, hoping this will reduce some of our spurious redactions in GHA logs
* Reduce the width of sync status reporting messages by removing one level of context nesting