### PR TITLE
[DDO-2816] Don't rerun `helm dependency update` on dependencies

### DIFF
--- a/internal/thelma/render/resolver/cache.go
+++ b/internal/thelma/render/resolver/cache.go
@@ -63,6 +63,7 @@ func newSyncCacheWithMapper[R any](resolver resolver[R], keyMapper keyMapper[R])
 	}
 }
 
+//nolint:unused
 func (c *syncCacheImpl[R]) get(resolvable R) (ResolvedChart, error) {
 	key := c.keyMapper(resolvable)
 	_entry := c.getEntry(key)
@@ -70,6 +71,7 @@ func (c *syncCacheImpl[R]) get(resolvable R) (ResolvedChart, error) {
 	return _entry.getValue(resolvable, c.resolver)
 }
 
+//nolint:unused
 func (c *syncCacheImpl[R]) getEntry(key string) *entry[R] {
 	// get a read lock so we can safely read from the map
 	c.globalMutex.RLock()
@@ -91,6 +93,8 @@ func (c *syncCacheImpl[R]) getEntry(key string) *entry[R] {
 }
 
 // Represents an entry in the cache
+//
+//nolint:unused
 type entry[R any] struct {
 	initialized   bool
 	mutex         sync.RWMutex
@@ -99,6 +103,8 @@ type entry[R any] struct {
 }
 
 // Returns the cached value for a given entry
+//
+//nolint:unused
 func (e *entry[R]) getValue(resolvable R, resolver resolver[R]) (ResolvedChart, error) {
 	// Obtain a read lock
 	// if we've been initialized already, return the cached values

--- a/internal/thelma/render/resolver/cache.go
+++ b/internal/thelma/render/resolver/cache.go
@@ -9,22 +9,29 @@ import (
 const defaultCacheKeySeparator = " " // URLs can't have whitespace, so this won't show up
 // in Helm repo and chart names, or in chart version strings
 
-// Synchronized cache is a concurrent-safe cache for ResolvedCharts.
-// It guarantees that the chart resolver function will only be called once for a given cache key.
-type syncCache interface {
-	get(chartRelease ChartRelease, resolver resolverFn) (ResolvedChart, error)
+// syncCache is a concurrent-safe cache for ResolvedCharts. Guarantees a chart won't be resolved multiple times.
+//
+// The important complexity here is that different resolvers want to resolve charts from different input:
+//   - remoteResolver, for instance, wants the cache to operate per ChartRelease.
+//   - localResolver, by contrast, wants the cache to operate per on-disk Chart, regardless of what environment it is
+//     being released to.
+//
+// syncCache is generic on the input type so that it can accomplish either case with the same important mutex/locking
+// behavior.
+type syncCache[R any] interface {
+	get(resolvable R) (ResolvedChart, error)
 }
 
-// Maps chart releases to cache keys.
-// This is useful because the local chart resolver, for example, ignores chart versions
-// when resolving charts.
-type keyMapper func(chartRelease ChartRelease) string
+// keyMapper determines how syncCache should resolve the resolvable input to a cache key.
+// In other words, this determines when syncCache will actually call resolver on the resolvable versus getting a
+// cache hit.
+type keyMapper[R any] func(resolvable R) string
 
-// Function the cache should use for resolving a chart release.
-type resolverFn func(chartRelease ChartRelease) (ResolvedChart, error)
+// resolver is responsible for converting an (uncached) resolvable to a ResolvedChart.
+type resolver[R any] func(resolvable R) (ResolvedChart, error)
 
-// Default key mapper factors all fields of ChartRelease into a unique key
-func defaultCacheKeyMapper(chartRelease ChartRelease) string {
+// chartReleaseKeyMapper is the default keyMapper for a syncCache of ChartRelease (the usual case)
+func chartReleaseKeyMapper(chartRelease ChartRelease) string {
 	return strings.Join(
 		[]string{
 			chartRelease.Repo,
@@ -35,33 +42,35 @@ func defaultCacheKeyMapper(chartRelease ChartRelease) string {
 	)
 }
 
-type syncCacheImpl struct {
+type syncCacheImpl[R any] struct {
 	globalMutex sync.RWMutex
-	keyMapper   keyMapper
-	cache       map[string]*entry
+	keyMapper   keyMapper[R]
+	resolver    resolver[R]
+	cache       map[string]*entry[R]
 }
 
 // Returns a new syncCache instance
-func newSyncCache() syncCache {
-	return newSyncCacheWithMapper(defaultCacheKeyMapper)
+func newSyncCache(resolver resolver[ChartRelease]) syncCache[ChartRelease] {
+	return newSyncCacheWithMapper(resolver, chartReleaseKeyMapper)
 }
 
-func newSyncCacheWithMapper(keyMapper func(ChartRelease) string) syncCache {
-	return &syncCacheImpl{
+func newSyncCacheWithMapper[R any](resolver resolver[R], keyMapper keyMapper[R]) syncCache[R] {
+	return &syncCacheImpl[R]{
 		globalMutex: sync.RWMutex{},
 		keyMapper:   keyMapper,
-		cache:       make(map[string]*entry),
+		resolver:    resolver,
+		cache:       make(map[string]*entry[R]),
 	}
 }
 
-func (c *syncCacheImpl) get(chartRelease ChartRelease, resolver resolverFn) (ResolvedChart, error) {
-	key := c.keyMapper(chartRelease)
+func (c *syncCacheImpl[R]) get(resolvable R) (ResolvedChart, error) {
+	key := c.keyMapper(resolvable)
 	_entry := c.getEntry(key)
 
-	return _entry.getValue(chartRelease, resolver)
+	return _entry.getValue(resolvable, c.resolver)
 }
 
-func (c *syncCacheImpl) getEntry(key string) *entry {
+func (c *syncCacheImpl[R]) getEntry(key string) *entry[R] {
 	// get a read lock so we can safely read from the map
 	c.globalMutex.RLock()
 	_entry, exists := c.cache[key]
@@ -75,14 +84,14 @@ func (c *syncCacheImpl) getEntry(key string) *entry {
 	c.globalMutex.Lock()
 	defer c.globalMutex.Unlock()
 
-	_entry = &entry{}
+	_entry = &entry[R]{}
 	c.cache[key] = _entry
 
 	return _entry
 }
 
 // Represents an entry in the cache
-type entry struct {
+type entry[R any] struct {
 	initialized   bool
 	mutex         sync.RWMutex
 	resolvedChart ResolvedChart
@@ -90,7 +99,7 @@ type entry struct {
 }
 
 // Returns the cached value for a given entry
-func (e *entry) getValue(chartRelease ChartRelease, resolver resolverFn) (ResolvedChart, error) {
+func (e *entry[R]) getValue(resolvable R, resolver resolver[R]) (ResolvedChart, error) {
 	// Obtain a read lock
 	// if we've been initialized already, return the cached values
 	e.mutex.RLock()
@@ -105,7 +114,7 @@ func (e *entry) getValue(chartRelease ChartRelease, resolver resolverFn) (Resolv
 	defer e.mutex.Unlock()
 
 	// generate the values
-	rc, err := resolver(chartRelease)
+	rc, err := resolver(resolvable)
 
 	// save them & mark this entry as initialized
 	e.resolvedChart = rc

--- a/internal/thelma/render/resolver/resolved_chart.go
+++ b/internal/thelma/render/resolver/resolved_chart.go
@@ -1,96 +1,86 @@
 package resolver
 
 import (
-	"fmt"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-type ResolutionType int
-
-const (
-	Local  ResolutionType = iota // Indicates matching chart was found on local filesystem
-	Remote                       // Indicates matching chart was found in Helm repo
-)
-
-func (t ResolutionType) String() string {
-	if t.IsLocal() {
-		return "local"
-	} else {
-		return "repo"
-	}
-}
-
-func (t ResolutionType) IsLocal() bool {
-	switch t {
-	case Local:
-		return true
-	case Remote:
-		return false
-	default:
-		panic(fmt.Errorf("unknown resolution type: %d", t))
-	}
-}
-
 // ResolvedChart represents the outcome of a successful resolution of a chart release.
 type ResolvedChart interface {
-	// Returns path where the resolved chart can be found on disk
+	// Path where the resolved chart can be found on disk
 	Path() string
-	// Returns version of the resolved chart.
+	// Version of the resolved chart.
 	Version() string
-	// Returns a succinct description of where the chart was found.
+	// SourceDescription of where the chart was found.
 	// If local, this will be path on disk relative to current working directory. (eg. "./charts/agora")
 	// If repo, this will be the name of the Helm repo. (eg. "terra-helm")
 	SourceDescription() string
 }
 
-func NewResolvedChart(path string, chartVersion string, _type ResolutionType, release ChartRelease) ResolvedChart {
-	return &resolvedChart{
-		path:           path,
-		chartVersion:   chartVersion,
-		resolutionType: _type,
-		chartRelease:   release,
+// NewLocallyResolvedChart creates a ResolvedChart based from the local filesystem
+func NewLocallyResolvedChart(path string, chartVersion string) ResolvedChart {
+	return &locallyResolvedChart{
+		path: path, chartVersion: chartVersion,
 	}
 }
 
-type resolvedChart struct {
-	path           string
-	chartVersion   string
-	resolutionType ResolutionType
-	chartRelease   ChartRelease
+type locallyResolvedChart struct {
+	path         string
+	chartVersion string
 }
 
-func (r *resolvedChart) Path() string {
-	return r.path
+func (c *locallyResolvedChart) Path() string {
+	return c.path
 }
 
-func (r *resolvedChart) Version() string {
-	return r.chartVersion
+func (c *locallyResolvedChart) Version() string {
+	return c.chartVersion
 }
 
-func (r *resolvedChart) SourceDescription() string {
-	if r.resolutionType.IsLocal() {
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Warn().Msgf("resolver: unexpected error calling os.GetWd(): %v", err)
-			return r.Path()
-		}
-		abs, err := filepath.Abs(r.Path())
-		if err != nil {
-			log.Warn().Msgf("resolver: unexpected error calling filepath.Abs(): %v", err)
-			return r.Path()
-		}
-		relPath, err := filepath.Rel(cwd, abs)
-		if err != nil {
-			log.Warn().Msgf("resolver: unexpected error calling filepath.Rel(): %v", err)
-			return r.Path()
-		}
-
-		// Need to use strings.Join instead of path.Join because the latter omits "."
-		return strings.Join([]string{".", relPath}, string(os.PathSeparator))
-	} else {
-		return r.chartRelease.Repo
+func (c *locallyResolvedChart) SourceDescription() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Warn().Msgf("resolver: unexpected error calling os.GetWd(): %v", err)
+		return c.path
 	}
+	abs, err := filepath.Abs(c.path)
+	if err != nil {
+		log.Warn().Msgf("resolver: unexpected error calling filepath.Abs(): %v", err)
+		return c.path
+	}
+	relPath, err := filepath.Rel(cwd, abs)
+	if err != nil {
+		log.Warn().Msgf("resolver: unexpected error calling filepath.Rel(): %v", err)
+		return c.path
+	}
+
+	// Need to use strings.Join instead of path.Join because the latter omits "."
+	return strings.Join([]string{".", relPath}, string(os.PathSeparator))
+}
+
+// NewRemotelyResolvedChart creates a ResolvedChart based from a remote Helm repo
+func NewRemotelyResolvedChart(path string, chartVersion string, chartRepo string) ResolvedChart {
+	return &remotelyResolvedChart{
+		path: path, chartVersion: chartVersion, chartRepo: chartRepo,
+	}
+}
+
+type remotelyResolvedChart struct {
+	path         string
+	chartVersion string
+	chartRepo    string
+}
+
+func (c *remotelyResolvedChart) Path() string {
+	return c.path
+}
+
+func (c *remotelyResolvedChart) Version() string {
+	return c.chartVersion
+}
+
+func (c *remotelyResolvedChart) SourceDescription() string {
+	return c.chartRepo
 }

--- a/internal/thelma/render/resolver/resolved_chart_test.go
+++ b/internal/thelma/render/resolver/resolved_chart_test.go
@@ -13,37 +13,25 @@ func TestResolvedChart_SourceDescription(t *testing.T) {
 	assert.NoError(t, err)
 
 	testCases := []struct {
-		name     string
-		resType  ResolutionType
-		expected string
+		name          string
+		resolvedChart ResolvedChart
+		expected      string
 	}{
 		{
-			name:     "local charts should be relative to cwd even when fully-qualified path is supplied",
-			resType:  Local,
-			expected: fmt.Sprintf("./testdata/charts/%s", fakeChart1Name),
+			name:          "local charts should be relative to cwd even when fully-qualified path is supplied",
+			resolvedChart: NewLocallyResolvedChart(fakeChartPath, fakeChart1Version),
+			expected:      fmt.Sprintf("./testdata/charts/%s", fakeChart1Name),
 		},
 		{
-			name:     "remote charts source should be repo name",
-			resType:  Remote,
-			expected: fakeChart1Repo,
+			name:          "remote charts source should be repo name",
+			resolvedChart: NewRemotelyResolvedChart(fakeChartPath, fakeChart1Version, fakeChart1Repo),
+			expected:      fakeChart1Repo,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.NoError(t, err)
-
-			rc := NewResolvedChart(
-				fakeChartPath,
-				fakeChart1Version,
-				tc.resType,
-				ChartRelease{
-					Name:    fakeChart1Name,
-					Repo:    fakeChart1Repo,
-					Version: fakeChart1Version,
-				})
-
-			assert.Equal(t, tc.expected, rc.SourceDescription())
+			assert.Equal(t, tc.expected, tc.resolvedChart.SourceDescription())
 		})
 	}
 }

--- a/internal/thelma/render/resolver/resolved_chart_test.go
+++ b/internal/thelma/render/resolver/resolved_chart_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestResolvedChart_SourceDescription(t *testing.T) {
-	fakeChartPath, err := utils.ExpandAndVerifyExists(path.Join("testdata", "charts", fakeChartName), "fake chart path")
+	fakeChartPath, err := utils.ExpandAndVerifyExists(path.Join("testdata", "charts", fakeChart1Name), "fake chart path")
 	assert.NoError(t, err)
 
 	testCases := []struct {
@@ -20,12 +20,12 @@ func TestResolvedChart_SourceDescription(t *testing.T) {
 		{
 			name:     "local charts should be relative to cwd even when fully-qualified path is supplied",
 			resType:  Local,
-			expected: fmt.Sprintf("./testdata/charts/%s", fakeChartName),
+			expected: fmt.Sprintf("./testdata/charts/%s", fakeChart1Name),
 		},
 		{
 			name:     "remote charts source should be repo name",
 			resType:  Remote,
-			expected: fakeChartRepo,
+			expected: fakeChart1Repo,
 		},
 	}
 
@@ -35,12 +35,12 @@ func TestResolvedChart_SourceDescription(t *testing.T) {
 
 			rc := NewResolvedChart(
 				fakeChartPath,
-				fakeChartVersion,
+				fakeChart1Version,
 				tc.resType,
 				ChartRelease{
-					Name:    fakeChartName,
-					Repo:    fakeChartRepo,
-					Version: fakeChartVersion,
+					Name:    fakeChart1Name,
+					Repo:    fakeChart1Repo,
+					Version: fakeChart1Version,
 				})
 
 			assert.Equal(t, tc.expected, rc.SourceDescription())

--- a/internal/thelma/render/resolver/resolver_test.go
+++ b/internal/thelma/render/resolver/resolver_test.go
@@ -12,14 +12,22 @@ import (
 )
 
 const chartSourceDir = "testdata/charts"
-const fakeChartName = "fakechart"
-const fakeChartVersion = "0.10.0"
-const fakeChartRepo = "terra-helm"
+const fakeChart1Name = "fakechart1"
+const fakeChart1Version = "0.10.0"
+const fakeChart1Repo = "terra-helm"
+const fakeChart2Name = "fakechart2"
+const fakeChart2Version = "0.5.0"
+const fakeChart2Repo = "terra-helm"
 
-var fakeChartDependencyTopographicOrder = []string{
+var fakeChartDependencyTopographicOrder1 = []string{
 	"fakechartdep2",
 	"fakechartdep1",
-	"fakechart",
+	"fakechart1",
+}
+
+var fakeChartDependencyTopographicOrder2 = []string{
+	"fakechartdep2",
+	"fakechart2",
 }
 
 type testCfg struct {
@@ -27,6 +35,7 @@ type testCfg struct {
 	cacheDir   string
 	scratchDir string
 	mockRunner *shell.MockRunner
+	preInputs  []*ChartRelease // other inputs to have passed before running input
 	input      *ChartRelease
 }
 
@@ -48,12 +57,12 @@ func TestResolver(t *testing.T) {
 			name: "development mode should successfully resolve chart from source directory",
 			mode: Development,
 			setupMocks: func(tc *testCfg) {
-				tc.expectHelmDependencyUpdate()
+				tc.expectHelmDependencyUpdate(fakeChartDependencyTopographicOrder1...)
 			},
 			expect: func(e *expect, _ *testCfg) {
-				e.path = path.Join(chartSourceDir, fakeChartName)
-				e.version = fakeChartVersion
-				e.sourceDesc = fmt.Sprintf("./%s/%s", chartSourceDir, fakeChartName)
+				e.path = path.Join(chartSourceDir, fakeChart1Name)
+				e.version = fakeChart1Version
+				e.sourceDesc = fmt.Sprintf("./%s/%s", chartSourceDir, fakeChart1Name)
 			},
 		},
 		{
@@ -89,9 +98,9 @@ func TestResolver(t *testing.T) {
 				tc.expectHelmFetch(true)
 			},
 			expect: func(e *expect, tc *testCfg) {
-				e.path = path.Join(tc.cacheDir, fakeChartRepo, fmt.Sprintf("%s-%s", fakeChartName, fakeChartVersion))
-				e.version = fakeChartVersion
-				e.sourceDesc = fakeChartRepo
+				e.path = path.Join(tc.cacheDir, fakeChart1Repo, fmt.Sprintf("%s-%s", fakeChart1Name, fakeChart1Version))
+				e.version = fakeChart1Version
+				e.sourceDesc = fakeChart1Repo
 			},
 		},
 		{
@@ -99,12 +108,12 @@ func TestResolver(t *testing.T) {
 			mode: Deploy,
 			setupMocks: func(tc *testCfg) {
 				tc.expectHelmFetch(false)
-				tc.expectHelmDependencyUpdate()
+				tc.expectHelmDependencyUpdate(fakeChartDependencyTopographicOrder1...)
 			},
 			expect: func(e *expect, _ *testCfg) {
-				e.path = path.Join(chartSourceDir, fakeChartName)
-				e.version = fakeChartVersion
-				e.sourceDesc = fmt.Sprintf("./%s/%s", chartSourceDir, fakeChartName)
+				e.path = path.Join(chartSourceDir, fakeChart1Name)
+				e.version = fakeChart1Version
+				e.sourceDesc = fmt.Sprintf("./%s/%s", chartSourceDir, fakeChart1Name)
 			},
 		},
 		{
@@ -126,9 +135,9 @@ func TestResolver(t *testing.T) {
 				scratchDir: t.TempDir(),
 				mockRunner: shell.DefaultMockRunner(),
 				input: &ChartRelease{
-					Repo:    fakeChartRepo,
-					Name:    fakeChartName,
-					Version: fakeChartVersion,
+					Repo:    fakeChart1Repo,
+					Name:    fakeChart1Name,
+					Version: fakeChart1Version,
 				},
 			}
 
@@ -153,6 +162,11 @@ func TestResolver(t *testing.T) {
 				ScratchDir: cfg.scratchDir,
 			})
 
+			for _, preInput := range cfg.preInputs {
+				_, err := resolver.Resolve(*preInput)
+				assert.NoError(t, err)
+			}
+
 			result, err := resolver.Resolve(*cfg.input)
 
 			if testCase.errMatcher != "" {
@@ -174,8 +188,8 @@ func TestResolver(t *testing.T) {
 	}
 }
 
-func (tc *testCfg) expectHelmDependencyUpdate() {
-	for _, chartName := range fakeChartDependencyTopographicOrder {
+func (tc *testCfg) expectHelmDependencyUpdate(chartNames ...string) {
+	for _, chartName := range chartNames {
 		tc.mockRunner.ExpectCmd(shell.Command{
 			Prog: "helm",
 			Args: []string{

--- a/internal/thelma/render/resolver/resolver_test.go
+++ b/internal/thelma/render/resolver/resolver_test.go
@@ -125,6 +125,29 @@ func TestResolver(t *testing.T) {
 			},
 			errMatcher: "error downloading chart",
 		},
+		{
+			name: "development mode (problematically) reruns helm dependency update on dependencies",
+			mode: Development,
+			setupMocks: func(tc *testCfg) {
+				tc.preInputs = []*ChartRelease{
+					{
+						Name:    fakeChart1Name,
+						Version: fakeChart1Version,
+						Repo:    fakeChart1Repo,
+					},
+				}
+				tc.input.Name = fakeChart2Name
+				tc.input.Version = fakeChart2Version
+				tc.input.Repo = fakeChart2Repo
+				// Note that the topographic orders here aren't mutually exclusive!
+				tc.expectHelmDependencyUpdate(append(fakeChartDependencyTopographicOrder1, fakeChartDependencyTopographicOrder2...)...)
+			},
+			expect: func(e *expect, _ *testCfg) {
+				e.path = path.Join(chartSourceDir, fakeChart2Name)
+				e.version = fakeChart2Version
+				e.sourceDesc = fmt.Sprintf("./%s/%s", chartSourceDir, fakeChart2Name)
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/thelma/render/resolver/testdata/charts/fakechart1/Chart.yaml
+++ b/internal/thelma/render/resolver/testdata/charts/fakechart1/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: fakechart
+name: fakechart1
 version: 0.10.0
 description: Fake chart for testing resolver
 type: application

--- a/internal/thelma/render/resolver/testdata/charts/fakechart2/Chart.yaml
+++ b/internal/thelma/render/resolver/testdata/charts/fakechart2/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: fakechart2
+version: 0.5.0
+description: Fake chart for testing resolver
+type: application
+dependencies:
+  - name: fakechartdep2
+    repository: file://../fakechartdep2
+    version: 0.7.0


### PR DESCRIPTION
## Description

Solves the issue discussed [here](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1683126783453789) by being a lot smarter about how we run `helm dependency update`. We now cache that at a "per chart directory on disk" level, rather than "per top level released chart" like we were effectively doing before. 

## Testing

Managed to write a mocked unit test for this! Basically we can tell that the caching is working because we skip a `helm dependency update` for dependency of another chart. Can't quite test the fact that this helps with thread-safety from a unit test, but the behavior works.

- [b94b2d0](https://github.com/broadinstitute/thelma/pull/136/commits/b94b2d0f24331e739aeb5cf1cb4bae065fe310eb) adds a test that passes for the old not-ideal behavior.
- [c27e68b](https://github.com/broadinstitute/thelma/pull/136/commits/c27e68ba206f1a93fd8eb7555003f3960d8cc1a4) tweaks it to be correct but now fail. 
- [03ac2cb](https://github.com/broadinstitute/thelma/pull/136/commits/03ac2cbb9c139ab01c952c04d68fa58751d623ef) implements all the code changes to get the test passing (described more below).

I ran it locally with a ton of parallel workers a bunch of times and it A) worked B) didn't hit the bug we're trying to solve.

## Risk

We've actually got stellar test coverage here, even before my change. I think this is super low risk.

## Background

Thelma already has a `syncCache` thing it uses at three levels to handle not overdoing dependency resolution:
1. At the top-level, per ChartRelease
2. The remote resolver, per ChartRelease
3. The local resolver, which was technically per ChartRelease but was fudging the keys to make it per chart name

The `syncCache` does locking and caching to make sure that we don't update the same dependencies twice, much less twice at the same time. It's basically exactly what we want, except it doesn't quite work in its current state for the local resolver. See, we actually spread out calls to `helm dependency update` (which isn't thread-safe) across not just the ChartRelease's chart but its dependencies too. When a dependency _itself_ has yet more dependencies, this results in filesystem operation in the _dependency's_ directory, which is currently unlocked and uncached.

What's the fix? Basically we make `syncCache` generic so the local resolver can use `syncCache` per true individual source.Chart instances, which covers those dependencies we care about. We basically swap the call-order of the caching stuff and Mike's topo-sort stuff, so we cache all the individual things after we know about dependencies. I did some type system refactoring too, to better handle the polymorphism of a locally-resolved chart and a remotely-resolved chart.