### PR TITLE
[DDO-2489] Fix a Thelma -> Sherlock typo

### DIFF
--- a/internal/thelma/clients/sherlock/chart_version_updater.go
+++ b/internal/thelma/clients/sherlock/chart_version_updater.go
@@ -27,7 +27,7 @@ func (c *Client) UpdateForNewChartVersion(chartSelector string, newVersion strin
 		Description:  description,
 	}
 	if lastVersion != "" {
-		chartVersion.ParentChartVersion = fmt.Sprintf("%s/%s", chartVersion, lastVersion)
+		chartVersion.ParentChartVersion = fmt.Sprintf("%s/%s", chartSelector, lastVersion)
 	}
 	_, _, err := c.client.ChartVersions.PostAPIV2ChartVersions(
 		chart_versions.NewPostAPIV2ChartVersionsParams().WithChartVersion(chartVersion))


### PR DESCRIPTION
Little typo I made, just means that https://beehive.dsp-devops.broadinstitute.org/charts/consent/chart-versions/0.63.0 doesn't have https://beehive.dsp-devops.broadinstitute.org/charts/consent/chart-versions/0.62.0 as its parent in Sherlock's database. This will fix that going forward.