### PR TITLE
DDO-2476 Propagate git refs from Sherlock into ArgoCD when services are synced

### DIFF
--- a/internal/thelma/cli/commands/argocd/sync/sync_command.go
+++ b/internal/thelma/cli/commands/argocd/sync/sync_command.go
@@ -55,6 +55,11 @@ func (cmd *syncCommand) Run(app app.ThelmaApp, rc cli.RunContext) error {
 		return err
 	}
 
+	// workaround for DDO-2476
+	// okay so, ideally we would have per-environment level-1 generators for every single environment
+	// here is the thing.
+	// we want to be able to sync JUST THE SPECIFIC ARGO app.
+	//
 	_sync, err := app.Ops().Sync()
 	if err != nil {
 		return err

--- a/internal/thelma/cli/commands/argocd/sync/sync_command.go
+++ b/internal/thelma/cli/commands/argocd/sync/sync_command.go
@@ -55,11 +55,6 @@ func (cmd *syncCommand) Run(app app.ThelmaApp, rc cli.RunContext) error {
 		return err
 	}
 
-	// workaround for DDO-2476
-	// okay so, ideally we would have per-environment level-1 generators for every single environment
-	// here is the thing.
-	// we want to be able to sync JUST THE SPECIFIC ARGO app.
-	//
 	_sync, err := app.Ops().Sync()
 	if err != nil {
 		return err

--- a/internal/thelma/clients/vault/masking_round_tripper_test.go
+++ b/internal/thelma/clients/vault/masking_round_tripper_test.go
@@ -18,6 +18,7 @@ func Test_MaskingRoundTripper(t *testing.T) {
 			"field2":     "mask-me-2",
 			"project_id": "should-not-be-masked-1",
 			"user":       "should-not-be-masked-2",
+			"too-short":  "abcd", // should not be masked
 		},
 	)
 

--- a/internal/thelma/ops/status/event_matcher.go
+++ b/internal/thelma/ops/status/event_matcher.go
@@ -1,0 +1,117 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"github.com/rs/zerolog/log"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+type eventMatcher struct {
+	events    []corev1.Event
+	namespace string
+	apiClient kubernetes.Interface
+}
+
+func newEventMatcher(apiClient kubernetes.Interface, namespace string) (*eventMatcher, error) {
+	events, err := apiClient.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &eventMatcher{
+		events:    events.Items,
+		namespace: namespace,
+		apiClient: apiClient,
+	}, nil
+}
+
+// annotateResource with any matching events
+func (e *eventMatcher) annotateResourceWithMatchingEvents(resource *Resource) error {
+	if resource.Namespace != e.namespace {
+		panic(fmt.Errorf("resource namespace %s does not match event cache namespace %s", resource.Namespace, e.namespace))
+	}
+
+	var podSelector *metav1.LabelSelector
+	var resourceUID types.UID
+
+	if resource.Kind == "Deployment" {
+		deployment, err := e.apiClient.AppsV1().Deployments(resource.Namespace).Get(context.Background(), resource.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		podSelector = deployment.Spec.Selector
+		resourceUID = deployment.UID
+	} else if resource.Kind == "Statefulset" {
+		sts, err := e.apiClient.AppsV1().StatefulSets(resource.Namespace).Get(context.Background(), resource.Namespace, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		podSelector = sts.Spec.Selector
+		resourceUID = sts.UID
+	} else {
+		// not sure how to select pods in whatever type of this resource this is, so don't try
+		return nil
+	}
+
+	selectorMap, err := metav1.LabelSelectorAsMap(podSelector)
+	if err != nil {
+		return err
+	}
+
+	selectorString := labels.SelectorFromSet(selectorMap).String()
+
+	podList, err := e.apiClient.CoreV1().Pods(resource.Namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: selectorString,
+	})
+	if err != nil {
+		return err
+	}
+	log.Debug().Msgf("Found %d pods in %s %s", len(podList.Items), resource.Kind, resource.Name)
+
+	var matchingEvents []corev1.Event
+	matchingEvents = append(matchingEvents, e.eventsMatchingUID(resourceUID)...)
+	matchingEvents = append(matchingEvents, e.eventsForPods(podList.Items)...)
+
+	var events []Event
+	for _, k8sEvent := range matchingEvents {
+		events = append(events, toEventView(k8sEvent))
+	}
+	resource.Events = events
+	return nil
+}
+
+func (e *eventMatcher) eventsForPods(pods []corev1.Pod) []corev1.Event {
+	var podEvents []corev1.Event
+	for _, pod := range pods {
+		matches := e.eventsMatchingUID(pod.UID)
+		podEvents = append(podEvents, matches...)
+	}
+	return podEvents
+}
+
+func (e *eventMatcher) eventsMatchingUID(uid types.UID) []corev1.Event {
+	var matches []corev1.Event
+
+	for _, event := range e.events {
+		if event.InvolvedObject.UID == uid {
+			matches = append(matches, event)
+		}
+	}
+	return matches
+}
+
+func toEventView(event corev1.Event) Event {
+	return Event{
+		Count:          event.Count,
+		Message:        event.Message,
+		Node:           event.Source.Host,
+		FirstTimestamp: event.FirstTimestamp.Time,
+		LastTimestamp:  event.LastTimestamp.Time,
+		Type:           event.Type,
+	}
+}

--- a/internal/thelma/ops/status/reporter.go
+++ b/internal/thelma/ops/status/reporter.go
@@ -1,0 +1,121 @@
+package status
+
+import (
+	"fmt"
+	k8sclients "github.com/broadinstitute/thelma/internal/thelma/clients/kubernetes"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	argocdnames "github.com/broadinstitute/thelma/internal/thelma/state/api/terra/argocd"
+	"github.com/broadinstitute/thelma/internal/thelma/tools/argocd"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
+	"github.com/rs/zerolog/log"
+	"sync"
+)
+
+type Reporter interface {
+	Status(release terra.Release) (Status, error)
+	Statuses(releases []terra.Release) (map[terra.Release]Status, error)
+}
+
+func NewReporter(argocd argocd.ArgoCD, kubeclients k8sclients.Clients) Reporter {
+	return &reporter{
+		argocd:      argocd,
+		kubeclients: kubeclients,
+	}
+}
+
+type reporter struct {
+	argocd      argocd.ArgoCD
+	kubeclients k8sclients.Clients
+}
+
+func (r *reporter) Status(release terra.Release) (Status, error) {
+	appStatus, err := r.argocd.AppStatus(argocdnames.ApplicationName(release))
+	if err != nil {
+		return errStatus(err)
+	}
+
+	status := Status{
+		Health:             &appStatus.Health.Status,
+		Sync:               &appStatus.Sync.Status,
+		UnhealthyResources: r.buildUnhealthyResourceList(appStatus, release),
+	}
+
+	return status, nil
+}
+
+func (r *reporter) Statuses(releases []terra.Release) (map[terra.Release]Status, error) {
+	statuses := make(map[terra.Release]Status)
+	var mutex sync.Mutex
+
+	var jobs []pool.Job
+
+	for _, unsafe := range releases {
+		release := unsafe // copy invariant to tmp variable
+
+		jobs = append(jobs, pool.Job{
+			Name: release.FullName(),
+			Run: func(_ pool.StatusReporter) error {
+				status, err := r.Status(release)
+				if err != nil {
+					return fmt.Errorf("error generating status report for %s: %v", release.Name(), err)
+				}
+				mutex.Lock()
+				statuses[release] = status
+				mutex.Unlock()
+				return nil
+			},
+		})
+	}
+
+	_pool := pool.New(jobs, func(options *pool.Options) {
+		options.NumWorkers = 10
+		options.Summarizer.WorkDescription = "services checked"
+	})
+	err := _pool.Execute()
+	if err != nil {
+		return nil, err
+	}
+	return statuses, nil
+}
+
+func (r *reporter) buildUnhealthyResourceList(appStatus argocd.ApplicationStatus, release terra.Release) []Resource {
+	var unhealthyResources []Resource
+
+	for _, argoResource := range appStatus.Resources {
+		if argoResource.Health == nil || argoResource.Health.Status == argocd.Healthy {
+			continue
+		}
+		unhealthyResources = append(unhealthyResources, Resource{Resource: argoResource})
+	}
+
+	_eventMatcher, err := r.buildEventMatcher(release)
+	if err != nil {
+		log.Warn().Err(err).Msgf("failed to load events from Kubernetes API for %s; disabling rich status reports", release.FullName())
+		return unhealthyResources
+	}
+
+	for i, resource := range unhealthyResources {
+		if err := _eventMatcher.annotateResourceWithMatchingEvents(&resource); err != nil {
+			log.Warn().Err(err).Msgf("failed to load events for %s from Kubernetes API in %s", resource.Name, release.FullName())
+			continue
+		}
+		unhealthyResources[i] = resource
+	}
+
+	return unhealthyResources
+}
+
+func (r *reporter) buildEventMatcher(release terra.Release) (*eventMatcher, error) {
+	apiClient, err := r.kubeclients.ForRelease(release)
+	if err != nil {
+		return nil, err
+	}
+	return newEventMatcher(apiClient, release.Namespace())
+}
+
+// indicates an error was encountered while retrieving the status
+func errStatus(err error) (Status, error) {
+	return Status{
+		Error: err.Error(),
+	}, err
+}

--- a/internal/thelma/ops/status/status.go
+++ b/internal/thelma/ops/status/status.go
@@ -1,27 +1,16 @@
 package status
 
 import (
-	"context"
 	"fmt"
-	k8sclients "github.com/broadinstitute/thelma/internal/thelma/clients/kubernetes"
-	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
-	argocdnames "github.com/broadinstitute/thelma/internal/thelma/state/api/terra/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/tools/argocd"
-	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
-	"github.com/rs/zerolog/log"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
-	"sync"
 	"time"
 )
 
 type Status struct {
-	Health             *argocd.HealthStatus
-	Sync               *argocd.SyncStatus
-	Error              error      `yaml:",omitempty"`
-	UnhealthyResources []Resource `yaml:"resources,omitempty"`
+	Health             *argocd.HealthStatus `yaml:",omitempty"`
+	Sync               *argocd.SyncStatus   `yaml:",omitempty"`
+	Error              string               `yaml:",omitempty"`
+	UnhealthyResources []Resource           `yaml:"resources,omitempty"`
 }
 
 func (s Status) IsHealthy() bool {
@@ -45,108 +34,8 @@ type Event struct {
 	Type           string
 }
 
-type Reporter interface {
-	Status(release terra.Release) (Status, error)
-	Statuses(releases []terra.Release) (map[terra.Release]Status, error)
-}
-
-func NewReporter(argocd argocd.ArgoCD, kubeclients k8sclients.Clients) Reporter {
-	return &reporter{
-		argocd:      argocd,
-		kubeclients: kubeclients,
-	}
-}
-
-type reporter struct {
-	argocd      argocd.ArgoCD
-	kubeclients k8sclients.Clients
-}
-
-func (r *reporter) Status(release terra.Release) (Status, error) {
-	appStatus, err := r.argocd.AppStatus(argocdnames.ApplicationName(release))
-	if err != nil {
-		return errStatus(err)
-	}
-
-	healthy := appStatus.Health.Status == argocd.Healthy
-
-	var unhealthyResources []Resource
-
-	if !healthy {
-		apiClient, err := r.kubeclients.ForRelease(release)
-		if err != nil {
-			return errStatus(err)
-		}
-		eventList, err := apiClient.CoreV1().Events(release.Namespace()).List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			return errStatus(err)
-		}
-
-		for _, argoResource := range appStatus.Resources {
-			if argoResource.Health.Status != argocd.Healthy {
-				resource := Resource{Resource: argoResource}
-				if argoResource.Health.Status != argocd.Missing {
-					var podSelector *metav1.LabelSelector
-					var resourceUID types.UID
-
-					if argoResource.Kind == "Deployment" {
-						deployment, err := apiClient.AppsV1().Deployments(release.Namespace()).Get(context.Background(), argoResource.Name, metav1.GetOptions{})
-						if err != nil {
-							return errStatus(err)
-						}
-						podSelector = deployment.Spec.Selector
-						resourceUID = deployment.UID
-					} else if argoResource.Kind == "Statefulset" {
-						sts, err := apiClient.AppsV1().StatefulSets(release.Namespace()).Get(context.Background(), argoResource.Namespace, metav1.GetOptions{})
-						if err != nil {
-							return errStatus(err)
-						}
-						podSelector = sts.Spec.Selector
-						resourceUID = sts.UID
-					} else {
-						// not sure how to select pods in whatever type of this resource this is, so don't try
-						continue
-					}
-
-					selectorMap, err := metav1.LabelSelectorAsMap(podSelector)
-					if err != nil {
-						return errStatus(err)
-					}
-
-					selectorString := labels.SelectorFromSet(selectorMap).String()
-
-					podList, err := apiClient.CoreV1().Pods(release.Namespace()).List(context.Background(), metav1.ListOptions{
-						LabelSelector: selectorString,
-					})
-					if err != nil {
-						return Status{}, err
-					}
-					log.Debug().Msgf("Found %d pods in %s %s", len(podList.Items), argoResource.Kind, argoResource.Name)
-
-					var matchingEvents []corev1.Event
-					matchingEvents = append(matchingEvents, r.eventsMatchingUID(eventList.Items, resourceUID)...)
-					matchingEvents = append(matchingEvents, r.eventsForPods(eventList.Items, podList.Items)...)
-
-					var events []Event
-					for _, k8sEvent := range matchingEvents {
-						events = append(events, toEventView(k8sEvent))
-					}
-					resource.Events = events
-				}
-				unhealthyResources = append(unhealthyResources, resource)
-			}
-		}
-	}
-
-	return Status{
-		Health:             &appStatus.Health.Status,
-		Sync:               &appStatus.Sync.Status,
-		UnhealthyResources: unhealthyResources,
-	}, nil
-}
-
 func (s *Status) Headline() string {
-	if s.Error != nil {
+	if s.Error != "" {
 		return fmt.Sprintf("error: %v", s.Error)
 	}
 	if s.Health == nil {
@@ -171,77 +60,4 @@ func (s *Status) Headline() string {
 		}
 	}
 	return fmt.Sprintf("%s: %s: %s", s.Health.String(), resource.Name, mostRecentEvent.Message)
-}
-
-func (r *reporter) Statuses(releases []terra.Release) (map[terra.Release]Status, error) {
-	statuses := make(map[terra.Release]Status)
-	var mutex sync.Mutex
-
-	var jobs []pool.Job
-
-	for _, unsafe := range releases {
-		release := unsafe // copy invariant to tmp variable
-
-		jobs = append(jobs, pool.Job{
-			Name: release.FullName(),
-			Run: func(_ pool.StatusReporter) error {
-				status, err := r.Status(release)
-				if err != nil {
-					return fmt.Errorf("error generating status report for %s: %v", release.Name(), err)
-				}
-				mutex.Lock()
-				statuses[release] = status
-				mutex.Unlock()
-				return nil
-			},
-		})
-	}
-
-	_pool := pool.New(jobs, func(options *pool.Options) {
-		options.NumWorkers = 10
-		options.Summarizer.WorkDescription = "services checked"
-	})
-	err := _pool.Execute()
-	if err != nil {
-		return nil, err
-	}
-	return statuses, nil
-}
-
-func (r *reporter) eventsForPods(events []corev1.Event, pods []corev1.Pod) []corev1.Event {
-	var podEvents []corev1.Event
-	for _, pod := range pods {
-		matches := r.eventsMatchingUID(events, pod.UID)
-		podEvents = append(podEvents, matches...)
-	}
-	return podEvents
-}
-
-func (r *reporter) eventsMatchingUID(events []corev1.Event, uid types.UID) []corev1.Event {
-	var matches []corev1.Event
-
-	for _, event := range events {
-		if event.InvolvedObject.UID == uid {
-			matches = append(matches, event)
-		}
-	}
-	return matches
-}
-
-func toEventView(event corev1.Event) Event {
-	return Event{
-		Count:          event.Count,
-		Message:        event.Message,
-		Node:           event.Source.Host,
-		FirstTimestamp: event.FirstTimestamp.Time,
-		LastTimestamp:  event.LastTimestamp.Time,
-		Type:           event.Type,
-	}
-}
-
-// indicates an error was encountered while retrieving the status
-func errStatus(err error) (Status, error) {
-	return Status{
-		Error: err,
-	}, err
 }

--- a/internal/thelma/ops/sync/sync.go
+++ b/internal/thelma/ops/sync/sync.go
@@ -95,6 +95,9 @@ func (s *syncer) waitHealthy(release terra.Release, maxWait time.Duration, statu
 		return
 	}
 	updateStatus(lastStatus, statusReporter)
+	if lastStatus.IsHealthy() {
+		return
+	}
 
 	if maxWait == 0 {
 		log.Debug().Msgf("Not waiting for %s to be healthy", release.FullName())

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -567,7 +567,7 @@ func (a *argocd) diffWithRetries(appName string, opts SyncOptions) (hasDifferenc
 		log.Warn().Str("app", appName).Int("count", i).Err(err).Msgf("attempt %d to diff %s returned error: %v", i, appName, err)
 
 		if i < a.cfg.DiffRetries {
-			log.Warn().Str("app", appName).Int("count", i).Msgf("Will retry in %d seconds", a.cfg.DiffRetryInterval)
+			log.Warn().Str("app", appName).Int("count", i).Msgf("Will retry in %s", a.cfg.DiffRetryInterval)
 			time.Sleep(a.cfg.DiffRetryInterval)
 		}
 	}

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
-	url "net/url"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -180,6 +180,11 @@ func BrowserLogin(thelmaConfig config.Config, shellRunner shell.Runner, iapToken
 
 // New return a new ArgoCD client
 func New(thelmaConfig config.Config, shellRunner shell.Runner, iapToken string, vaultClient *vaultapi.Client) (ArgoCD, error) {
+	return newArgocd(thelmaConfig, shellRunner, iapToken, vaultClient)
+}
+
+// private constructor used in tests
+func newArgocd(thelmaConfig config.Config, shellRunner shell.Runner, iapToken string, vaultClient *vaultapi.Client) (*argocd, error) {
 	a, err := newUnauthenticated(thelmaConfig, shellRunner, iapToken)
 	if err != nil {
 		return nil, err
@@ -288,6 +293,9 @@ func (a *argocd) SyncRelease(release terra.Release, options ...SyncOption) error
 	// Sync the legacy configs app, if one exists
 	legacyConfigsWereSynced := false
 	if hasLegacyConfigsApp {
+		if err := a.setRef(legacyConfigsApp, release.FirecloudDevelopRef()); err != nil {
+			return err
+		}
 		syncResult, err := a.SyncApp(legacyConfigsApp, options...)
 		if err != nil {
 			return err
@@ -300,6 +308,9 @@ func (a *argocd) SyncRelease(release terra.Release, options ...SyncOption) error
 		options.WaitHealthy = false
 	})
 
+	if err := a.setRef(primaryApp, release.TerraHelmfileRef()); err != nil {
+		return err
+	}
 	if _, err := a.SyncApp(primaryApp, optionsNoWaitHealthy...); err != nil {
 		return err
 	}
@@ -336,6 +347,14 @@ func (a *argocd) SyncRelease(release terra.Release, options ...SyncOption) error
 func (a *argocd) HardRefresh(appName string) error {
 	_, err := a.diffWithRetries(appName, a.DefaultSyncOptions())
 	return err
+}
+
+func (a *argocd) AppStatus(appName string) (ApplicationStatus, error) {
+	app, err := a.getApplication(appName)
+	if err != nil {
+		return ApplicationStatus{}, err
+	}
+	return app.Status, nil
 }
 
 func (a *argocd) waitHealthy(appName string, timeoutSeconds int) error {
@@ -605,6 +624,34 @@ func (a *argocd) ensureLoggedIn() error {
 func (a *argocd) browserLogin() error {
 	log.Info().Msgf("Launching browser to authenticate Thelma to ArgoCD")
 	return a.runCommand([]string{"login", "--sso", a.cfg.Host})
+}
+
+// run `argocd app set <app-name> --revision=<ref>` to set an Argo app's git ref
+func (a *argocd) setRef(appName string, ref string) error {
+	err := a.runCommand([]string{"app", "set", appName, "--revision", ref})
+	if err != nil {
+		return fmt.Errorf("error setting %s to revision %q: %v", appName, ref, err)
+	}
+	return nil
+}
+
+// run `argocd app get <app-name>` to retrive an ArgoCD application's YAML definition
+func (a *argocd) getApplication(appName string) (application, error) {
+	var app application
+
+	buf := bytes.Buffer{}
+	err := a.runCommand([]string{"app", "get", appName, "-o", "yaml"}, func(options *shell.RunOptions) {
+		options.Stdout = &buf
+	})
+	if err != nil {
+		return app, err
+	}
+
+	if err = yaml.Unmarshal(buf.Bytes(), &app); err != nil {
+		return app, fmt.Errorf("error unmarshalling argo app %s: %v", appName, err)
+	}
+
+	return app, nil
 }
 
 func (a *argocd) runCommandAndParseYamlOutput(args []string, out interface{}) error {

--- a/internal/thelma/tools/argocd/status.go
+++ b/internal/thelma/tools/argocd/status.go
@@ -118,7 +118,7 @@ type Resource struct {
 	Version   string
 	Namespace string
 	Status    SyncStatus
-	Health    struct {
+	Health    *struct {
 		Status  HealthStatus `yaml:",omitempty"`
 		Message string       `yaml:",omitempty"`
 	} `yaml:",omitempty"`

--- a/internal/thelma/tools/argocd/status_test.go
+++ b/internal/thelma/tools/argocd/status_test.go
@@ -4,10 +4,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	"os"
 	"testing"
 )
 
-func Test_Marshallers(t *testing.T) {
+func Test_AppUnmarshalling(t *testing.T) {
+	content, err := os.ReadFile("testdata/application.yaml")
+	require.NoError(t, err)
+
+	var app application
+	err = yaml.Unmarshal(content, &app)
+	require.NoError(t, err)
+
+	assert.Equal(t, "HEAD", app.Spec.Source.TargetRevision)
+
+	assert.Equal(t, Degraded, app.Status.Health.Status)
+	assert.Equal(t, 18, len(app.Status.Resources))
+
+	var deployment Resource
+	for _, r := range app.Status.Resources {
+		if r.Name == "workspacemanager-deployment" {
+			deployment = r
+			break
+		}
+	}
+
+	assert.Equal(t, "apps", deployment.Group)
+	assert.Equal(t, "Deployment", deployment.Kind)
+	assert.Equal(t, "v1", deployment.Version)
+	assert.Equal(t, "workspacemanager-deployment", deployment.Name)
+	assert.Equal(t, "terra-staging", deployment.Namespace)
+	assert.Equal(t, OutOfSync, deployment.Status)
+	assert.Equal(t, Degraded, deployment.Health.Status)
+	assert.Equal(t, `Deployment "workspacemanager-deployment" exceeded its progress deadline`, deployment.Health.Message)
+
+	assert.Equal(t, OutOfSync, app.Status.Sync.Status)
+}
+
+func Test_EnumMarshallers(t *testing.T) {
 	out, err := yaml.Marshal(Healthy)
 	require.NoError(t, err)
 	assert.Equal(t, "Healthy\n", string(out))
@@ -25,5 +59,4 @@ func Test_Marshallers(t *testing.T) {
 	err = yaml.Unmarshal(out, &syncstatus)
 	require.NoError(t, err)
 	assert.Equal(t, OutOfSync, syncstatus)
-
 }

--- a/internal/thelma/tools/argocd/testdata/application.yaml
+++ b/internal/thelma/tools/argocd/testdata/application.yaml
@@ -1,0 +1,649 @@
+# Sample argocd application yaml to test our serializers
+# Pulled from ArgoCD using `argocd app get <name> -o yaml`
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"argoproj.io/v1alpha1","kind":"Application","metadata":{"annotations":{},"finalizers":["resources-finalizer.argocd.argoproj.io"],"labels":{"app":"workspacemanager","argocd.argoproj.io/instance":"terra-staging-generator","cluster":"terra-qa-bees","env":"staging","has-legacy-configs":"false","jenkins-sync-enabled":"true","release":"workspacemanager","type":"app"},"name":"workspacemanager-staging","namespace":"ap-argocd"},"spec":{"destination":{"namespace":"terra-staging","server":"https://35.224.67.121"},"project":"terra-staging","source":{"path":".","plugin":{"env":[{"name":"TERRA_ENV","value":"staging"},{"name":"TERRA_RELEASE","value":"workspacemanager"},{"name":"THELMA_RENDER_MODE","value":""}],"name":"terra-helmfile-app"},"repoURL":"https://github.com/broadinstitute/terra-helmfile","targetRevision":"HEAD"}}}
+  creationTimestamp: "2022-06-06T22:06:32Z"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  generation: 49259
+  labels:
+    app: workspacemanager
+    argocd.argoproj.io/instance: terra-staging-generator
+    cluster: terra-qa-bees
+    env: staging
+    has-legacy-configs: "false"
+    jenkins-sync-enabled: "true"
+    release: workspacemanager
+    type: app
+  managedFields:
+  - apiVersion: argoproj.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:summary: {}
+    manager: argocd-server
+    operation: Update
+    time: "2022-08-11T20:59:59Z"
+  - apiVersion: argoproj.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+        f:finalizers:
+          .: {}
+          v:"resources-finalizer.argocd.argoproj.io": {}
+        f:labels:
+          .: {}
+          f:app: {}
+          f:argocd.argoproj.io/instance: {}
+          f:cluster: {}
+          f:env: {}
+          f:has-legacy-configs: {}
+          f:jenkins-sync-enabled: {}
+          f:release: {}
+          f:type: {}
+      f:spec:
+        .: {}
+        f:destination:
+          .: {}
+          f:namespace: {}
+          f:server: {}
+        f:project: {}
+        f:source:
+          .: {}
+          f:path: {}
+          f:plugin:
+            .: {}
+            f:env: {}
+            f:name: {}
+          f:repoURL: {}
+          f:targetRevision: {}
+      f:status:
+        .: {}
+        f:health:
+          .: {}
+          f:status: {}
+        f:history: {}
+        f:operationState:
+          .: {}
+          f:finishedAt: {}
+          f:message: {}
+          f:operation:
+            .: {}
+            f:initiatedBy:
+              .: {}
+              f:username: {}
+            f:retry: {}
+            f:sync:
+              .: {}
+              f:revision: {}
+              f:syncOptions: {}
+              f:syncStrategy:
+                .: {}
+                f:hook: {}
+          f:phase: {}
+          f:startedAt: {}
+          f:syncResult:
+            .: {}
+            f:resources: {}
+            f:revision: {}
+            f:source:
+              .: {}
+              f:path: {}
+              f:plugin:
+                .: {}
+                f:env: {}
+                f:name: {}
+              f:repoURL: {}
+              f:targetRevision: {}
+        f:reconciledAt: {}
+        f:resources: {}
+        f:sourceType: {}
+        f:summary:
+          f:images: {}
+        f:sync:
+          .: {}
+          f:comparedTo:
+            .: {}
+            f:destination:
+              .: {}
+              f:namespace: {}
+              f:server: {}
+            f:source:
+              .: {}
+              f:path: {}
+              f:plugin:
+                .: {}
+                f:env: {}
+                f:name: {}
+              f:repoURL: {}
+              f:targetRevision: {}
+          f:revision: {}
+          f:status: {}
+    manager: argocd-application-controller
+    operation: Update
+    time: "2022-11-21T18:45:41Z"
+  name: workspacemanager-staging
+  namespace: ap-argocd
+  resourceVersion: "719759516"
+  uid: 6c2ded23-9f24-4e92-b9dd-71aceea52606
+spec:
+  destination:
+    namespace: terra-staging
+    server: https://35.224.67.121
+  project: terra-staging
+  source:
+    path: .
+    plugin:
+      env:
+      - name: TERRA_ENV
+        value: staging
+      - name: TERRA_RELEASE
+        value: workspacemanager
+      - name: THELMA_RENDER_MODE
+        value: ""
+      name: terra-helmfile-app
+    repoURL: https://github.com/broadinstitute/terra-helmfile
+    targetRevision: HEAD
+status:
+  health:
+    status: Degraded
+  history:
+  - deployStartedAt: "2022-06-06T22:06:50Z"
+    deployedAt: "2022-06-06T22:07:03Z"
+    id: 0
+    revision: 002f616e2d6385f466ebb7511faccd50fd8b598e
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: master
+  - deployStartedAt: "2022-06-10T17:27:39Z"
+    deployedAt: "2022-06-10T17:28:10Z"
+    id: 1
+    revision: cb03659bc713c2f678ced4b620b5902c520d5627
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: HEAD
+  - deployStartedAt: "2022-06-10T22:20:19Z"
+    deployedAt: "2022-06-10T22:20:44Z"
+    id: 2
+    revision: cea64210e84941e5dc8112927cbbd19fa187acc6
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: HEAD
+  - deployStartedAt: "2022-06-13T17:52:32Z"
+    deployedAt: "2022-06-13T17:52:35Z"
+    id: 3
+    revision: 05869a3f9f0380a535796f1527eb8275256aded4
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: master
+  - deployStartedAt: "2022-06-13T21:30:39Z"
+    deployedAt: "2022-06-13T21:30:42Z"
+    id: 4
+    revision: 7508604b200991654539e736e62e547b0dbb8a4f
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: master
+  - deployStartedAt: "2022-06-24T18:11:52Z"
+    deployedAt: "2022-06-24T18:11:55Z"
+    id: 5
+    revision: 00a5a6e0a3882949f295d571f32a8813ee5886ab
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: master
+  - deployStartedAt: "2022-07-06T20:23:49Z"
+    deployedAt: "2022-07-06T20:24:13Z"
+    id: 6
+    revision: f128018432d33025256909423dbc0853e0ea03dd
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: HEAD
+  - deployStartedAt: "2022-07-06T21:00:17Z"
+    deployedAt: "2022-07-06T21:00:42Z"
+    id: 7
+    revision: 4c6b214eb77642e0dad34e2402ab11e23092b465
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: HEAD
+  - deployStartedAt: "2022-08-11T20:59:59Z"
+    deployedAt: "2022-08-11T21:00:02Z"
+    id: 8
+    revision: 7465e91b9516c2af5020e117f5cb2908965cfc3a
+    source:
+      path: .
+      plugin:
+        env:
+        - name: TERRA_ENV
+          value: staging
+        - name: TERRA_RELEASE
+          value: workspacemanager
+        - name: THELMA_RENDER_MODE
+          value: ""
+        name: terra-helmfile-app
+      repoURL: https://github.com/broadinstitute/terra-helmfile
+      targetRevision: HEAD
+  operationState:
+    finishedAt: "2022-08-11T21:00:02Z"
+    message: successfully synced (all tasks run)
+    operation:
+      initiatedBy:
+        username: sergiy.getlin@gmail.com
+      retry: {}
+      sync:
+        revision: 7465e91b9516c2af5020e117f5cb2908965cfc3a
+        syncOptions:
+        - CreateNamespace=true
+        syncStrategy:
+          hook: {}
+    phase: Succeeded
+    startedAt: "2022-08-11T20:59:59Z"
+    syncResult:
+      resources:
+      - group: ""
+        hookPhase: Succeeded
+        kind: ServiceAccount
+        message: serviceaccount/workspacemanager-service-sa configured
+        name: workspacemanager-service-sa
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: ""
+        hookPhase: Succeeded
+        kind: Secret
+        message: secret/workspacemanager-db-creds configured
+        name: workspacemanager-db-creds
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: ""
+        hookPhase: Succeeded
+        kind: ConfigMap
+        message: configmap/workspacemanager-postgres-initdb configured
+        name: workspacemanager-postgres-initdb
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: rbac.authorization.k8s.io
+        hookPhase: Succeeded
+        kind: Role
+        message: role.rbac.authorization.k8s.io/workspacemanager-service-role reconciled.
+          role.rbac.authorization.k8s.io/workspacemanager-service-role configured
+        name: workspacemanager-service-role
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: rbac.authorization.k8s.io
+        hookPhase: Succeeded
+        kind: RoleBinding
+        message: rolebinding.rbac.authorization.k8s.io/workspacemanager-service-role-binding
+          reconciled. rolebinding.rbac.authorization.k8s.io/workspacemanager-service-role-binding
+          configured
+        name: workspacemanager-service-role-binding
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: ""
+        hookPhase: Succeeded
+        kind: Service
+        message: service/workspacemanager-postgres-service unchanged
+        name: workspacemanager-postgres-service
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: apps
+        hookPhase: Succeeded
+        kind: StatefulSet
+        message: 'partitioned roll out complete: 1 new pods have been updated...'
+        name: workspacemanager-postgres
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: policy
+        hookPhase: Running
+        kind: PodDisruptionBudget
+        message: poddisruptionbudget.policy/workspacemanager-pdb unchanged
+        name: workspacemanager-pdb
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1beta1
+      - group: ""
+        hookPhase: Running
+        kind: ConfigMap
+        message: configmap/workspacemanager-oauth2-configmap configured
+        name: workspacemanager-oauth2-configmap
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: ""
+        hookPhase: Running
+        kind: ConfigMap
+        message: configmap/workspacemanager-prometheus-configmap configured
+        name: workspacemanager-prometheus-configmap
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: ""
+        hookPhase: Running
+        kind: ConfigMap
+        message: configmap/workspacemanager-proxy-configmap configured
+        name: workspacemanager-proxy-configmap
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: ""
+        hookPhase: Running
+        kind: Service
+        message: service/workspacemanager-service configured
+        name: workspacemanager-service
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: apps
+        hookPhase: Running
+        kind: Deployment
+        message: deployment.apps/workspacemanager-deployment configured
+        name: workspacemanager-deployment
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: secrets-manager.tuenti.io
+        hookPhase: Running
+        kind: SecretDefinition
+        message: secretdefinition.secrets-manager.tuenti.io/workspacemanager-app-sa
+          configured
+        name: workspacemanager-app-sa
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1alpha1
+      - group: secrets-manager.tuenti.io
+        hookPhase: Running
+        kind: SecretDefinition
+        message: secretdefinition.secrets-manager.tuenti.io/secretdefinition-wsm-azure-managed-app-creds
+          created
+        name: secretdefinition-wsm-azure-managed-app-creds
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1alpha1
+      - group: cloud.google.com
+        hookPhase: Running
+        kind: BackendConfig
+        message: backendconfig.cloud.google.com/workspacemanager-ingress-backendconfig
+          configured
+        name: workspacemanager-ingress-backendconfig
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: monitoring.coreos.com
+        hookPhase: Running
+        kind: PodMonitor
+        message: podmonitor.monitoring.coreos.com/workspacemanager-jvm-monitor configured
+        name: workspacemanager-jvm-monitor
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1
+      - group: secrets-manager.tuenti.io
+        hookPhase: Running
+        kind: SecretDefinition
+        message: secretdefinition.secrets-manager.tuenti.io/workspacemanager-proxy-b2c-secrets
+          created
+        name: workspacemanager-proxy-b2c-secrets
+        namespace: terra-staging
+        status: Synced
+        syncPhase: Sync
+        version: v1alpha1
+      revision: 7465e91b9516c2af5020e117f5cb2908965cfc3a
+      source:
+        path: .
+        plugin:
+          env:
+          - name: TERRA_ENV
+            value: staging
+          - name: TERRA_RELEASE
+            value: workspacemanager
+          - name: THELMA_RENDER_MODE
+            value: ""
+          name: terra-helmfile-app
+        repoURL: https://github.com/broadinstitute/terra-helmfile
+        targetRevision: HEAD
+  reconciledAt: "2022-11-21T19:13:03Z"
+  resources:
+  - kind: ConfigMap
+    name: workspacemanager-oauth2-configmap
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - kind: ConfigMap
+    name: workspacemanager-postgres-initdb
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - kind: ConfigMap
+    name: workspacemanager-prometheus-configmap
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - kind: ConfigMap
+    name: workspacemanager-proxy-configmap
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - kind: Secret
+    name: workspacemanager-db-creds
+    namespace: terra-staging
+    status: Synced
+    version: v1
+  - health:
+      status: Healthy
+    kind: Service
+    name: workspacemanager-postgres-service
+    namespace: terra-staging
+    status: Synced
+    version: v1
+  - health:
+      status: Healthy
+    kind: Service
+    name: workspacemanager-service
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - kind: ServiceAccount
+    name: workspacemanager-service-sa
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - group: apps
+    health:
+      message: Deployment "workspacemanager-deployment" exceeded its progress deadline
+      status: Degraded
+    kind: Deployment
+    name: workspacemanager-deployment
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - group: apps
+    health:
+      message: 'partitioned roll out complete: 1 new pods have been updated...'
+      status: Healthy
+    kind: StatefulSet
+    name: workspacemanager-postgres
+    namespace: terra-staging
+    status: Synced
+    version: v1
+  - group: cloud.google.com
+    kind: BackendConfig
+    name: workspacemanager-ingress-backendconfig
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - group: monitoring.coreos.com
+    kind: PodMonitor
+    name: workspacemanager-jvm-monitor
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - group: policy
+    health:
+      status: Missing
+    kind: PodDisruptionBudget
+    name: workspacemanager-pdb
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1beta1
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: workspacemanager-service-role
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: workspacemanager-service-role-binding
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1
+  - group: secrets-manager.tuenti.io
+    kind: SecretDefinition
+    name: secretdefinition-wsm-azure-managed-app-creds
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1alpha1
+  - group: secrets-manager.tuenti.io
+    kind: SecretDefinition
+    name: workspacemanager-app-sa
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1alpha1
+  - group: secrets-manager.tuenti.io
+    kind: SecretDefinition
+    name: workspacemanager-proxy-b2c-secrets
+    namespace: terra-staging
+    status: OutOfSync
+    version: v1alpha1
+  sourceType: Plugin
+  summary:
+    images:
+    - alpine:3.12.0
+    - gcr.io/terra-kernel-k8s/terra-workspace-manager:0.254.343
+    - postgres:9.6
+    - us.gcr.io/broad-dsp-gcr-public/openidc-terra-proxy:v0.1.12
+  sync:
+    comparedTo:
+      destination:
+        namespace: terra-staging
+        server: https://35.224.67.121
+      source:
+        path: .
+        plugin:
+          env:
+          - name: TERRA_ENV
+            value: staging
+          - name: TERRA_RELEASE
+            value: workspacemanager
+          - name: THELMA_RENDER_MODE
+            value: ""
+          name: terra-helmfile-app
+        repoURL: https://github.com/broadinstitute/terra-helmfile
+        targetRevision: HEAD
+    revision: 8884fcce91ef53fe01e73224f8e49f5f039f0fc9
+    status: OutOfSync

--- a/internal/thelma/utils/pool/pool.go
+++ b/internal/thelma/utils/pool/pool.go
@@ -129,23 +129,23 @@ func (p *pool) spawnWorker(id int) {
 		for {
 			select {
 			case <-p.cancelCtx.Done():
-				logger.Debug().Msg("execution cancelled, returning")
+				logger.Trace().Msg("execution cancelled, returning")
 				return
 
 			case item, ok := <-p.queue:
 				if !ok {
-					logger.Debug().Msg("queue empty, returning")
+					logger.Trace().Msg("queue empty, returning")
 					return
 				}
 
 				itemLogger := logger.With().Str("job", item.getName()).Int("id", item.getId()).Logger()
-				itemLogger.Debug().Msg("starting job")
+				itemLogger.Trace().Msg("starting job")
 				item.execute()
-				itemLogger.Debug().Dur("duration", item.duration()).Str("result", item.getPhase().String()).Err(item.getErr()).Msgf("finished job")
+				itemLogger.Trace().Dur("duration", item.duration()).Str("result", item.getPhase().String()).Err(item.getErr()).Msgf("finished job")
 
 				if item.hasErr() {
 					if p.options.StopProcessingOnError {
-						logger.Debug().Msgf("cancelling pool")
+						logger.Trace().Msgf("error encountered; cancelling pool")
 						p.cancelFn()
 						return
 					}

--- a/internal/thelma/utils/pool/summarizer.go
+++ b/internal/thelma/utils/pool/summarizer.go
@@ -7,15 +7,15 @@ import (
 	"time"
 )
 
-const elapsedTimeField = "time"
+const elapsedTimeField = "t"
 
 type SummarizerOptions struct {
 	// Enabled if true, print a periodic summary of pool status while items are being processed. For example:
 	//
 	// 2/5 items processed queued=1 running=2 success=1 error=1
-	// foo:    error   err="something bad happened" duration=2m30s
-	// bar:    running status="downloading file" duration=30s
-	// baz:    running status="uploading file" duration=1m53s
+	// foo:    error   err="something bad happened" dur=2m30s
+	// bar:    running status="downloading file" dur=30s
+	// baz:    running status="uploading file" dur=1m53s
 	// quux:   queued
 	// blergh: success status="finished transfer"
 	//

--- a/internal/thelma/utils/pool/summarizer.go
+++ b/internal/thelma/utils/pool/summarizer.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+const elapsedTimeField = "time"
+
 type SummarizerOptions struct {
 	// Enabled if true, print a periodic summary of pool status while items are being processed. For example:
 	//
@@ -133,11 +135,21 @@ func (s *summarizer) logSummary() {
 
 		event := s.log()
 
-		if item.status() != nil {
-			event.Dict("status", item.status().Dict())
+		status := item.status()
+		if status != nil {
+			if status.Message != "" {
+				event.Str("status", status.Message)
+			}
+			event.Str("status", status.Message)
+			if len(status.Context) > 0 {
+				for k, v := range status.Context {
+					event.Interface(k, v)
+				}
+			}
 		}
 		if phase != Queued {
-			event.Dur("duration", item.duration())
+			// optimizing for humans reading the logs
+			event.Str(elapsedTimeField, fmt.Sprintf("%s", item.duration().Round(time.Second)))
 		}
 		if item.hasErr() {
 			event.Err(item.getErr())

--- a/internal/thelma/utils/pool/summarizer.go
+++ b/internal/thelma/utils/pool/summarizer.go
@@ -149,7 +149,7 @@ func (s *summarizer) logSummary() {
 		}
 		if phase != Queued {
 			// optimizing for humans reading the logs
-			event.Str(elapsedTimeField, fmt.Sprintf("%s", item.duration().Round(time.Second)))
+			event.Str(elapsedTimeField, item.duration().Round(time.Second).String())
 		}
 		if item.hasErr() {
 			event.Err(item.getErr())

--- a/internal/thelma/utils/pool/summarizer_test.go
+++ b/internal/thelma/utils/pool/summarizer_test.go
@@ -120,17 +120,13 @@ func Test_Summarizer(t *testing.T) {
 		{
 			"level":   "warn",
 			"message": "carrot: running",
-			"status": map[string]interface{}{
-				"message": "rabbit gnawing",
-				"name":    "peter",
-			},
+			"status":  "rabbit gnawing",
+			"name":    "peter",
 		},
 		{
 			"level":   "warn",
 			"message": "celery: running",
-			"status": map[string]interface{}{
-				"message": "12% complete",
-			},
+			"status":  "12% complete",
 		},
 		{
 			"level":   "warn",
@@ -151,24 +147,18 @@ func Test_Summarizer(t *testing.T) {
 		{
 			"level":   "warn",
 			"message": "carrot: success",
-			"status": map[string]interface{}{
-				"message": "rabbit full",
-				"name":    "peter",
-			},
+			"status":  "rabbit full",
+			"name":    "peter",
 		},
 		{
 			"level":   "warn",
 			"message": "celery: running",
-			"status": map[string]interface{}{
-				"message": "67% complete",
-			},
+			"status":  "67% complete",
 		},
 		{
 			"level":   "warn",
 			"message": "onion:  running",
-			"status": map[string]interface{}{
-				"message": "onion pending",
-			},
+			"status":  "onion pending",
 		},
 		{
 			"level":   "warn",
@@ -185,25 +175,19 @@ func Test_Summarizer(t *testing.T) {
 		{
 			"level":   "warn",
 			"message": "carrot: success",
-			"status": map[string]interface{}{
-				"message": "rabbit full",
-				"name":    "peter",
-			},
+			"status":  "rabbit full",
+			"name":    "peter",
 		},
 		{
 			"level":   "warn",
 			"message": "celery: success",
-			"status": map[string]interface{}{
-				"message": "100% complete",
-			},
+			"status":  "100% complete",
 		},
 		{
 			"level":   "warn",
 			"message": "onion:  error",
 			"error":   "whoopsies",
-			"status": map[string]interface{}{
-				"message": "onion pending",
-			},
+			"status":  "onion pending",
 		},
 		{
 			"level":   "warn",
@@ -235,7 +219,7 @@ func parseMessages(t *testing.T, file string) []map[string]interface{} {
 		}
 
 		// remove duration field because it's unpredictable so we can't assert on it
-		delete(msg, "duration")
+		delete(msg, elapsedTimeField)
 
 		messages = append(messages, msg)
 	}

--- a/internal/thelma/utils/pool/summarizer_test.go
+++ b/internal/thelma/utils/pool/summarizer_test.go
@@ -200,7 +200,6 @@ func parseMessages(t *testing.T, file string) []map[string]interface{} {
 	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	fmt.Println(string(content))
 	var messages []map[string]interface{}
 	for _, line := range bytes.Split(content, []byte("\n")) {
 		if len(line) == 0 {


### PR DESCRIPTION
This PR updates thelma's `argocd sync` command so that Argo apps are pointed at the correct* terra-helmfile ref and firecloud-develop ref prior to syncing, using the ArgoCD cli's `argocd app set <name> --revision <rev>` command.

I chose this approach over syncing the generator because it will work for live environments too without (1) causing a huge performance hit (syncing `terra-app-generator` takes, like, several minutes) or (2) having cross-application effects (ONLY the service we are syncing will be impacted).

(*correct in this case means "whatever's in Sherlock")

### Other changes

This PR also includes some small cosmetic changes to Thelma's logging:
* Don't auto-mask secrets that are < 5 characters long, hoping this will reduce some of our spurious redactions in GHA logs
* Reduce the width of sync status reporting messages by removing one level of context nesting