### PR TITLE
DDO-2447 Add another exception to the list of retryables for requests to firecloud-orchestration

### DIFF
--- a/internal/thelma/clients/google/terraapi/firecloudorch.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch.go
@@ -25,6 +25,7 @@ const defaultRetryDelay = 30 * time.Second
 var retryableErrors = []*regexp.Regexp{
 	regexp.MustCompile(`java\.net\.SocketTimeoutException`),
 	regexp.MustCompile(`java\.net\.UnknownHostException`),
+	regexp.MustCompile(`akka\.http\.impl\.engine\.client\.OutgoingConnectionBlueprint\$UnexpectedConnectionClosureException`),
 }
 
 type FirecloudOrchClient interface {

--- a/internal/thelma/clients/google/terraapi/firecloudorch.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch.go
@@ -26,6 +26,7 @@ var retryableErrors = []*regexp.Regexp{
 	regexp.MustCompile(`java\.net\.SocketTimeoutException`),
 	regexp.MustCompile(`java\.net\.UnknownHostException`),
 	regexp.MustCompile(`akka\.http\.impl\.engine\.client\.OutgoingConnectionBlueprint\$UnexpectedConnectionClosureException`),
+	regexp.MustCompile(`(?m)503 Service Temporarily Unavailable.*nginx`),
 }
 
 type FirecloudOrchClient interface {


### PR DESCRIPTION

Add regexps matching:
```
11:42:22 #1: 500 Internal Server Error from 
https://firecloudorch.jenkins-swat-leo-6269.bee.envs-terra.bio/register/profile 
({"causes":[],
"exceptionClass":"akka.http.impl.engine.client.OutgoingConnectionBlueprint$UnexpectedConnectionClosureException",
"message":"The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests",
"source":"Thurloe",
...
```
(encountered [here](https://fc-jenkins.dsp-techops.broadinstitute.org/job/fiab-start/88570/console))

and

```
17:51:51   "message": "ErrorReport(Agora,<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n,Some(503 Service Unavailable),List(),List(),None)",
```
(encountered [here](https://fc-jenkins.dsp-techops.broadinstitute.org/job/fiab-start/88626/console))
