### PR TITLE
DDO-2500 fix: argocd cli now prefixes application names with namespace

### DIFF
--- a/internal/thelma/tools/argocd/argocd.go
+++ b/internal/thelma/tools/argocd/argocd.go
@@ -24,6 +24,7 @@ import (
 const prog = `argocd`
 const configPrefix = `argocd`
 const yamlFormat = "yaml"
+const applicationNamespace = "ap-argocd"
 
 // envVars holds names of environment variables we pass to the `argocd` cli
 var envVars = struct {
@@ -518,7 +519,7 @@ func (a *argocd) hasLegacyConfigsApp(release terra.Release) (bool, error) {
 
 	legacyConfigsName := naming.LegacyConfigsApplicationName(release)
 	for _, line := range lines {
-		if strings.TrimSpace(line) == legacyConfigsName {
+		if strings.TrimSpace(line) == fmt.Sprintf("%s/%s", applicationNamespace, legacyConfigsName) {
 			return true, nil
 		}
 	}

--- a/internal/thelma/tools/argocd/argocd_test.go
+++ b/internal/thelma/tools/argocd/argocd_test.go
@@ -152,7 +152,7 @@ func Test_joinSelector(t *testing.T) {
 }
 
 func Test_SyncRelease(t *testing.T) {
-	// TODO we should add more test cases with different options and config paramters
+	// TODO we should add more test cases with different options and config parameters
 	_mocks := setupMocks(t)
 	_argocd := _mocks.argocd
 
@@ -168,7 +168,7 @@ func Test_SyncRelease(t *testing.T) {
 
 	// check for legacy configs app
 	_mocks.expectCmd("app", "list", "--output", "name", "--selector", "app=leonardo,env=dev").
-		WithStdout("leonardo-configs-dev\nleonardo-dev\n")
+		WithStdout("ap-argocd/leonardo-configs-dev\nap-argocd/leonardo-dev\n")
 
 	// sync legacy configs app
 	_mocks.expectCmd("app", "set", "leonardo-configs-dev", "--revision", "dev", "--validate=false")
@@ -218,7 +218,7 @@ func Test_RefreshRelease(t *testing.T) {
 
 	// check for legacy configs app
 	_mocks.expectCmd("app", "list", "--output", "name", "--selector", "app=leonardo,env=dev").
-		WithStdout("leonardo-configs-dev\nleonardo-dev\n")
+		WithStdout("ap-argocd/leonardo-configs-dev\nap-argocd/leonardo-dev\n")
 
 	// sync legacy configs app
 	_mocks.expectCmd("app", "set", "leonardo-configs-dev", "--revision", "dev", "--validate=false")


### PR DESCRIPTION
`argocd app get -o name` now lists applications with namespace (`<namespace>/<application>`) instead of just `<application>`)

(ref https://github.com/argoproj/argo-cd/pull/9755)