### PR TITLE
[DDO-2669] Continue applying schedule even if a BEE errors

### DIFF
--- a/internal/thelma/cli/commands/bees/apply_schedule/apply_schedule_command.go
+++ b/internal/thelma/cli/commands/bees/apply_schedule/apply_schedule_command.go
@@ -184,6 +184,7 @@ func (cmd *command) Run(app app.ThelmaApp, rc cli.RunContext) error {
 					log.Info().Msgf("Syncing %s", env.Name())
 					_, err := bees.SyncArgoAppsIn(env, func(options *argocd.SyncOptions) {
 						options.SkipLegacyConfigsRestart = true
+						options.WaitHealthy = false
 					})
 					if err != nil {
 						return err

--- a/internal/thelma/cli/commands/bees/apply_schedule/apply_schedule_command.go
+++ b/internal/thelma/cli/commands/bees/apply_schedule/apply_schedule_command.go
@@ -206,6 +206,7 @@ func (cmd *command) Run(app app.ThelmaApp, rc cli.RunContext) error {
 		o.Summarizer.Enabled = true
 		o.Metrics.Enabled = !cmd.options.dryRun // When dry-running, don't report metrics!
 		o.Metrics.PoolName = "bees_apply_schedule"
+		o.StopProcessingOnError = false
 	}).Execute()
 
 	if err != nil {


### PR DESCRIPTION
So the schedule screwed up because some BEEs are in a broken state. It stopped some but not all. I suspect it will start some but not all in the morning.

This PR tackles that issue in two ways:
- First, don't exit if there was an error applying the schedule for one of the BEEs. I didn't realize this wasn't the default for pool, my bad.
- Second, don't wait for the BEEs to be healthy because we kinda don't care. We care about them being synced; I don't think we want this job throwing errors if a dev leaves their BEE in a broken state at the end of the day.