### PR TITLE
DDO-2626 Prepare to break tools into separate directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir /thelma && tar -xvf ${THELMA_LINUX_RELEASE} -C /thelma
 # Remove the copied tarball
 RUN rm ${THELMA_LINUX_RELEASE}
 
-ENV PATH="/thelma/bin:${PATH}"
+ENV PATH="/thelma/bin:/thelma/tools/bin:${PATH}"
 
 # Make sure thelma executes
 RUN /thelma/bin/thelma --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN rm ${THELMA_LINUX_RELEASE}
 ENV PATH="/thelma/bin:/thelma/tools/bin:${PATH}"
 
 # Make sure thelma executes
-RUN /thelma/bin/thelma --help
+RUN thelma --help

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ OUTPUT_DIR=./output
 # BIN_DIR location where compiled binaries are generated
 BIN_DIR=${OUTPUT_DIR}/bin
 
-# RUNTIME_DEPS_BIN_DIR location where 3rd-party runtime dependency binaries are downloaded
+# TOOLS_BIN_DIR symlink to 3rd-party tools binaries (helm, kubectl, etc)
+TOOLS_BIN_DIR=${OUTPUT_DIR}/tools/bin
+
+# RUNTIME_DEPS_BIN_DIR location where 3rd-party tools dependency binaries are downloaded
 RUNTIME_DEPS_BIN_DIR=${OUTPUT_DIR}/runtime-deps/${TARGET_OS}/${TARGET_ARCH}/bin
 
 # RELEASE_STAGING_DIR directory where release archive is staged before assembly
@@ -61,7 +64,7 @@ RELEASE_ARCHIVE_DIR=${OUTPUT_DIR}/releases
 COVERAGE_DIR=${OUTPUT_DIR}/coverage
 
 # Add runtime dependencies to PATH
-export PATH := $(shell pwd)/${RUNTIME_DEPS_BIN_DIR}:$(PATH)
+export PATH := $(shell pwd)/${TOOLS_BIN_DIR}:$(PATH)
 
 # Self-documenting help target copied from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 # NOTE:
@@ -96,10 +99,23 @@ echo-vars: # Echo makefile variables for debugging purposes
 init: echo-vars # Initialization steps for build & other targets
 	mkdir -p ${OUTPUT_DIR}
 
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
+RELATIVE_PREFIX := $(subst $(SPACE),/,$(patsubst %,..,$(subst /, ,$(subst ${OUTPUT_DIR},,${TOOLS_BIN_DIR}))))
+
 runtime-deps: init # Download runtime binary dependencies, such as helm, helmfile, and so on, to output directory
 	env OS=${TARGET_OS} ARCH=${TARGET_ARCH} SCRATCH_DIR=${OUTPUT_DIR}/downloads TESTEXEC=${RUNTIME_DEPS_TESTEXEC} ./scripts/install-runtime-deps.sh ${RUNTIME_DEPS_BIN_DIR}
 
-build: init ## Compile thelma into output directory
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
+runtime-deps-symlink: # Create symlink from ${TOOLS_BIN_DIR} to ${RUNTIME_DEPS_BIN_DIR} so compiled thelma can find its tools
+	mkdir -p $(dir ${TOOLS_BIN_DIR})
+	# "fun" hack to compute relative path --
+	# all the gnarly pattern substitution does is add the appropriate number of
+	# "../"'s to the runtime deps directory for symlinking
+	ln -sfn $(subst $(SPACE),/,$(patsubst %,..,$(subst /,$(SPACE),$(subst ${OUTPUT_DIR},,${TOOLS_BIN_DIR}))))/${RUNTIME_DEPS_BIN_DIR} ${TOOLS_BIN_DIR}
+
+build: init runtime-deps runtime-deps-symlink ## Compile thelma into output directory
 	CGO_ENABLED=0 \
 	GO111MODULE=on \
 	GOBIN=${BIN_DIR} \

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ release: runtime-deps build ## Assemble thelma binary + runtime dependencies int
 	mkdir -p ${RELEASE_ARCHIVE_DIR}
 
     # Copy runtime dependencies into staging dir
-	mkdir -p ${RUNTIME_DEPS_BIN_DIR}/tools/bin
+	mkdir -p ${RELEASE_STAGING_DIR}/tools/bin
 	cp -r ${RUNTIME_DEPS_BIN_DIR}/. ${RELEASE_STAGING_DIR}/tools/bin
 
     # Copy compiled thelma binary into staging dir

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ release: runtime-deps build ## Assemble thelma binary + runtime dependencies int
 	mkdir -p ${RELEASE_ARCHIVE_DIR}
 
     # Copy runtime dependencies into staging dir
-	cp -r ${RUNTIME_DEPS_BIN_DIR}/. ${RELEASE_STAGING_DIR}/bin
+	mkdir -p ${RUNTIME_DEPS_BIN_DIR}/tools/bin
+	cp -r ${RUNTIME_DEPS_BIN_DIR}/. ${RELEASE_STAGING_DIR}/tools/bin
 
     # Copy compiled thelma binary into staging dir
 	cp -r ${BIN_DIR}/. ${RELEASE_STAGING_DIR}/bin

--- a/internal/thelma/app/root/releases_dir.go
+++ b/internal/thelma/app/root/releases_dir.go
@@ -1,0 +1,39 @@
+package root
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app/version"
+	"path"
+)
+
+const currentSymlink = "current"
+
+type ReleasesDir interface {
+	// Root return path of root of releases dir (~/.thelma/releases)
+	Root() string
+	// CurrentSymlink return path of current release symlink (~/.thelma/releases/current)
+	CurrentSymlink() string
+	// ForVersion return path of release dir for specific version (~/.thelma/releases/v1.2.3)
+	ForVersion(version string) string
+	// ForCurrentVersion return path of release dir for current running thelma version (~/.thelma/releases/v1.2.3)
+	ForCurrentVersion() string
+}
+
+type releasesDir struct {
+	dir string
+}
+
+func (r releasesDir) Root() string {
+	return r.dir
+}
+
+func (r releasesDir) CurrentSymlink() string {
+	return path.Join(r.dir, currentSymlink)
+}
+
+func (r releasesDir) ForVersion(version string) string {
+	return path.Join(r.dir, version)
+}
+
+func (r releasesDir) ForCurrentVersion() string {
+	return path.Join(r.dir, version.Version)
+}

--- a/internal/thelma/app/root/releases_dir_test.go
+++ b/internal/thelma/app/root/releases_dir_test.go
@@ -1,0 +1,18 @@
+package root
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app/version"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+)
+
+func TestReleasesDir(t *testing.T) {
+	dir := t.TempDir()
+	_root := New(dir)
+	_releasesDir := _root.ReleasesDir()
+	assert.Equal(t, path.Join(dir, "releases"), _releasesDir.Root())
+	assert.Equal(t, path.Join(dir, "releases", "current"), _releasesDir.CurrentSymlink())
+	assert.Equal(t, path.Join(dir, "releases", version.Version), _releasesDir.ForCurrentVersion())
+	assert.Equal(t, path.Join(dir, "releases", "blah"), _releasesDir.ForVersion("blah"))
+}

--- a/internal/thelma/app/root/root.go
+++ b/internal/thelma/app/root/root.go
@@ -3,12 +3,9 @@ package root
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/env"
-	"github.com/broadinstitute/thelma/internal/thelma/tools/helm"
-	"github.com/broadinstitute/thelma/internal/thelma/utils"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path"
-	"path/filepath"
 )
 
 //
@@ -123,38 +120,6 @@ func (r root) ToolsDir() (ToolsDir, error) {
 	return toolsDir{
 		dir: dir,
 	}, nil
-}
-
-func (r root) findToolsDirRelativeToExe() (string, error) {
-	exepath, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-
-	exepath, err = filepath.EvalSymlinks(exepath)
-	if err != nil {
-		return "", err
-	}
-
-	toolsdir := filepath.Clean(path.Join(exepath, "..", "tools", "bin"))
-
-	if err = r.validateToolsDir(toolsdir); err != nil {
-		return "", err
-	}
-	return toolsdir, nil
-}
-
-func (r root) validateToolsDir(toolsdir string) error {
-	// make sure a helm executable exists in the tools dir
-	helmpath := path.Join(toolsdir, helm.ProgName)
-	exists, err := utils.FileExists(helmpath)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("tools dir not found; %s does not exist", helmpath)
-	}
-	return nil
 }
 
 func (r root) CreateDirectories() error {

--- a/internal/thelma/app/root/tools_dir.go
+++ b/internal/thelma/app/root/tools_dir.go
@@ -1,0 +1,80 @@
+package root
+
+import (
+	"fmt"
+	"github.com/broadinstitute/thelma/internal/thelma/tools/helm"
+	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/rs/zerolog/log"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+const toolsdirname = "tools"
+const bindirname = "bin"
+
+// ToolsDir path on disk where Thelma's bundled tools, such as `kubectl`, `helm`, etc live
+type ToolsDir interface {
+	// Bin subdir within tools dir that includes tool binaries
+	Bin() string
+}
+
+type toolsDir struct {
+	dir string
+}
+
+func (t toolsDir) Bin() string {
+	return path.Join(t.dir, bindirname)
+}
+
+func findToolsDir(releasesDir ReleasesDir) (string, error) {
+	toolsdir, err := findToolsDirRelativeToThelmaExecutable()
+	if err == nil {
+		return toolsdir, nil
+	}
+
+	log.Warn().Err(err).Msgf("error identifying path to thelma executable; will search %s for bundled tools", releasesDir.Root())
+
+	toolsdir = path.Join(releasesDir.ForCurrentVersion(), toolsdirname)
+	if err = validateToolsDir(toolsdir); err != nil {
+		return "", err
+	}
+	return toolsdir, nil
+}
+
+// try to expand ../../tools relative to $0
+// we make it possible to pass in a fake path for testing
+func findToolsDirRelativeToThelmaExecutable() (string, error) {
+	// use os lib to find executable that launched the process.
+	// Note that in the real world, this should always be the THelma binary, but in
+	// tests it will be a `go test` command
+	exepath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	exepath, err = filepath.EvalSymlinks(exepath)
+	if err != nil {
+		return "", err
+	}
+
+	toolsdir := filepath.Clean(path.Join(exepath, "..", "..", toolsdirname))
+
+	if err = validateToolsDir(toolsdir); err != nil {
+		return "", err
+	}
+	return toolsdir, nil
+}
+
+func validateToolsDir(toolsdir string) error {
+	// make sure a helm executable exists in the tools dir.
+	helmexe := path.Join(toolsdir, bindirname, helm.ProgName)
+	exists, err := utils.FileExists(helmexe)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("tools dir not found; %s does not exist", helmexe)
+	}
+	return nil
+}

--- a/internal/thelma/app/root/tools_dir_test.go
+++ b/internal/thelma/app/root/tools_dir_test.go
@@ -1,0 +1,26 @@
+package root
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app/version"
+	"github.com/broadinstitute/thelma/internal/thelma/tools/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path"
+	"testing"
+)
+
+func Test_ToolsDir(t *testing.T) {
+	rootdir := t.TempDir()
+	_root := New(rootdir)
+	_, err := _root.ToolsDir()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "tools/bin/helm does not exist")
+
+	bindir := path.Join(rootdir, "releases", version.Version, "tools", "bin")
+	require.NoError(t, os.MkdirAll(bindir, 0755))
+	require.NoError(t, os.WriteFile(path.Join(bindir, helm.ProgName), []byte("#!/bin/sh\necho fake helm"), 0755))
+	_tools, err := _root.ToolsDir()
+	require.NoError(t, err)
+	assert.Equal(t, bindir, _tools.Bin())
+}

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -48,6 +48,7 @@ CMD_AUTH_FLAGS="--apple-id ${APPLE_ID} --password ${THELMA_MACOS_APP_PWD} --team
 
 # Sign one file
 sign() {
+  echo "Signing ${1}..."
 	codesign -f -o runtime,library --timestamp -s "${SECURITY_ID}" "${1}"
 }
 
@@ -163,6 +164,7 @@ notarize() {
 
 # Check the notarization status of the given file
 verify() {
+  echo "Verifying ${1}..."
 	_not_info=$(codesign -vvvv -R="notarized" --check-notarization "${1}" 2>&1)
 	if echo "${_not_info}" | tr '\n' ' ' | grep -Eq 'valid on disk.*satisfies its Designated Requirement.*explicit requirement satisfied'; then
 		echo "${1} was successfully notarized!"
@@ -184,7 +186,7 @@ tar -xf "${RELEASE_TARBALL}" -C "${untar_dir}"
 
 # Sign each binary
 echo -n "Signing binaries..."
-for bin in "${untar_dir}"/bin/*
+for bin in "${untar_dir}"/bin/* "${untar_dir}"/tools/bin/*
 do
 	sign "${bin}"
 done
@@ -204,7 +206,7 @@ notarize "$(archive "${untar_dir}")"
 #       that Apple registers the binaries as "safe" and then lets users computers
 #       do a check later when they're run....or something. This is all very opaque
 #       and the process is unclear.
-for bin in "${untar_dir}"/bin/*
+for bin in "${untar_dir}"/bin/* "${untar_dir}"/tools/bin/*
 do
 	verify "${bin}"
 done


### PR DESCRIPTION
In the release archive and Docker images, move Thelma's tools into a separate directory from the main thelma binary.

Th is allows developers to have Thelma on PATH without shadowing existing local installations of Helm, Kubectl, etc.