### PR TITLE
Add Azure Kubelogin Kubectl Plugin To Runtime Deps

### DIFF
--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -13,6 +13,7 @@ HELM_DOCS_VERSION=1.5.0
 ARGOCD_VERSION=2.5.3
 KUBECTL_VERSION=1.24.0
 KUBECONFORM_VERSION=0.5.0
+KUBELOGIN_VERSION='v0.0.27'
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
@@ -147,6 +148,16 @@ install_kubectl() {
     mv ./kubectl "${INSTALL_DIR}/kubectl"
 }
 
+install_kubelogin() {
+  URL="https://github.com/Azure/kubelogin/releases/download/${KUBELOGIN_VERSION}/kubelogin-${OS}-${ARCH}.zip"
+  echo "Downloading kubelogin from ${URL}"
+  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - |\
+    tar -xz --strip-components=2 "bin/${OS}_${ARCH}/kubelogin" && 
+    chmod +x ./kubelogin && \
+    testexec ./kubelogin --version && \
+    mv ./kubelogin "${INSTALL_DIR}/kubelogin"
+}
+
 install_kubeconform() {
   URL="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-${OS}-${ARCH}.tar.gz"
   echo "Downloading kubeconform from ${URL}"
@@ -209,6 +220,14 @@ fi
 if [[ ! -f "${INSTALL_DIR}/kubectl" ]]; then
   if ! install_kubectl; then
     echo "kubectl install failed!" >&2
+    exit 1
+  fi
+fi
+
+# Install kubelogin
+if [[ ! -f "${INSTALL_DIR}/kubelogin" ]]; then
+  if ! install_kubelogin; then
+    echo "kubelogin install failed!" >&2
     exit 1
   fi
 fi

--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -151,11 +151,11 @@ install_kubectl() {
 install_kubelogin() {
   URL="https://github.com/Azure/kubelogin/releases/download/${KUBELOGIN_VERSION}/kubelogin-${OS}-${ARCH}.zip"
   echo "Downloading kubelogin from ${URL}"
-  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - |\
-    bsdtar -xz --strip-components=2 "bin/${OS}_${ARCH}/kubelogin" && 
-    chmod +x ./kubelogin && \
-    testexec ./kubelogin --version && \
-    mv ./kubelogin "${INSTALL_DIR}/kubelogin"
+  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O ./kubelogin.zip && \
+    unzip -qo kubelogin && \
+    chmod +x "./bin/${OS}_${ARCH}/kubelogin" && 
+    testexec "./bin/${OS}_${ARCH}/kubelogin" --version && \
+    mv "./bin/${OS}_${ARCH}/kubelogin" "${INSTALL_DIR}/kubelogin"
 }
 
 install_kubeconform() {

--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -152,7 +152,7 @@ install_kubelogin() {
   URL="https://github.com/Azure/kubelogin/releases/download/${KUBELOGIN_VERSION}/kubelogin-${OS}-${ARCH}.zip"
   echo "Downloading kubelogin from ${URL}"
   wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - |\
-    tar -xz --strip-components=2 "bin/${OS}_${ARCH}/kubelogin" && 
+    bsdtar -xz --strip-components=2 "bin/${OS}_${ARCH}/kubelogin" && 
     chmod +x ./kubelogin && \
     testexec ./kubelogin --version && \
     mv ./kubelogin "${INSTALL_DIR}/kubelogin"


### PR DESCRIPTION
I'm starting to do some experimentation with having thelma talk to azure k8s clusters related to new service spin up projects. Connecting to the k8s api using user identities in Azure requires [this kubectl plugin](https://github.com/Azure/kubelogin/) (similar to how gke also requires one).

This will also be needed for the azure implementation of `sql connect` when we are ready for that.

Unfortunately the release for the plugin are published as zip archive rather than a tarball :(