### PR TITLE
[DDO-2683] Minor logging adjustments

### DIFF
--- a/internal/thelma/app/autoupdate/bootstrap/welcome_test.go
+++ b/internal/thelma/app/autoupdate/bootstrap/welcome_test.go
@@ -6,10 +6,6 @@ import (
 	"testing"
 )
 
-func Test_Welcome(t *testing.T) {
-
-}
-
 func Test_computeTerminalWidth(t *testing.T) {
 	testCases := []struct {
 		input    int

--- a/internal/thelma/app/logging/logging.go
+++ b/internal/thelma/app/logging/logging.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"time"
 )
 
 const logFile = "thelma.log"
@@ -144,8 +145,13 @@ func newConsoleWriter(cfg *logConfig, consoleStream io.Writer) zerolog.LevelWrit
 	if cfg.Console.WordWrap {
 		outputStream = NewWrappingWriter(consoleStream, func(options *wordwrap.Options) {
 			options.DynamicMaxWidth = true
-			options.Padding = "           "
 			options.EscapeNewlineStringLiteral = true
+
+			// try to match the width of zero-log's preconfigured date formatter
+			options.Padding = "           "
+			if time.Now().Hour()%12 >= 10 {
+				options.Padding += " "
+			}
 		})
 	}
 

--- a/internal/thelma/app/logging/logging_test.go
+++ b/internal/thelma/app/logging/logging_test.go
@@ -187,7 +187,7 @@ func Test_newLogger(t *testing.T) {
 
 				jsonLog, err := os.ReadFile(r.logFile)
 				require.NoError(t, err)
-				assert.Regexp(t, `{"level":"info","key1":"\*\*\*\*\*\*","key2":"extra \*\*\*\*\*\* stuff","time":".*","message":"Hello \*\*\*\*\*\*"}`, string(jsonLog))
+				assert.Regexp(t, `{"level":"info","pid":\d+,"key1":"\*\*\*\*\*\*","key2":"extra \*\*\*\*\*\* stuff","time":".*","message":"Hello \*\*\*\*\*\*"}`, string(jsonLog))
 			},
 		},
 	}
@@ -241,7 +241,7 @@ func Test_newLogger(t *testing.T) {
 	}
 }
 
-func Test_ConsoleFormatter(t *testing.T) {
+func Test_ConsoleTimeFormat(t *testing.T) {
 	testCases := []struct {
 		input    string
 		expected string

--- a/internal/thelma/utils/wordwrap/wordwrap_test.go
+++ b/internal/thelma/utils/wordwrap/wordwrap_test.go
@@ -380,6 +380,19 @@ VAR3=yet-another-long-string \
 			padding:  "      ",
 			expected: "long word\n      occursatendofstring\n",
 		},
+		{
+			name:     "should correctly wrap emoji",
+			maxWidth: 10,
+			input:    "🦄🦄🦄 a 👹 b 🎏c🎏d🎏 e 🦜f🦜g🦜h🦜i🦜j🦜k ⚠️ ☣️ l m 💯 💯 🚽 🧻",
+			padding:  "🍜🍜🍜🍜",
+			expected: `🦄🦄🦄 a 👹 b
+🍜🍜🍜🍜🎏c🎏d🎏
+🍜🍜🍜🍜e
+🍜🍜🍜🍜🦜f🦜g🦜h🦜i🦜j🦜k
+🍜🍜🍜🍜⚠️ ☣️
+🍜🍜🍜🍜l m 💯
+🍜🍜🍜🍜💯 🚽 🧻`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Small misc PR I forgot to push earlier this week.
* Fix an issue where word-wrapped console logs are misaligned if the current 12-hour time begins with a single digit.
* Add `pid` to Thelma's debug logs, so it's easier to distinguish between individual Thelma runs
* Add a testcase to the wordwrap package that includes emoji