### PR TITLE
DDO-2490 K8s Manifest Validation

### DIFF
--- a/internal/thelma/render/render.go
+++ b/internal/thelma/render/render.go
@@ -3,15 +3,17 @@ package render
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/app/metrics/labels"
 	"github.com/broadinstitute/thelma/internal/thelma/render/helmfile"
 	"github.com/broadinstitute/thelma/internal/thelma/render/resolver"
 	"github.com/broadinstitute/thelma/internal/thelma/render/scope"
+	"github.com/broadinstitute/thelma/internal/thelma/render/validator"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
 	"github.com/rs/zerolog/log"
-	"strconv"
 )
 
 // Options encapsulates CLI options for a render
@@ -24,6 +26,7 @@ type Options struct {
 	ChartSourceDir  string          // ChartSourceDir path on filesystem where chart sources live
 	ResolverMode    resolver.Mode   // ResolverMode resolver mode
 	ParallelWorkers int             // ParallelWorkers number of parallel workers
+	Validate        validator.Mode  // Validate post-render manifest validation mode
 }
 
 // multiRender renders manifests for multiple environments and clusters
@@ -31,6 +34,7 @@ type multiRender struct {
 	options    *Options             // Options global render options
 	state      terra.State          // state terra state provider for looking up environments, clusters, and releases
 	configRepo *helmfile.ConfigRepo // configRepo reference to use for executing `helmfile template`
+	validator  *validator.Validator
 }
 
 // prefix for configuration settings
@@ -58,6 +62,13 @@ func DoRender(app app.ThelmaApp, globalOptions *Options, helmfileArgs *helmfile.
 	}
 	if err = r.renderAll(helmfileArgs); err != nil {
 		return err
+	}
+
+	if r.validator.Mode != validator.Skip {
+		err := r.validator.ValidateDir(globalOptions.OutputDir)
+		if r.validator.Mode == validator.Fail {
+			return err
+		}
 	}
 	return nil
 }
@@ -100,6 +111,8 @@ func newRender(app app.ThelmaApp, options *Options) (*multiRender, error) {
 		ScratchDir:       scratchDir,
 		ShellRunner:      app.ShellRunner(),
 	})
+
+	r.validator = validator.New(options.Validate)
 
 	return r, nil
 }

--- a/internal/thelma/render/render.go
+++ b/internal/thelma/render/render.go
@@ -34,7 +34,7 @@ type multiRender struct {
 	options    *Options             // Options global render options
 	state      terra.State          // state terra state provider for looking up environments, clusters, and releases
 	configRepo *helmfile.ConfigRepo // configRepo reference to use for executing `helmfile template`
-	validator  validator.Validator
+	validator  validator.Validator  // Validator to use for post-render manifest validation if enabled
 }
 
 // prefix for configuration settings

--- a/internal/thelma/render/render.go
+++ b/internal/thelma/render/render.go
@@ -34,7 +34,7 @@ type multiRender struct {
 	options    *Options             // Options global render options
 	state      terra.State          // state terra state provider for looking up environments, clusters, and releases
 	configRepo *helmfile.ConfigRepo // configRepo reference to use for executing `helmfile template`
-	validator  *validator.Validator
+	validator  validator.Validator
 }
 
 // prefix for configuration settings
@@ -64,9 +64,9 @@ func DoRender(app app.ThelmaApp, globalOptions *Options, helmfileArgs *helmfile.
 		return err
 	}
 
-	if r.validator.Mode != validator.Skip {
+	if r.validator.GetMode() != validator.Skip {
 		err := r.validator.ValidateDir(globalOptions.OutputDir)
-		if r.validator.Mode == validator.Fail {
+		if r.validator.GetMode() == validator.Fail {
 			return err
 		}
 	}

--- a/internal/thelma/render/validator/validator.go
+++ b/internal/thelma/render/validator/validator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 )
 
+// Mode determinations behavior of the post-render manifest validation. Default is skip.
 type Mode int
 
 const (
@@ -44,15 +45,20 @@ func (m Mode) String() string {
 	}
 }
 
+// Validator top level interfaced used by multirender to perform validation of all output files after the render has completed.
 type Validator interface {
 	dirValidator
 	GetMode() Mode
 }
 
+// dirValidator is a package private interface that decouples the underlying mechanism performing validation from the options governing its behavior.
+// The main advantage of this interface is that it would enable us to swap out kubeconform with any other validation engine without changing any code in package render.
+// as long as the new mechanism implements this interface
 type dirValidator interface {
 	ValidateDir(path string) error
 }
 
+// validator providers a concrete implementation of the Validator interface
 type validator struct {
 	dirValidator
 	Mode Mode
@@ -62,6 +68,7 @@ func (v validator) GetMode() Mode {
 	return v.Mode
 }
 
+// New returns a new instance of a kubeconform Validator
 func New(mode Mode) validator {
 	return validator{kubeconform.New(shell.NewRunner()), mode}
 }

--- a/internal/thelma/render/validator/validator.go
+++ b/internal/thelma/render/validator/validator.go
@@ -1,0 +1,54 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/broadinstitute/thelma/internal/thelma/tools/kubeconform"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+)
+
+type Mode int
+
+const (
+	// Skip will skip performing any post render validation on k8s manifests
+	Skip Mode = iota
+	// Warn will print validation output but will not cause the render command to exit with error if problems are detected
+	Warn
+	// Fail will cause the render command to exit with an error code if validation errors are detected
+	Fail
+)
+
+func FromString(value string) (Mode, error) {
+	switch value {
+	case "skip":
+		return Skip, nil
+	case "warn":
+		return Warn, nil
+	case "fail":
+		return Fail, nil
+	default:
+		return Skip, fmt.Errorf("unknown validation mode: %q", value)
+	}
+}
+
+func (m Mode) String() string {
+	switch m {
+	case Skip:
+		return "skip"
+	case Warn:
+		return "warn"
+	case Fail:
+		return "fail"
+	default:
+		return "unknown"
+	}
+}
+
+type Validator struct {
+	kubeconform.Kubeconform
+	Mode Mode
+}
+
+func New(mode Mode) *Validator {
+	return &Validator{kubeconform.New(shell.NewRunner()), mode}
+}

--- a/internal/thelma/render/validator/validator.go
+++ b/internal/thelma/render/validator/validator.go
@@ -44,11 +44,24 @@ func (m Mode) String() string {
 	}
 }
 
-type Validator struct {
-	kubeconform.Kubeconform
+type Validator interface {
+	dirValidator
+	GetMode() Mode
+}
+
+type dirValidator interface {
+	ValidateDir(path string) error
+}
+
+type validator struct {
+	dirValidator
 	Mode Mode
 }
 
-func New(mode Mode) *Validator {
-	return &Validator{kubeconform.New(shell.NewRunner()), mode}
+func (v validator) GetMode() Mode {
+	return v.Mode
+}
+
+func New(mode Mode) validator {
+	return validator{kubeconform.New(shell.NewRunner()), mode}
 }

--- a/internal/thelma/tools/kubeconform/kubeconform.go
+++ b/internal/thelma/tools/kubeconform/kubeconform.go
@@ -30,6 +30,8 @@ func (k *kubeconform) ValidateDir(path string) error {
 			"-summary",
 			"-ignore-missing-schemas",
 			"-strict",
+			"-output",
+			"json",
 			path,
 		},
 	}, func(opts *shell.RunOptions) {

--- a/internal/thelma/tools/kubeconform/kubeconform.go
+++ b/internal/thelma/tools/kubeconform/kubeconform.go
@@ -1,6 +1,11 @@
 package kubeconform
 
-import "github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+import (
+	"os"
+
+	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/rs/zerolog"
+)
 
 const prog = "kubeconform"
 
@@ -21,8 +26,12 @@ func (k *kubeconform) ValidateDir(path string) error {
 		Prog: prog,
 		Args: []string{
 			"-summary",
-			"-n 16", // number of parallel workers to use for validation
-			"path",
+			"-ignore-missing-schemas",
+			path,
 		},
+	}, func(opts *shell.RunOptions) {
+		opts.LogLevel = zerolog.DebugLevel
+		opts.Stdout = os.Stdout
+		opts.Stderr = os.Stderr
 	})
 }

--- a/internal/thelma/tools/kubeconform/kubeconform.go
+++ b/internal/thelma/tools/kubeconform/kubeconform.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 const prog = "kubeconform"
@@ -22,11 +23,13 @@ func New(runner shell.Runner) *kubeconform {
 }
 
 func (k *kubeconform) ValidateDir(path string) error {
+	log.Info().Msgf("Validating rendered manifests in %s", path)
 	return k.Run(shell.Command{
 		Prog: prog,
 		Args: []string{
 			"-summary",
 			"-ignore-missing-schemas",
+			"-strict",
 			path,
 		},
 	}, func(opts *shell.RunOptions) {

--- a/internal/thelma/tools/kubeconform/kubeconform.go
+++ b/internal/thelma/tools/kubeconform/kubeconform.go
@@ -1,0 +1,28 @@
+package kubeconform
+
+import "github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+
+const prog = "kubeconform"
+
+type Kubeconform interface {
+	ValidateDir(path string) error
+}
+
+type kubeconform struct {
+	shell.Runner
+}
+
+func New(runner shell.Runner) *kubeconform {
+	return &kubeconform{runner}
+}
+
+func (k *kubeconform) ValidateDir(path string) error {
+	return k.Run(shell.Command{
+		Prog: prog,
+		Args: []string{
+			"-summary",
+			"-n 16", // number of parallel workers to use for validation
+			"path",
+		},
+	})
+}

--- a/internal/thelma/tools/kubeconform/kubeconform.go
+++ b/internal/thelma/tools/kubeconform/kubeconform.go
@@ -18,6 +18,7 @@ func New(runner shell.Runner) *kubeconform {
 	return &kubeconform{runner}
 }
 
+// Validate Invoke kubeconform to perfom recursive manifest validation on all k8s yaml files under path
 func (k *kubeconform) ValidateDir(path string) error {
 	log.Info().Msgf("Validating rendered manifests in %s", path)
 	return k.Run(shell.Command{

--- a/internal/thelma/tools/kubeconform/kubeconform.go
+++ b/internal/thelma/tools/kubeconform/kubeconform.go
@@ -10,10 +10,6 @@ import (
 
 const prog = "kubeconform"
 
-type Kubeconform interface {
-	ValidateDir(path string) error
-}
-
 type kubeconform struct {
 	shell.Runner
 }
@@ -29,9 +25,7 @@ func (k *kubeconform) ValidateDir(path string) error {
 		Args: []string{
 			"-summary",
 			"-ignore-missing-schemas",
-			"-strict",
-			"-output",
-			"json",
+			// "-strict",
 			path,
 		},
 	}, func(opts *shell.RunOptions) {

--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -12,6 +12,7 @@ YQ_VERSION=4.11.2
 HELM_DOCS_VERSION=1.5.0
 ARGOCD_VERSION=2.5.3
 KUBECTL_VERSION=1.24.0
+KUBECONFORM_VERSION=0.5.0
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
@@ -146,6 +147,15 @@ install_kubectl() {
     mv ./kubectl "${INSTALL_DIR}/kubectl"
 }
 
+install_kubeconform() {
+  URL="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-${OS}-${ARCH}.tar.gz"
+  echo "Downloading kubeconform from ${URL}"
+  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - |\
+    tar -xz && \
+    testexec ./kubeconform -v && \
+    mv ./kubeconform "${INSTALL_DIR}/kubeconform"
+}
+
 mkdir -p "${INSTALL_DIR}"
 mkdir -p "${SCRATCH_DIR}"
 
@@ -199,6 +209,14 @@ fi
 if [[ ! -f "${INSTALL_DIR}/kubectl" ]]; then
   if ! install_kubectl; then
     echo "kubectl install failed!" >&2
+    exit 1
+  fi
+fi
+
+# Install kubeconform
+if [[ ! -f "${INSTALL_DIR}/kubeconform" ]]; then
+  if ! install_kubeconform; then
+    echo "kubeconform install failed!" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Adds support for a `thelma render --validate <ARG>` flag. This is implemented via adding [kubeconfrom](https://github.com/yannh/kubeconform) to Thelma's packaged binaries and then creating it a wrapper for it in the `tools` package. The main uses cases for this new functionality are for use in local helm chart development and as a CI check in terra-helmfile.

`--validate` is implemented as a post render step. Once all the renders for a thelma invocation have finished, kubeconform will then be invoked against the output directly where it will recursively find and validate all k8s manifest yaml files.

The default behavior of this new flag is `skip` which will skip performing any validation. This is to avoid causing failures in existing render processes as well as to avoid adding the runtime overhead of validation where it isn't need. 

Why Kubeconform?
[kubeval](https://github.com/instrumenta/kubeval/) is the usual go to tool in this space but as of recently it is no longer being maintained and kubeconform is the recommended replacement. 