### PR TITLE
[DDO-2699] Utilities/library changes for thelma sql connect

### DIFF
--- a/internal/thelma/app/seed/seed.go
+++ b/internal/thelma/app/seed/seed.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Rand seeds the math/rand package's pseudo random number generator
-// Via stack overflow: https://stackoverflow.com/questions/12321133/how-to-properly-seed-random-number-generator
+// Via stack overflow: https://stackoverflow.com/a/54491783
 func Rand() {
 	var seed [8]byte
 	_, err := cryptorand.Read(seed[:])

--- a/internal/thelma/utils/pwgen/pwgen.go
+++ b/internal/thelma/utils/pwgen/pwgen.go
@@ -2,16 +2,13 @@ package pwgen
 
 import (
 	"github.com/broadinstitute/thelma/internal/thelma/app/logging"
-	"github.com/broadinstitute/thelma/internal/thelma/app/seed"
 	"math/rand"
 )
 
 const defaultLength = 24
 const absoluteMinimumLength = 8
 
-func init() {
-	seed.Rand()
-}
+var r = rand.New(&source{})
 
 var lower = []rune(`abcdefghijklmnopqrstuvwxyz`)
 var upper = []rune(`ABCDEFGHIJKLMNOPQRSTUVWXYZ`)
@@ -78,7 +75,7 @@ func (p Pwgen) Generate() string {
 		buf[i] = pick(all)
 	}
 
-	rand.Shuffle(n, func(a, b int) {
+	r.Shuffle(n, func(a, b int) {
 		buf[a], buf[b] = buf[b], buf[a]
 	})
 
@@ -88,5 +85,5 @@ func (p Pwgen) Generate() string {
 }
 
 func pick(from []rune) rune {
-	return from[rand.Intn(len(from))]
+	return from[r.Intn(len(from))]
 }

--- a/internal/thelma/utils/pwgen/pwgen.go
+++ b/internal/thelma/utils/pwgen/pwgen.go
@@ -1,0 +1,92 @@
+package pwgen
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app/logging"
+	"github.com/broadinstitute/thelma/internal/thelma/app/seed"
+	"math/rand"
+)
+
+const defaultLength = 24
+const absoluteMinimumLength = 8
+
+func init() {
+	seed.Rand()
+}
+
+var lower = []rune(`abcdefghijklmnopqrstuvwxyz`)
+var upper = []rune(`ABCDEFGHIJKLMNOPQRSTUVWXYZ`)
+var num = []rune(`1234567890`)
+var special = []rune(`!@#$%^&*()_-+={}[]/\<>.,;?:|'"`)
+
+var all = func() []rune {
+	var a []rune
+	a = append(a, lower...)
+	a = append(a, upper...)
+	a = append(a, num...)
+	a = append(a, special...)
+	return a
+}()
+
+type Pwgen struct {
+	MinLength  int
+	MinLower   int
+	MinUpper   int
+	MinNum     int
+	MinSpecial int
+}
+
+func (p Pwgen) Generate() string {
+	l := p.MinLength
+	if l <= 0 {
+		l = defaultLength
+	}
+	if l < absoluteMinimumLength {
+		l = absoluteMinimumLength
+	}
+
+	minChars := p.MinLower + p.MinUpper + p.MinNum + p.MinSpecial
+	if l < minChars {
+		l = minChars
+	}
+
+	buf := make([]rune, l)
+
+	i := 0
+
+	n := p.MinLower
+	for ; i < n; i++ {
+		buf[i] = pick(lower)
+	}
+
+	n += p.MinUpper
+	for ; i < n; i++ {
+		buf[i] = pick(upper)
+	}
+
+	n += p.MinNum
+	for ; i < n; i++ {
+		buf[i] = pick(num)
+	}
+
+	n += p.MinSpecial
+	for ; i < n; i++ {
+		buf[i] = pick(special)
+	}
+
+	n = l
+	for ; i < n; i++ {
+		buf[i] = pick(all)
+	}
+
+	rand.Shuffle(n, func(a, b int) {
+		buf[a], buf[b] = buf[b], buf[a]
+	})
+
+	password := string(buf)
+	logging.MaskSecret(password)
+	return password
+}
+
+func pick(from []rune) rune {
+	return from[rand.Intn(len(from))]
+}

--- a/internal/thelma/utils/pwgen/pwgen_test.go
+++ b/internal/thelma/utils/pwgen/pwgen_test.go
@@ -33,6 +33,31 @@ func Test_Pwgen(t *testing.T) {
 			len: absoluteMinimumLength + 10,
 		},
 		{
+			name: "length increased min char requirements exceed",
+			pwgen: Pwgen{
+				MinLength:  8,
+				MinLower:   16,
+				MinUpper:   16,
+				MinNum:     16,
+				MinSpecial: 16,
+			},
+			len: 64,
+		},
+		{
+			name: "all lower",
+			pwgen: Pwgen{
+				MinLength: 9,
+				MinLower:  9,
+			},
+			minCounts: counts{
+				lower:   9,
+				upper:   0,
+				num:     0,
+				special: 0,
+			},
+			len: 9,
+		},
+		{
 			name: "all upper",
 			pwgen: Pwgen{
 				MinLength: 12,

--- a/internal/thelma/utils/pwgen/pwgen_test.go
+++ b/internal/thelma/utils/pwgen/pwgen_test.go
@@ -1,0 +1,167 @@
+package pwgen
+
+import (
+	"fmt"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Pwgen(t *testing.T) {
+	testCases := []struct {
+		name      string
+		pwgen     Pwgen
+		minCounts counts
+		len       int
+	}{
+		{
+			name: "length 0",
+			len:  defaultLength,
+		},
+		{
+			name: "length rounded up to absolute min",
+			pwgen: Pwgen{
+				MinLength: 2,
+			},
+			len: absoluteMinimumLength,
+		},
+		{
+			name: "length respected if greater than absolute min",
+			pwgen: Pwgen{
+				MinLength: absoluteMinimumLength + 10,
+			},
+			len: absoluteMinimumLength + 10,
+		},
+		{
+			name: "all upper",
+			pwgen: Pwgen{
+				MinLength: 12,
+				MinUpper:  12,
+			},
+			minCounts: counts{
+				lower:   0,
+				upper:   12,
+				num:     0,
+				special: 0,
+			},
+			len: 12,
+		},
+		{
+			name: "all num",
+			pwgen: Pwgen{
+				MinLength: 20,
+				MinNum:    20,
+			},
+			minCounts: counts{
+				lower:   0,
+				upper:   0,
+				num:     20,
+				special: 0,
+			},
+			len: 20,
+		},
+		{
+			name: "all special",
+			pwgen: Pwgen{
+				MinLength:  47,
+				MinSpecial: 47,
+			},
+			minCounts: counts{
+				lower:   0,
+				upper:   0,
+				num:     0,
+				special: 47,
+			},
+			len: 47,
+		},
+		{
+			name: "mixed",
+			pwgen: Pwgen{
+				MinLength:  32,
+				MinLower:   6,
+				MinUpper:   7,
+				MinNum:     9,
+				MinSpecial: 10,
+			},
+			minCounts: counts{
+				lower:   6,
+				upper:   7,
+				num:     9,
+				special: 10,
+			},
+			len: 32,
+		},
+		{
+			name: "mixed with room for random chars",
+			pwgen: Pwgen{
+				MinLength:  12,
+				MinLower:   1,
+				MinUpper:   1,
+				MinNum:     1,
+				MinSpecial: 1,
+			},
+			minCounts: counts{
+				lower:   1,
+				upper:   1,
+				num:     1,
+				special: 1,
+			},
+			len: 12,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pass := tc.pwgen.Generate()
+
+			c := countKinds(pass)
+
+			assert.LessOrEqualf(t, tc.minCounts.lower, c.lower, "expect >= %d lowercase chars, have %d (%q)", tc.minCounts.lower, c.lower, pass)
+			assert.LessOrEqual(t, tc.minCounts.upper, c.upper, "expect >= %d uppercase chars, have %d (%q)", tc.minCounts.upper, c.upper, pass)
+			assert.LessOrEqual(t, tc.minCounts.num, c.num, "expect >= %d numeric chars, have %d (%q)", tc.minCounts.num, c.num, pass)
+			assert.LessOrEqual(t, tc.minCounts.special, c.special, "expect >= %d special chars, have %d (%q)", tc.minCounts.special, c.special, pass)
+			assert.Equal(t, tc.len, len(pass))
+		})
+	}
+}
+
+type counts struct {
+	lower   int
+	upper   int
+	num     int
+	special int
+}
+
+type runeSets struct {
+	lower   set.Set[rune]
+	upper   set.Set[rune]
+	num     set.Set[rune]
+	special set.Set[rune]
+}
+
+var rs = func() runeSets {
+	var s runeSets
+	s.lower = set.NewSet(lower...)
+	s.upper = set.NewSet(upper...)
+	s.num = set.NewSet(num...)
+	s.special = set.NewSet(special...)
+	return s
+}()
+
+func countKinds(s string) counts {
+	var c counts
+	for _, r := range s {
+		if rs.lower.Exists(r) {
+			c.lower++
+		} else if rs.upper.Exists(r) {
+			c.upper++
+		} else if rs.num.Exists(r) {
+			c.num++
+		} else if rs.special.Exists(r) {
+			c.special++
+		} else {
+			panic(fmt.Errorf("unrecognized character: %c", r))
+		}
+	}
+
+	return c
+}

--- a/internal/thelma/utils/pwgen/source.go
+++ b/internal/thelma/utils/pwgen/source.go
@@ -1,0 +1,34 @@
+package pwgen
+
+import (
+	crypto "crypto/rand"
+	"encoding/binary"
+	"fmt"
+)
+
+// Provide a cryptographic rand source - pulled from a PR to go standard lib
+// https://github.com/golang/go/issues/25531
+
+type reader struct{}
+
+func (r *reader) Read(p []byte) (n int, err error) {
+	return crypto.Read(p)
+}
+
+// random source that relies on crypto/rand
+type source struct{}
+
+func (s *source) Int63() (random int64) {
+	err := binary.Read(&reader{}, binary.BigEndian, &random)
+	if err != nil {
+		panic(fmt.Sprintf("converting random bytes to an int64: %s", err.Error()))
+	}
+	if random < 0 {
+		random = -random
+	}
+	return random
+}
+
+func (s *source) Seed(_ int64) {
+	panic("you cannot seed the cryptographic source")
+}

--- a/internal/thelma/utils/set/set.go
+++ b/internal/thelma/utils/set/set.go
@@ -1,0 +1,85 @@
+package set
+
+type Set[K comparable] interface {
+	// Add adds the element(s) to the set
+	Add(elements ...K)
+	// Remove removes the element(s) from the set, if they are included
+	Remove(elements ...K)
+	// Exists returns true if the element exists in the set
+	Exists(element K) bool
+	// Elements returns the elements of the set as a slice of strings
+	Elements() []K
+	// Difference returns a new set containing the elements that are in this set but not in s
+	Difference(s Set[K]) Set[K]
+	// Size returns the size of the set
+	Size() int
+	// Empty returns true if this set is empty
+	Empty() bool
+}
+
+type set[K comparable] struct {
+	set map[K]interface{}
+}
+
+// NewSet returns a new Set for the given comparable type
+func NewSet[K comparable](elements ...K) Set[K] {
+	s := &set[K]{
+		set: make(map[K]interface{}),
+	}
+	s.Add(elements...)
+	return s
+}
+
+// Add adds the element(s) to the set
+func (s *set[K]) Add(elements ...K) {
+	for _, e := range elements {
+		s.set[e] = struct{}{}
+	}
+}
+
+// Remove removes the element(s) from the set, if they are included
+func (s *set[K]) Remove(elements ...K) {
+	for _, e := range elements {
+		delete(s.set, e)
+	}
+}
+
+// Exists returns true if the element exists in the set
+func (s *set[K]) Exists(element K) bool {
+	_, exists := s.set[element]
+	return exists
+}
+
+// Difference returns a new set containing the elements that are in this set but not in other
+func (s *set[K]) Difference(other Set[K]) Set[K] {
+	diff := NewSet[K]()
+	for e := range s.set {
+		if !other.Exists(e) {
+			diff.Add(e)
+		}
+	}
+	return diff
+}
+
+// Elements returns the elements of the set as a slice of strings
+func (s *set[K]) Elements() []K {
+	elements := make([]K, s.Size())
+
+	i := 0
+	for e := range s.set {
+		elements[i] = e
+		i++
+	}
+
+	return elements
+}
+
+// Size returns the size of the set
+func (s *set[K]) Size() int {
+	return len(s.set)
+}
+
+// Empty returns true if the set is empty
+func (s *set[K]) Empty() bool {
+	return s.Size() == 0
+}

--- a/internal/thelma/utils/set/set_test.go
+++ b/internal/thelma/utils/set/set_test.go
@@ -1,0 +1,90 @@
+package set
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sort"
+	"testing"
+)
+
+func TestSet_BasicOperations(t *testing.T) {
+	s := NewSet("a", "a", "b")
+	assert.False(t, s.Empty())
+	assert.Equal(t, 2, s.Size())
+	assert.True(t, s.Exists("a"))
+	assert.True(t, s.Exists("b"))
+
+	elts := s.Elements()
+	sort.Strings(elts)
+	assert.Equal(t, []string{"a", "b"}, elts)
+
+	// add 2 new elements
+	s.Add("c", "a", "d", "b", "b", "d")
+	assert.Equal(t, 4, s.Size())
+	assert.True(t, s.Exists("c"))
+	assert.True(t, s.Exists("d"))
+
+	elts = s.Elements()
+	sort.Strings(elts)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, elts)
+
+	// remove elements
+	s.Remove("a", "z")
+	assert.Equal(t, 3, s.Size())
+	assert.False(t, s.Exists("a"))
+	assert.True(t, s.Exists("b"))
+	assert.True(t, s.Exists("c"))
+	assert.True(t, s.Exists("d"))
+
+	elts = s.Elements()
+	sort.Strings(elts)
+	assert.Equal(t, []string{"b", "c", "d"}, elts)
+
+}
+
+func TestSet_Difference(t *testing.T) {
+	testCases := []struct {
+		name     string
+		set      []string
+		diff     []string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			expected: []string{},
+		},
+		{
+			name:     "one elt",
+			set:      []string{"a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "one elt in dff",
+			set:      []string{"a"},
+			diff:     []string{"a"},
+			expected: []string{},
+		},
+		{
+			name:     "extra elt",
+			set:      []string{"a"},
+			diff:     []string{"a", "b"},
+			expected: []string{},
+		},
+		{
+			name:     "complex",
+			set:      []string{"a", "b", "c", "d"},
+			diff:     []string{"a", "c", "e", "f"},
+			expected: []string{"b", "d"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSet(tc.set...)
+			diff := NewSet(tc.diff...)
+
+			result := s.Difference(diff).Elements()
+			sort.Strings(result)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/thelma/utils/utils.go
+++ b/internal/thelma/utils/utils.go
@@ -157,3 +157,27 @@ func Not[T any](fn func(T) bool) func(T) bool {
 		return !fn(t)
 	}
 }
+
+func MapValues[K comparable, V any](m map[K]V) []V {
+	var vs []V
+	for _, v := range m {
+		vs = append(vs, v)
+	}
+	return vs
+}
+
+func MapValuesFlattened[K comparable, V any](m map[K][]V) []V {
+	var vs []V
+	for _, v := range m {
+		vs = append(vs, v...)
+	}
+	return vs
+}
+
+func MapKeys[K comparable, V any](m map[K]V) []K {
+	var ks []K
+	for k, _ := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/internal/thelma/utils/utils.go
+++ b/internal/thelma/utils/utils.go
@@ -176,7 +176,7 @@ func MapValuesFlattened[K comparable, V any](m map[K][]V) []V {
 
 func MapKeys[K comparable, V any](m map[K]V) []K {
 	var ks []K
-	for k, _ := range m {
+	for k := range m {
 		ks = append(ks, k)
 	}
 	return ks

--- a/internal/thelma/utils/utils_test.go
+++ b/internal/thelma/utils/utils_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sort"
+	"testing"
+)
+
+func Test_Not(t *testing.T) {
+	isEven := func(n int) bool {
+		return n%2 == 0
+	}
+
+	assert.False(t, Not(isEven)(0))
+	assert.True(t, Not(isEven)(1))
+	assert.False(t, Not(isEven)(2))
+}
+
+func Test_MapValues(t *testing.T) {
+	input := map[string]string{
+		"1": "a",
+		"2": "b",
+		"3": "c",
+	}
+	expected := []string{"a", "b", "c"}
+	actual := MapValues(input)
+	sort.Strings(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_MapValuesFlattened(t *testing.T) {
+	input := map[string][]string{
+		"1": {"a", "a", "a"},
+		"2": {"b"},
+		"3": {"c", "c"},
+	}
+	expected := []string{"a", "a", "a", "b", "c", "c"}
+	actual := MapValuesFlattened(input)
+	sort.Strings(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_MapKeys(t *testing.T) {
+	input := map[string]string{
+		"1": "a",
+		"2": "b",
+		"3": "c",
+	}
+	expected := []string{"1", "2", "3"}
+	actual := MapKeys(input)
+	sort.Strings(actual)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
`utils`:
* Add generic `set` implementation (previously only supported strings)
* Password generation
* Add a few generic functions for converting map keys and values into slices

`logging`:
* When masking secrets, also mask the escaped versions of secrets. Else, secrets like passwords that have special characters like `\` and `"` can be leaked in logs (because zerolog messages are JSON objects).