### PR TITLE
DDO-2447 Retry failed orch requests during seeding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/armon/go-metrics v0.3.9 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
 github.com/aws/aws-sdk-go-v2/credentials v1.4.3/go.mod h1:FNNC6nQZQUuyhq5aE5c7ata8o9e4ECGmS4lAXC7o1mQ=

--- a/internal/thelma/clients/google/terraapi/firecloudorch.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch.go
@@ -4,9 +4,28 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/avast/retry-go"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/rs/zerolog/log"
 	"net/http"
+	"regexp"
+	"time"
 )
+
+// BEE seeding occasionally fails, with Orch occasionally encountering connection timeouts, resets, or DNS errors
+// while communicating with some of the services it proxies. (The most common culprits are Agora and Thurloe).
+//
+// While we investigate this issue, we have configured this client to aggressively retry failed requests that
+// seem to be network-related every 30 seconds, for up to 20 minutes, with the goal of determining whether
+// the issues resolve on their own after a period of time or require manual intervention (say, a restart of orch).
+
+const defaultRetryAttempts = 40
+const defaultRetryDelay = 30 * time.Second
+
+var retryableErrors = []*regexp.Regexp{
+	regexp.MustCompile(`java\.net\.SocketTimeoutException`),
+	regexp.MustCompile(`java\.net\.UnknownHostException`),
+}
 
 type FirecloudOrchClient interface {
 	RegisterProfile(firstName string, lastName string, title string, contactEmail string, institute string, institutionalProgram string, programLocationCity string, programLocationState string, programLocationCountry string, pi string, nonProfitStatus string) (*http.Response, string, error)
@@ -19,7 +38,9 @@ type FirecloudOrchClient interface {
 
 type firecloudOrchClient struct {
 	*terraClient
-	appRelease terra.AppRelease
+	appRelease    terra.AppRelease
+	retryAttempts uint
+	retryDelay    time.Duration
 }
 
 func (c *firecloudOrchClient) RegisterProfile(firstName string, lastName string, title string, contactEmail string, institute string, institutionalProgram string, programLocationCity string, programLocationState string, programLocationCountry string, pi string, nonProfitStatus string) (*http.Response, string, error) {
@@ -48,49 +69,75 @@ func (c *firecloudOrchClient) RegisterProfile(firstName string, lastName string,
 		Pi:                     pi,
 		NonProfitStatus:        nonProfitStatus,
 	}
-	body, err := json.Marshal(bodyStruct)
-	if err != nil {
-		return nil, "", err
-	}
-	return c.doJsonRequest(http.MethodPost, fmt.Sprintf("%s/register/profile", c.appRelease.URL()), bytes.NewBuffer(body))
+	return c.doJsonRequestWithRetries(http.MethodPost, fmt.Sprintf("%s/register/profile", c.appRelease.URL()), bodyStruct)
 }
-
 func (c *firecloudOrchClient) AgoraMakeMethod(data interface{}) (*http.Response, string, error) {
-	body, err := json.Marshal(data)
-	if err != nil {
-		return nil, "", err
-	}
-	return c.doJsonRequest(http.MethodPost, fmt.Sprintf("%s/api/methods", c.appRelease.URL()), bytes.NewBuffer(body))
+	return c.doJsonRequestWithRetries(http.MethodPost, fmt.Sprintf("%s/api/methods", c.appRelease.URL()), data)
 }
 
 func (c *firecloudOrchClient) AgoraSetMethodACLs(name string, namespace string, acls interface{}) (*http.Response, string, error) {
-	body, err := json.Marshal(acls)
-	if err != nil {
-		return nil, "", err
-	}
-	return c.doJsonRequest(http.MethodPost, fmt.Sprintf("%s/api/methods/%s/%s/1/permissions", c.appRelease.URL(), namespace, name), bytes.NewBuffer(body))
+	return c.doJsonRequestWithRetries(http.MethodPost, fmt.Sprintf("%s/api/methods/%s/%s/1/permissions", c.appRelease.URL(), namespace, name), acls)
 }
 
 func (c *firecloudOrchClient) AgoraMakeConfig(data interface{}) (*http.Response, string, error) {
-	body, err := json.Marshal(data)
-	if err != nil {
-		return nil, "", err
-	}
-	return c.doJsonRequest(http.MethodPost, fmt.Sprintf("%s/api/configurations", c.appRelease.URL()), bytes.NewBuffer(body))
+	return c.doJsonRequestWithRetries(http.MethodPost, fmt.Sprintf("%s/api/configurations", c.appRelease.URL()), data)
 }
 
 func (c *firecloudOrchClient) AgoraSetConfigACLs(name string, namespace string, acls interface{}) (*http.Response, string, error) {
-	body, err := json.Marshal(acls)
-	if err != nil {
-		return nil, "", err
-	}
-	return c.doJsonRequest(http.MethodPost, fmt.Sprintf("%s/api/configurations/%s/%s/1/permissions", c.appRelease.URL(), namespace, name), bytes.NewBuffer(body))
+	return c.doJsonRequestWithRetries(http.MethodPost, fmt.Sprintf("%s/api/configurations/%s/%s/1/permissions", c.appRelease.URL(), namespace, name), acls)
 }
 
 func (c *firecloudOrchClient) AgoraSetNamespaceACLs(namespace string, acls interface{}) (*http.Response, string, error) {
-	body, err := json.Marshal(acls)
-	if err != nil {
-		return nil, "", err
+	return c.doJsonRequestWithRetries(http.MethodPost, fmt.Sprintf("%s/api/configurations/%s/permissions", c.appRelease.URL(), namespace), acls)
+}
+
+func (c *firecloudOrchClient) doJsonRequestWithRetries(method string, url string, bodyData interface{}) (*http.Response, string, error) {
+	retryAttempts := c.retryAttempts
+	if retryAttempts == 0 {
+		retryAttempts = defaultRetryAttempts
 	}
-	return c.doJsonRequest(http.MethodPost, fmt.Sprintf("%s/api/configurations/%s/permissions", c.appRelease.URL(), namespace), bytes.NewBuffer(body))
+
+	retryDelay := c.retryDelay
+	if retryDelay == 0 {
+		retryDelay = defaultRetryDelay
+	}
+
+	var resp *http.Response
+	var responseBody string
+	var err error
+
+	requestBody, err := json.Marshal(bodyData)
+	if err != nil {
+		return nil, "", fmt.Errorf("error marshalling request body for %s %s: %v", method, url, err)
+	}
+
+	requestFn := func() error {
+		resp, responseBody, err = c.doJsonRequest(method, url, bytes.NewBuffer(requestBody))
+		return err
+	}
+
+	if retryErr := retry.Do(
+		requestFn,
+		retry.Attempts(retryAttempts),
+		retry.DelayType(retry.FixedDelay),
+		retry.Delay(retryDelay),
+		retry.OnRetry(func(n uint, err error) {
+			log.Warn().Err(err).Msgf("%s %s failed (attempt %d of %d): %v", method, url, n, defaultRetryAttempts, err)
+		}),
+		retry.RetryIf(isRetryableError),
+	); retryErr != nil {
+		return nil, "", retryErr
+	}
+
+	return resp, responseBody, nil
+}
+
+func isRetryableError(err error) bool {
+	msg := err.Error()
+	for _, matcher := range retryableErrors {
+		if matcher.MatchString(msg) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/thelma/clients/google/terraapi/firecloudorch_test.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch_test.go
@@ -1,0 +1,64 @@
+package terraapi
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	googleoauth "google.golang.org/api/oauth2/v2"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_OrchClientRetriesFailedRequests(t *testing.T) {
+	var requestCount int
+
+	fakeOrchServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Path != "/register/profile" {
+			t.Errorf("expected to request '/register/profile', got: %s", r.URL.Path)
+		}
+
+		var status int
+		var body string
+
+		if requestCount > 3 {
+			status = http.StatusOK
+			body = `this is ignored`
+		} else {
+			status = http.StatusInternalServerError
+			body = `error connecting to thurloe: java.net.UnknownHostException`
+		}
+
+		w.WriteHeader(status)
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("error writing fake http response: %v", err)
+		}
+	}))
+	defer fakeOrchServer.Close()
+
+	orchRelease := mocks.NewAppRelease(t)
+	orchRelease.On("URL").Return(fakeOrchServer.URL)
+
+	client := &firecloudOrchClient{
+		terraClient: &terraClient{
+			tokenSource: testutils.NewFakeTokenSource("fake-token"),
+			userInfo:    googleoauth.Userinfo{},
+			httpClient:  *fakeOrchServer.Client(),
+		},
+		appRelease: orchRelease,
+		retryDelay: 5 * time.Millisecond,
+	}
+
+	_, _, err := client.RegisterProfile(
+		"Jane", "Doe",
+		"Owner", "jdoe@broadinstitute.org",
+		"None", "None",
+		"None", "None", "None",
+		"None", "None",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 4, requestCount)
+}

--- a/internal/thelma/clients/google/terraapi/firecloudorch_test.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch_test.go
@@ -25,8 +25,8 @@ func Test_OrchClientRetriesFailedRequests(t *testing.T) {
 		var body string
 
 		if requestCount > 3 {
-			status = http.StatusOK
-			body = `this is ignored`
+			status = http.StatusInternalServerError
+			body = `this error does not match our retryable list, so should not cause a retry`
 		} else {
 			status = http.StatusInternalServerError
 			body = `error connecting to thurloe: java.net.UnknownHostException`
@@ -59,6 +59,7 @@ func Test_OrchClientRetriesFailedRequests(t *testing.T) {
 		"None", "None", "None",
 		"None", "None",
 	)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does not match our retryable list")
 	assert.Equal(t, 4, requestCount)
 }

--- a/internal/thelma/clients/kubernetes/kubecfg/kubecfg_test.go
+++ b/internal/thelma/clients/kubernetes/kubecfg/kubecfg_test.go
@@ -2,6 +2,7 @@ package kubecfg
 
 import (
 	"encoding/base64"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/testutils"
 	"os"
 	"path"
 	"testing"
@@ -12,16 +13,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
 )
-
-type fakeTokenSource struct {
-	fakeToken string
-}
-
-func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{AccessToken: f.fakeToken}, nil
-}
 
 func Test_Kubecfg(t *testing.T) {
 	cluster1 := mocks.NewCluster(t)
@@ -94,9 +86,7 @@ func Test_Kubecfg(t *testing.T) {
 
 	// write kubecfg to temporary file
 	file := path.Join(t.TempDir(), "kubecfg")
-	tokenSource := &fakeTokenSource{
-		fakeToken: "fake-token",
-	}
+	tokenSource := testutils.NewFakeTokenSource("fake-token")
 	kubecfg := New(file, gkeClient, tokenSource)
 
 	// get kubecfg for release1

--- a/internal/thelma/utils/testutils/fake_token_source.go
+++ b/internal/thelma/utils/testutils/fake_token_source.go
@@ -1,0 +1,17 @@
+package testutils
+
+import "golang.org/x/oauth2"
+
+type fakeTokenSource struct {
+	fakeToken string
+}
+
+func NewFakeTokenSource(token string) oauth2.TokenSource {
+	return &fakeTokenSource{
+		fakeToken: token,
+	}
+}
+
+func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: f.fakeToken}, nil
+}


### PR DESCRIPTION
This change updates Thelma's firecloud-orchestration client to retry failed requests that include an error message matching `java.net.UnknownHostException` or `java.net.SocketTimeoutException`.

Failed requests will be retried every 30 seconds for up to 20 minutes. The long timeout is to help us determine if these issues eventually resolve on their own, or if more aggressive intervention (say, restarting orch  or its dependencies), is required.

### Background

The BEE seeding process sometimes fails with errors from Orch like this:
```
Class":"akka.stream.StreamTcpException","message":"Tcp command 
  [Connect(thurloe.jenkins-swat-72360.bee.envs-terra.bio/<unresolved>:443,None,List(),
    Some(20 seconds),true)] 
  failed because of java.net.UnknownHostException: thurloe.jenkins-swat-72360.bee.envs-terra.bio"
```

These errors are fatal, and are incredibly annoying if you've spent 12 minutes waiting for a BEE to provision only for orch to randomly blip during seeding. 