### PR TITLE
[DDO-2961] Use Sherlock's /connection-check

### DIFF
--- a/internal/thelma/clients/iap/iap.go
+++ b/internal/thelma/clients/iap/iap.go
@@ -37,10 +37,10 @@ const configKey = "iap"
 // tokenKey unique name for IAP tokens issued by this package, used to identify it in Thelma's token storage
 const tokenKey = "iap-oauth-token"
 
-// URL to request in order to validate IAP credentials are working
-// Note that Sherlock doesn't actually have a thelma-iap-check endpoint so this will 404, but we don't care.
-// We just care that we don't get the iap response header back in the response
-const tokenValidationURL = "https://sherlock.dsp-devops.broadinstitute.org/thelma-iap-check"
+// URL to request in order to validate IAP credentials are working.
+// We don't read the body, we just use tokenValidationIapResponseHeader to check that IAP didn't send it.
+// If IAP didn't send it, then we are through to Sherlock.
+const tokenValidationURL = "https://sherlock.dsp-devops.broadinstitute.org/connection-check"
 
 // how long to wait before timing out token validation request
 const tokenValidationRequestTimeout = 15 * time.Second


### PR DESCRIPTION
Hit https://sherlock.dsp-devops.broadinstitute.org/swagger/index.html#/Misc/get_connection_check so it doesn't show up as a 404 in Sherlock's logs.

## Testing

I did `make build` and then `./output/bin/thelma render -r leonardo -e prod`, it got an IAP credential without issue. Can hit https://sherlock.dsp-devops.broadinstitute.org/connection-check in the browser too.