### PR TITLE
DDO-2480 Prevent secrets from leaking in CI logs

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -32,8 +32,8 @@ type Bees interface {
 	PinVersions(bee terra.Environment, overrides PinOptions) error
 	UnpinVersions(bee terra.Environment) error
 	SyncEnvironmentGenerator(env terra.Environment) error
-	SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOption) (map[terra.Release]status.Status, error)
-	ResetStatefulSets(env terra.Environment) (map[terra.Release]status.Status, error)
+	SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOption) (map[terra.Release]*status.Status, error)
+	ResetStatefulSets(env terra.Environment) (map[terra.Release]*status.Status, error)
 	RefreshBeeGenerator() error
 }
 
@@ -78,7 +78,7 @@ type PinOptions struct {
 // Bee encapsulates operational information about a BEE
 type Bee struct {
 	Environment      terra.Environment
-	Status           map[terra.Release]status.Status
+	Status           map[terra.Release]*status.Status
 	ContainerLogsURL string
 }
 
@@ -264,7 +264,7 @@ func (b *bees) SyncEnvironmentGenerator(env terra.Environment) error {
 	return err
 }
 
-func (b *bees) SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOption) (map[terra.Release]status.Status, error) {
+func (b *bees) SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOption) (map[terra.Release]*status.Status, error) {
 	releases, err := b.state.Releases().Filter(filter.Releases().BelongsToEnvironment(env))
 	if err != nil {
 		return nil, err
@@ -380,7 +380,7 @@ func (b *bees) GetTemplate(name string) (terra.Environment, error) {
 	return nil, fmt.Errorf("no template by the name %q exists, valid templates are: %s", name, strings.Join(names, ", "))
 }
 
-func (b *bees) ResetStatefulSets(env terra.Environment) (map[terra.Release]status.Status, error) {
+func (b *bees) ResetStatefulSets(env terra.Environment) (map[terra.Release]*status.Status, error) {
 	var err error
 
 	if err = b.kubectl.ShutDown(env); err != nil {

--- a/internal/thelma/cli/commands/bee/common/views/bee.go
+++ b/internal/thelma/cli/commands/bee/common/views/bee.go
@@ -56,7 +56,7 @@ func DescribeBee(bee *bee.Bee) BeeWithOperationalDetails {
 }
 
 type DescribeOptions struct {
-	Status           map[terra.Release]status.Status
+	Status           map[terra.Release]*status.Status
 	ContainerLogsURL string
 }
 
@@ -72,8 +72,11 @@ func DescribeBeeWith(env terra.Environment, opts ...DescribeOption) BeeWithOpera
 
 	if options.Status != nil {
 		for release, _status := range options.Status {
+			if _status == nil {
+				continue
+			}
 			details := releaseDetails[release.Name()]
-			details.Status = &_status
+			details.Status = _status
 			releaseDetails[release.Name()] = details
 		}
 	}

--- a/internal/thelma/ops/status/status.go
+++ b/internal/thelma/ops/status/status.go
@@ -7,17 +7,13 @@ import (
 )
 
 type Status struct {
-	Health             *argocd.HealthStatus `yaml:",omitempty"`
-	Sync               *argocd.SyncStatus   `yaml:",omitempty"`
-	Error              string               `yaml:",omitempty"`
-	UnhealthyResources []Resource           `yaml:"resources,omitempty"`
+	Health             argocd.HealthStatus `yaml:",omitempty"`
+	Sync               argocd.SyncStatus   `yaml:",omitempty"`
+	UnhealthyResources []Resource          `yaml:"resources,omitempty"`
 }
 
 func (s Status) IsHealthy() bool {
-	if s.Health == nil {
-		return false
-	}
-	return *s.Health == argocd.Healthy
+	return s.Health == argocd.Healthy
 }
 
 type Resource struct {
@@ -34,14 +30,7 @@ type Event struct {
 	Type           string
 }
 
-func (s *Status) Headline() string {
-	if s.Error != "" {
-		return fmt.Sprintf("error: %v", s.Error)
-	}
-	if s.Health == nil {
-		return "Unknown"
-	}
-
+func (s Status) Headline() string {
 	if len(s.UnhealthyResources) == 0 {
 		return s.Health.String()
 	}

--- a/internal/thelma/ops/status/status.go
+++ b/internal/thelma/ops/status/status.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Status struct {
-	Health             argocd.HealthStatus `yaml:",omitempty"`
-	Sync               argocd.SyncStatus   `yaml:",omitempty"`
-	UnhealthyResources []Resource          `yaml:"resources,omitempty"`
+	Health             argocd.HealthStatus
+	Sync               argocd.SyncStatus
+	UnhealthyResources []Resource `yaml:"resources,omitempty"`
 }
 
 func (s Status) IsHealthy() bool {

--- a/internal/thelma/ops/sync/sync.go
+++ b/internal/thelma/ops/sync/sync.go
@@ -95,6 +95,13 @@ func (s *syncer) Sync(releases []terra.Release, maxParallel int, options ...argo
 	return statusMap, err
 }
 
+// waitHealthy waits for a release's primary ArgoCD application to be healthy. If:
+// an unknown error is encountered while generating the status report (because, say, ArgoCD is down):
+// .     we return nil + the underlying error
+// the application becomes healthy within the timeout:
+// .     we return the status report and nil error
+// the application does not become healthy within the timeout:
+// .     we return the status report + a timeout error
 func (s *syncer) waitHealthy(release terra.Release, maxWait time.Duration, statusReporter pool.StatusReporter) (*status.Status, error) {
 	lastStatus, err := s.status.Status(release)
 	if err != nil {

--- a/internal/thelma/ops/sync/sync.go
+++ b/internal/thelma/ops/sync/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/tools/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
 	"github.com/rs/zerolog/log"
+	"sort"
 	"sync"
 	"time"
 )
@@ -16,7 +17,7 @@ const waitHealthyPollingInterval = 30 * time.Second
 type Sync interface {
 	// Sync will sync the Argo app(s) for a set of releases, wait for them to be healthy,
 	// and generate and return status reports (useful for understanding why a sync failed).
-	Sync(releases []terra.Release, maxParallel int, options ...argocd.SyncOption) (map[terra.Release]status.Status, error)
+	Sync(releases []terra.Release, maxParallel int, options ...argocd.SyncOption) (map[terra.Release]*status.Status, error)
 }
 
 func New(argocd argocd.ArgoCD, status status.Reporter) Sync {
@@ -31,7 +32,8 @@ type syncer struct {
 	status status.Reporter
 }
 
-func (s *syncer) Sync(releases []terra.Release, maxParallel int, options ...argocd.SyncOption) (map[terra.Release]status.Status, error) {
+// Sync a set of releases and return a status report indicating whether the release is healthy.
+func (s *syncer) Sync(releases []terra.Release, maxParallel int, options ...argocd.SyncOption) (map[terra.Release]*status.Status, error) {
 	var jobs []pool.Job
 
 	waitHealthyTimeout := s.extractWaitHealthy(options)
@@ -42,7 +44,7 @@ func (s *syncer) Sync(releases []terra.Release, maxParallel int, options ...argo
 
 	destination, hasSingleDestination := checkIfSingleDestination(releases)
 
-	statusMap := make(map[terra.Release]status.Status)
+	statusMap := make(map[terra.Release]*status.Status)
 	var mutex sync.Mutex
 
 	for _, unsafe := range releases {
@@ -74,6 +76,10 @@ func (s *syncer) Sync(releases []terra.Release, maxParallel int, options ...argo
 		})
 	}
 
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].Name < jobs[j].Name
+	})
+
 	_pool := pool.New(jobs, func(options *pool.Options) {
 		options.NumWorkers = maxParallel
 		options.StopProcessingOnError = false
@@ -89,19 +95,20 @@ func (s *syncer) Sync(releases []terra.Release, maxParallel int, options ...argo
 	return statusMap, err
 }
 
-func (s *syncer) waitHealthy(release terra.Release, maxWait time.Duration, statusReporter pool.StatusReporter) (lastStatus status.Status, err error) {
-	lastStatus, err = s.status.Status(release)
+func (s *syncer) waitHealthy(release terra.Release, maxWait time.Duration, statusReporter pool.StatusReporter) (*status.Status, error) {
+	lastStatus, err := s.status.Status(release)
 	if err != nil {
-		return
+		// we failed to retrieve status, so return an error
+		return nil, err
 	}
 	updateStatus(lastStatus, statusReporter)
 	if lastStatus.IsHealthy() {
-		return
+		return lastStatus, nil
 	}
 
 	if maxWait == 0 {
 		log.Debug().Msgf("Not waiting for %s to be healthy", release.FullName())
-		return
+		return lastStatus, nil
 	}
 
 	for {
@@ -115,18 +122,18 @@ func (s *syncer) waitHealthy(release terra.Release, maxWait time.Duration, statu
 			case <-ticker.C:
 				lastStatus, err = s.status.Status(release)
 				if err != nil {
-					return
+					return nil, err
 				}
 				updateStatus(lastStatus, statusReporter)
 				if lastStatus.IsHealthy() {
-					return
+					return lastStatus, nil
 				}
 			}
 		}
 	}
 }
 
-func updateStatus(status status.Status, statusReporter pool.StatusReporter) {
+func updateStatus(status *status.Status, statusReporter pool.StatusReporter) {
 	statusReporter.Update(pool.Status{Message: status.Headline()})
 }
 


### PR DESCRIPTION
Stop including error messages in Status objects, as it can lead to secrets leaking in CI logs.