### PR TITLE
[DDO-2779] bugfix: reload state after version pinning

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -441,6 +441,10 @@ func (b *bees) PinVersions(bee terra.Environment, pinOptions PinOptions) (terra.
 
 	log.Info().Msgf("Updated version overrides for %s", bee.Name())
 
+	// reload state since we mutated an environment
+	if err := b.reloadState(); err != nil {
+		return nil, err
+	}
 	// return a refreshed/updated bee environment object that includes the version overrides
 	return b.state.Environments().Get(bee.Name())
 }

--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -32,7 +32,7 @@ type Bees interface {
 	GetTemplate(templateName string) (terra.Environment, error)
 	Seeder() seed.Seeder
 	FilterBees(filter terra.EnvironmentFilter) ([]terra.Environment, error)
-	PinVersions(bee terra.Environment, overrides PinOptions) error
+	PinVersions(bee terra.Environment, overrides PinOptions) (terra.Environment, error)
 	UnpinVersions(bee terra.Environment) error
 	SyncEnvironmentGenerator(env terra.Environment) error
 	SyncArgoAppsIn(env terra.Environment, options ...argocd.SyncOption) (map[terra.Release]*status.Status, error)
@@ -160,9 +160,11 @@ func (b *bees) ProvisionWith(name string, options ProvisionOptions) (*Bee, error
 		return bee, err
 	}
 
-	if err = b.PinVersions(env, options.PinOptions); err != nil {
+	env, err = b.PinVersions(env, options.PinOptions)
+	if err != nil {
 		return bee, err
 	}
+	bee.Environment = env
 
 	if err = b.RefreshBeeGenerator(); err != nil {
 		return bee, err
@@ -392,12 +394,12 @@ func (b *bees) RefreshBeeGenerator() error {
 	return b.argocd.HardRefresh(generatorArgoApp)
 }
 
-func (b *bees) PinVersions(bee terra.Environment, pinOptions PinOptions) error {
+func (b *bees) PinVersions(bee terra.Environment, pinOptions PinOptions) (terra.Environment, error) {
 	// pin global terra-helmfile ref, if one is specified
 	if pinOptions.Flags.TerraHelmfileRef != "" {
 		was := bee.TerraHelmfileRef()
 		if err := b.state.Environments().PinEnvironmentToTerraHelmfileRef(bee.Name(), pinOptions.Flags.TerraHelmfileRef); err != nil {
-			return err
+			return nil, err
 		}
 		log.Info().Msgf("Set terra-helmfile ref to %s for %s (was: %s)", bee.Name(), pinOptions.Flags.TerraHelmfileRef, was)
 	}
@@ -427,18 +429,20 @@ func (b *bees) PinVersions(bee terra.Environment, pinOptions PinOptions) error {
 	}
 	releaseOverridesJson, err := json.Marshal(releaseOverrides)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	log.Debug().Bytes("overrides", releaseOverridesJson).Msgf("Updating release version overrides for %s", bee.Name())
 
 	_, err = b.state.Environments().PinVersions(bee.Name(), releaseOverrides)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	log.Info().Msgf("Updated version overrides for %s", bee.Name())
-	return nil
+
+	// return a refreshed/updated bee environment object that includes the version overrides
+	return b.state.Environments().Get(bee.Name())
 }
 
 func (b *bees) UnpinVersions(bee terra.Environment) error {
@@ -526,6 +530,7 @@ func (b *bees) templateNames() ([]string, error) {
 }
 
 func (b *bees) reloadState() error {
+	log.Debug().Msgf("reloading state from Sherlock...")
 	state, err := b.stateLoader.Reload()
 	if err != nil {
 		return err

--- a/internal/thelma/cli/commands/bee/pin/pin_command.go
+++ b/internal/thelma/cli/commands/bee/pin/pin_command.go
@@ -126,7 +126,8 @@ func (cmd *pinCommand) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 		return err
 	}
 
-	if err = bees.PinVersions(env, pinOptions); err != nil {
+	env, err = bees.PinVersions(env, pinOptions)
+	if err != nil {
 		return err
 	}
 	ctx.SetOutput(pinOptions)


### PR DESCRIPTION
Lots of context in [this slack thread](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1681408772749069), but basically there is a bug in thelma where PR branch version pins supplied to `thelma bee create` don't stick.

Thanks to @em-may for the report!

Tested by creating a bee locally, the correct settings are propagating now.
