### PR TITLE
DDO-2836 Update Regex For Ignoring 409s in Bee Seeding

### DIFF
--- a/internal/thelma/bee/seed/seed_step_2_register_sa_profiles.go
+++ b/internal/thelma/bee/seed/seed_step_2_register_sa_profiles.go
@@ -2,9 +2,10 @@ package seed
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/rs/zerolog/log"
-	"regexp"
 )
 
 func (s *seeder) seedStep2RegisterSaProfiles(appReleases map[string]terra.AppRelease, opts SeedOptions) error {
@@ -93,7 +94,7 @@ func _ignore409Conflict(maybe409Err error) error {
 		return nil
 	}
 
-	pattern := "(?s)409 [Cc]onflict.*[Uu]ser.*already exists"
+	pattern := "(?s)409 [Cc]onflict.*[Uu]ser.*already (?:exists|registered)"
 	matches, err := regexp.MatchString(pattern, maybe409Err.Error())
 
 	if err != nil {


### PR DESCRIPTION
Sam is returning a response like this when seeding app sa users results in 409:
```
409 Conflict from https://firecloudorch.jenkins-swat-leo-8316.bee.envs-terra.bio/register/profile ({"causes":[{"causes":[],"message":"user sam-qa@broad-dsde-qa.iam.gserviceaccount.com is already registered","source":"sam","stackTrace":[],"statusCode":409}],"message":"user sam-qa@broad-dsde-qa.iam.gserviceaccount.com is already registered","source":"Sam","stackTrace":[],"statusCode":409})
```

This message does not match regex handling that was used to ignore 409s so thelma was still erroring out on 409s with the above message.

I also tested the updated regex against the error with an online regex tool.

I've tested this by running a bee provision with thelma locally built from this branch. The error does seem to be transient, so it's hard to verify the fix for sure with out deploying the updating and giving it some heavier usage.