### PR TITLE
[DDO-2617] Hide Thelma Slack errors more

### DIFF
--- a/internal/thelma/clients/slack/slack.go
+++ b/internal/thelma/clients/slack/slack.go
@@ -83,7 +83,8 @@ func (s *Slack) SendDevopsAlert(title string, text string, ok bool) error {
 // SendDirectMessage send a direct message to a user, by email
 func (s *Slack) SendDirectMessage(email string, markdown string) error {
 	if err := s.requireClient(); err != nil {
-		return err
+		log.Debug().Msgf("Not sending Slack notification from Thelma; wasn't able to build Slack client: %v", err)
+		return nil
 	}
 	user, err := s.client.GetUserByEmail(email)
 	if err != nil {

--- a/internal/thelma/clients/slack/slack.go
+++ b/internal/thelma/clients/slack/slack.go
@@ -83,7 +83,8 @@ func (s *Slack) SendDevopsAlert(title string, text string, ok bool) error {
 // SendDirectMessage send a direct message to a user, by email
 func (s *Slack) SendDirectMessage(email string, markdown string) error {
 	if err := s.requireClient(); err != nil {
-		log.Debug().Msgf("Not sending Slack notification from Thelma; wasn't able to build Slack client: %v", err)
+		log.Info().Msg("will continue without sending Slack messages; enable debug logging for more information")
+		log.Debug().Msgf("failed to initialize Slack client: %v", err)
 		return nil
 	}
 	user, err := s.client.GetUserByEmail(email)


### PR DESCRIPTION
Thelma doesn't actually fail if it can't send Slack messages, but it does print the warning to console. In Jenkins, Thelma fails this step with a Vault-deny error, and a lot of folks assume that _that's_ the true source of the job erroring (not that the BEE failed to start). I'm thinking that by just swallowing the internal error folks will look at the BEE start error.