### PR TITLE
DDO-2476 Add --validate=false to `argocd app set`

### DIFF
--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -58,8 +58,6 @@ var retryableErrors = []*regexp.Regexp{
 	// occasional weird socket errors that only show up on OSX
 	regexp.MustCompile("Failed to establish connection to .*: listen unix .* bind: address already in use"),
 	regexp.MustCompile("Failed to establish connection to .*: listen unix .* bind: file exists"),
-	// occurs occasionally when repo server is under load and we run `argocd app set`
-	regexp.MustCompile("Unable to generate manifests in .*: rpc error: code = DeadlineExceeded desc = context deadline exceeded"),
 }
 
 // SyncOptions options for an ArgoCD sync operation

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -58,6 +58,8 @@ var retryableErrors = []*regexp.Regexp{
 	// occasional weird socket errors that only show up on OSX
 	regexp.MustCompile("Failed to establish connection to .*: listen unix .* bind: address already in use"),
 	regexp.MustCompile("Failed to establish connection to .*: listen unix .* bind: file exists"),
+	// occurs occasionally when repo server is under load and we run `argocd app set`
+	regexp.MustCompile("Unable to generate manifests in .*: rpc error: code = DeadlineExceeded desc = context deadline exceeded"),
 }
 
 // SyncOptions options for an ArgoCD sync operation

--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -628,7 +628,7 @@ func (a *argocd) browserLogin() error {
 
 // run `argocd app set <app-name> --revision=<ref>` to set an Argo app's git ref
 func (a *argocd) setRef(appName string, ref string) error {
-	err := a.runCommand([]string{"app", "set", appName, "--revision", ref})
+	err := a.runCommand([]string{"app", "set", appName, "--revision", ref, "--validate=false"})
 	if err != nil {
 		return fmt.Errorf("error setting %s to revision %q: %v", appName, ref, err)
 	}

--- a/internal/thelma/tools/argocd/argocd_test.go
+++ b/internal/thelma/tools/argocd/argocd_test.go
@@ -171,7 +171,7 @@ func Test_SyncRelease(t *testing.T) {
 		WithStdout("leonardo-configs-dev\nleonardo-dev\n")
 
 	// sync legacy configs app
-	_mocks.expectCmd("app", "set", "leonardo-configs-dev", "--revision", "dev")
+	_mocks.expectCmd("app", "set", "leonardo-configs-dev", "--revision", "dev", "--validate=false")
 
 	_mocks.expectCmd("app", "diff", "leonardo-configs-dev", "--hard-refresh").Exits(1) // non-zero indicates a diff was detected
 
@@ -182,7 +182,7 @@ func Test_SyncRelease(t *testing.T) {
 	_mocks.expectCmd("app", "wait", "leonardo-configs-dev", "--timeout", "600", "--health")
 
 	// sync primary app
-	_mocks.expectCmd("app", "set", "leonardo-dev", "--revision", "HEAD")
+	_mocks.expectCmd("app", "set", "leonardo-dev", "--revision", "HEAD", "--validate=false")
 
 	_mocks.expectCmd("app", "diff", "leonardo-dev", "--hard-refresh").Exits(1) // non-zero indicates a diff was detected
 
@@ -206,7 +206,7 @@ func Test_setRef(t *testing.T) {
 	_mocks := setupMocks(t)
 	_argocd := _mocks.argocd
 
-	_mocks.expectCmd("app", "set", "fake-app", "--revision", "main")
+	_mocks.expectCmd("app", "set", "fake-app", "--revision", "main", "--validate=false")
 	require.NoError(t, _argocd.setRef("fake-app", "main"))
 }
 


### PR DESCRIPTION
This avoids triggering a hard refresh, which we do later anyway, and which can take a lot of time and cause timeouts when ArgoCD is under load.

### Context

This is related a [change](https://github.com/broadinstitute/thelma/pull/84) we merged earlier today that lead to timeouts running `argocd app set` when the repo server is under load. Example: https://github.com/broadinstitute/terra-github-workflows/actions/runs/3526454011/jobs/5914394810#logs