### PR TITLE
DDO-2658 Add Support For Multi-Layer Helm Depedency Updates in Local Resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
-	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,9 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/thelma/charts/source/chart.go
+++ b/internal/thelma/charts/source/chart.go
@@ -47,9 +47,6 @@ type Chart interface {
 	BumpChartVersion(latestPublishedVersion string) (string, error)
 	// UpdateDependencies runs `helm dependency update` on the local copy of the chart.
 	UpdateDependencies() error
-	// UpdateDependenciesRecursive is the same as update dependencies but recurses through all
-	// local deps and runs helm dependency update in topological order
-	UpdateDependenciesRecursive() error
 	// PackageChart runs `helm package` to package a chart
 	PackageChart(destPath string) error
 	// GenerateDocs re-generates README documentation for the given chart
@@ -125,15 +122,6 @@ func (c *chart) UpdateDependencies() error {
 		Dir: c.path,
 	}
 	return c.shellRunner.Run(cmd)
-}
-
-func (c *chart) UpdateDependenciesRecursive() error {
-	// construct depedency graph
-
-	// toposort dependencies
-
-	// helm dependency update on deps in sorted order
-	return nil
 }
 
 // PackageChart runs `helm package` to package a chart

--- a/internal/thelma/charts/source/chart.go
+++ b/internal/thelma/charts/source/chart.go
@@ -2,15 +2,16 @@ package source
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"strings"
+
 	"github.com/broadinstitute/thelma/internal/thelma/charts/semver"
 	"github.com/broadinstitute/thelma/internal/thelma/tools/helm"
 	"github.com/broadinstitute/thelma/internal/thelma/tools/yq"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path"
-	"strings"
 )
 
 // initial version that is assigned to brand-new charts
@@ -46,6 +47,9 @@ type Chart interface {
 	BumpChartVersion(latestPublishedVersion string) (string, error)
 	// UpdateDependencies runs `helm dependency update` on the local copy of the chart.
 	UpdateDependencies() error
+	// UpdateDependenciesRecursive is the same as update dependencies but recurses through all
+	// local deps and runs helm dependency update in topological order
+	UpdateDependenciesRecursive() error
 	// PackageChart runs `helm package` to package a chart
 	PackageChart(destPath string) error
 	// GenerateDocs re-generates README documentation for the given chart
@@ -121,6 +125,15 @@ func (c *chart) UpdateDependencies() error {
 		Dir: c.path,
 	}
 	return c.shellRunner.Run(cmd)
+}
+
+func (c *chart) UpdateDependenciesRecursive() error {
+	// construct depedency graph
+
+	// toposort dependencies
+
+	// helm dependency update on deps in sorted order
+	return nil
 }
 
 // PackageChart runs `helm package` to package a chart

--- a/internal/thelma/render/resolver/local_resolver.go
+++ b/internal/thelma/render/resolver/local_resolver.go
@@ -76,7 +76,7 @@ func (r *localResolverImpl) resolverFn(chartRelease ChartRelease) (ResolvedChart
 	if err != nil {
 		return nil, err
 	}
-	chartsToUpdate, err := r.determineDepedenciesToUpdate(chart)
+	chartsToUpdate, err := r.determineDependenciesToUpdate(chart)
 	if err != nil {
 		return nil, fmt.Errorf("error determining charts to run helm dependency update on: %v", err)
 	}
@@ -104,10 +104,10 @@ func (r *localResolverImpl) chartSourcePath(chartName string) string {
 	return path.Join(r.sourceDir, chartName)
 }
 
-// determineDependenciesToUpdate is used to add support for lack of handling for multi-layer depedencies
+// determineDependenciesToUpdate is used to add support for lack of handling for multi-layer dependencies
 // in helm upgrade. It performs a BFS traversal of the dependency graph for a given chart and outputs
-// a topologically sorted list of charts to run helm depedency update upon
-func (r *localResolverImpl) determineDepedenciesToUpdate(chart source.Chart) ([]source.Chart, error) {
+// a topologically sorted list of charts to run helm dependency update upon
+func (r *localResolverImpl) determineDependenciesToUpdate(chart source.Chart) ([]source.Chart, error) {
 	dependencies := make(map[string][]string)
 	dependencies[chart.Name()] = chart.LocalDependencies()
 	chartsToProcess := make([]string, 0)

--- a/internal/thelma/render/resolver/local_resolver.go
+++ b/internal/thelma/render/resolver/local_resolver.go
@@ -8,7 +8,6 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/charts/dependency"
 	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
-	"github.com/rs/zerolog/log"
 )
 
 // LocalResolver is for resolving charts in local directory of chart sources.
@@ -77,11 +76,15 @@ func (r *localResolverImpl) resolverFn(chartRelease ChartRelease) (ResolvedChart
 	if err != nil {
 		return nil, err
 	}
-	dgraph := r.buildDependencyGraph(chart)
-	log.Info().Msgf("Testing Dgraph: %#v", dgraph)
-	err = chart.UpdateDependencies()
+	chartsToUpdate, err := r.determineDepedenciesToUpdate(chart)
 	if err != nil {
-		return nil, fmt.Errorf("error updating chart source directory %s: %v", chart.Path(), err)
+		return nil, fmt.Errorf("error determining charts to run helm dependency update on: %v", err)
+	}
+	for _, chart := range chartsToUpdate {
+		err = chart.UpdateDependencies()
+		if err != nil {
+			return nil, fmt.Errorf("error updating chart source directory %s: %v", chart.Path(), err)
+		}
 	}
 
 	return NewResolvedChart(chart.Path(), chart.ManifestVersion(), Local, chartRelease), nil
@@ -101,7 +104,10 @@ func (r *localResolverImpl) chartSourcePath(chartName string) string {
 	return path.Join(r.sourceDir, chartName)
 }
 
-func (r *localResolverImpl) buildDependencyGraph(chart source.Chart) []string {
+// determineDependenciesToUpdate is used to add support for lack of handling for multi-layer depedencies
+// in helm upgrade. It performs a BFS traversal of the dependency graph for a given chart and outputs
+// a topologically sorted list of charts to run helm depedency update upon
+func (r *localResolverImpl) determineDepedenciesToUpdate(chart source.Chart) ([]source.Chart, error) {
 	dependencies := make(map[string][]string)
 	dependencies[chart.Name()] = chart.LocalDependencies()
 	chartsToProcess := make([]string, 0)
@@ -112,15 +118,38 @@ func (r *localResolverImpl) buildDependencyGraph(chart source.Chart) []string {
 		currentChartName := chartsToProcess[0]
 		chartsToProcess = chartsToProcess[1:]
 
-		currentChart, _ := r.getChart(currentChartName)
+		currentChart, err := r.getChart(currentChartName)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error finding chart source locally while calculating depedencies. parent chart: %s, %v",
+				chart.Name(), err,
+			)
+		}
+
 		dependencies[currentChart.Name()] = currentChart.LocalDependencies()
 		chartsToProcess = append(chartsToProcess, currentChart.LocalDependencies()...)
 	}
-	dependencyGraph, _ := dependency.NewGraph(dependencies)
+
+	dependencyGraph, err := dependency.NewGraph(dependencies)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing depdency graph in local resolver: %v", err)
+	}
+
 	dependenciesToUpdate := make([]string, 0)
+	// dependency map keys need to be transferred into a slice in order to use Topo sort
 	for chart := range dependencies {
 		dependenciesToUpdate = append(dependenciesToUpdate, chart)
 	}
 	dependencyGraph.TopoSort(dependenciesToUpdate)
-	return dependenciesToUpdate
+
+	// convert to domain type
+	var chartsToUpdate []source.Chart
+	for _, chart := range dependenciesToUpdate {
+		sourceChart, err := r.getChart(chart)
+		if err != nil {
+			return nil, fmt.Errorf("error finding local source for chart: %s, %v", chart, err)
+		}
+		chartsToUpdate = append(chartsToUpdate, sourceChart)
+	}
+	return chartsToUpdate, nil
 }

--- a/internal/thelma/render/resolver/resolver_test.go
+++ b/internal/thelma/render/resolver/resolver_test.go
@@ -2,18 +2,25 @@ package resolver
 
 import (
 	"fmt"
-	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const chartSourceDir = "testdata/charts"
 const fakeChartName = "fakechart"
 const fakeChartVersion = "0.10.0"
 const fakeChartRepo = "terra-helm"
+
+var fakeChartDependencyTopographicOrder = []string{
+	"fakechartdep2",
+	"fakechartdep1",
+	"fakechart",
+}
 
 type testCfg struct {
 	srcDir     string
@@ -168,15 +175,17 @@ func TestResolver(t *testing.T) {
 }
 
 func (tc *testCfg) expectHelmDependencyUpdate() {
-	tc.mockRunner.ExpectCmd(shell.Command{
-		Prog: "helm",
-		Args: []string{
-			"dependency",
-			"update",
-			"--skip-refresh",
-		},
-		Dir: path.Join(chartSourceDir, tc.input.Name),
-	})
+	for _, chartName := range fakeChartDependencyTopographicOrder {
+		tc.mockRunner.ExpectCmd(shell.Command{
+			Prog: "helm",
+			Args: []string{
+				"dependency",
+				"update",
+				"--skip-refresh",
+			},
+			Dir: path.Join(chartSourceDir, chartName),
+		})
+	}
 }
 
 func (tc *testCfg) expectHelmFetch(success bool) {

--- a/internal/thelma/render/resolver/testdata/charts/fakechart/Chart.yaml
+++ b/internal/thelma/render/resolver/testdata/charts/fakechart/Chart.yaml
@@ -3,3 +3,7 @@ name: fakechart
 version: 0.10.0
 description: Fake chart for testing resolver
 type: application
+dependencies:
+  - name: fakechartdep1
+    repository: file://../fakechartdep1
+    version: 0.2.0

--- a/internal/thelma/render/resolver/testdata/charts/fakechartdep1/Chart.yaml
+++ b/internal/thelma/render/resolver/testdata/charts/fakechartdep1/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: fakechartdep1
+version: 0.2.0
+description: Fake chart for testing resolver
+type: application
+dependencies:
+  - name: fakechartdep2
+    repository: file://../fakechartdep2
+    version: 0.7.0

--- a/internal/thelma/render/resolver/testdata/charts/fakechartdep2/Chart.yaml
+++ b/internal/thelma/render/resolver/testdata/charts/fakechartdep2/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: fakechartdep2
+version: 0.7.0
+description: Fake chart for testing resolver
+type: application


### PR DESCRIPTION
A workaround for [this old issue](https://github.com/helm/helm/issues/2247) in helm. The new `foundation` helm chart has multiple layers of dependencies, currently the `localResolver` used in `development` mode only performs `helm dendency update` on the top level parent chart.

Following this change the local resolver will now determine all the dependencies of a parent chart that exist in the `sourceDir` and run `helm dependency update` on each of them in topological ordering. 

Example Debug log output from a render showing this in action
![Screen Shot 2023-02-10 at 8 53 24 AM](https://user-images.githubusercontent.com/60187023/218108791-6bcc79a1-0e83-4191-81a3-239922ee85ae.png)
