### PR TITLE
[DDO-2853] Render READMEs after bumping chart version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,2 @@
+skip-dirs:
+  - "**/mocks"

--- a/internal/thelma/charts/source/charts_dir.go
+++ b/internal/thelma/charts/source/charts_dir.go
@@ -86,9 +86,6 @@ func (d *chartsDir) PublishAndRelease(chartNames []string, description string) (
 
 		dependenciesToUpdate := d.determineDependenciesToUpdate(_chart)
 
-		if err := _chart.GenerateDocs(); err != nil {
-			return nil, err
-		}
 		lastVersions[chartName] = d.publisher.Index().MostRecentVersion(chartName)
 		newVersion, err := _chart.BumpChartVersion(lastVersions[chartName])
 		if err != nil {
@@ -107,6 +104,11 @@ func (d *chartsDir) PublishAndRelease(chartNames []string, description string) (
 		if err := _chart.PackageChart(d.publisher.ChartDir()); err != nil {
 			return nil, err
 		}
+		
+		if err := _chart.GenerateDocs(); err != nil {
+			return nil, err
+		}
+
 		publishedVersions[chartName] = newVersion
 	}
 

--- a/internal/thelma/charts/source/charts_dir.go
+++ b/internal/thelma/charts/source/charts_dir.go
@@ -101,11 +101,11 @@ func (d *chartsDir) PublishAndRelease(chartNames []string, description string) (
 			}
 		}
 
-		if err := _chart.PackageChart(d.publisher.ChartDir()); err != nil {
+		if err := _chart.GenerateDocs(); err != nil {
 			return nil, err
 		}
-		
-		if err := _chart.GenerateDocs(); err != nil {
+
+		if err := _chart.PackageChart(d.publisher.ChartDir()); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Fix the bug reported here: https://broadinstitute.slack.com/archives/CADM7MZ35/p1684255219101189

Also try to reduce runtime for golangci-lint runs by excluding generated mocks/ packages from linting.

### Testing

This change is trivial and will only impact chart publishing workflows, so I am comfortable merging as-is.