### PR TITLE
[DDO-2626] Move tools into separate directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir /thelma && tar -xvf ${THELMA_LINUX_RELEASE} -C /thelma
 # Remove the copied tarball
 RUN rm ${THELMA_LINUX_RELEASE}
 
-ENV PATH="/thelma/bin:${PATH}"
+ENV PATH="/thelma/bin:/thelma/tools/bin:${PATH}"
 
 # Make sure thelma executes
 RUN /thelma/bin/thelma --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN rm ${THELMA_LINUX_RELEASE}
 ENV PATH="/thelma/bin:/thelma/tools/bin:${PATH}"
 
 # Make sure thelma executes
-RUN /thelma/bin/thelma --help
+RUN thelma --help

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ release: runtime-deps build ## Assemble thelma binary + runtime dependencies int
 	mkdir -p ${RELEASE_ARCHIVE_DIR}
 
     # Copy runtime dependencies into staging dir
-	mkdir -p ${RUNTIME_DEPS_BIN_DIR}/tools/bin
+	mkdir -p ${RELEASE_STAGING_DIR}/tools/bin
 	cp -r ${RUNTIME_DEPS_BIN_DIR}/. ${RELEASE_STAGING_DIR}/tools/bin
 
     # Copy compiled thelma binary into staging dir

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ release: runtime-deps build ## Assemble thelma binary + runtime dependencies int
 	mkdir -p ${RELEASE_ARCHIVE_DIR}
 
     # Copy runtime dependencies into staging dir
-	cp -r ${RUNTIME_DEPS_BIN_DIR}/. ${RELEASE_STAGING_DIR}/bin
+	mkdir -p ${RUNTIME_DEPS_BIN_DIR}/tools/bin
+	cp -r ${RUNTIME_DEPS_BIN_DIR}/. ${RELEASE_STAGING_DIR}/tools/bin
 
     # Copy compiled thelma binary into staging dir
 	cp -r ${BIN_DIR}/. ${RELEASE_STAGING_DIR}/bin

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -48,6 +48,7 @@ CMD_AUTH_FLAGS="--apple-id ${APPLE_ID} --password ${THELMA_MACOS_APP_PWD} --team
 
 # Sign one file
 sign() {
+  echo "Signing ${1}..."
 	codesign -f -o runtime,library --timestamp -s "${SECURITY_ID}" "${1}"
 }
 
@@ -163,6 +164,7 @@ notarize() {
 
 # Check the notarization status of the given file
 verify() {
+  echo "Verifying ${1}..."
 	_not_info=$(codesign -vvvv -R="notarized" --check-notarization "${1}" 2>&1)
 	if echo "${_not_info}" | tr '\n' ' ' | grep -Eq 'valid on disk.*satisfies its Designated Requirement.*explicit requirement satisfied'; then
 		echo "${1} was successfully notarized!"
@@ -184,7 +186,7 @@ tar -xf "${RELEASE_TARBALL}" -C "${untar_dir}"
 
 # Sign each binary
 echo -n "Signing binaries..."
-for bin in "${untar_dir}"/bin/*
+for bin in "${untar_dir}"/bin/* "${untar_dir}"/tools/bin/*
 do
 	sign "${bin}"
 done
@@ -204,7 +206,7 @@ notarize "$(archive "${untar_dir}")"
 #       that Apple registers the binaries as "safe" and then lets users computers
 #       do a check later when they're run....or something. This is all very opaque
 #       and the process is unclear.
-for bin in "${untar_dir}"/bin/*
+for bin in "${untar_dir}"/bin/* "${untar_dir}"/tools/bin/*
 do
 	verify "${bin}"
 done


### PR DESCRIPTION
### Changes
* Move tools into a separate directory in the thelma release archive -- so we have `thelma/bin` and `thelma/tools/bin`. This way users can have thelma on PATH without shadowing locally-installed kubectl, vault client, etc.

### Related
* https://github.com/broadinstitute/terra-helmfile/pull/3762