### PR TITLE
DDO-3015 Retry all orch bee seeding errors

### DIFF
--- a/internal/thelma/clients/google/terraapi/firecloudorch.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/avast/retry-go"
-	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
-	"github.com/rs/zerolog/log"
 	"net/http"
 	"regexp"
 	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/rs/zerolog/log"
 )
 
 // BEE seeding occasionally fails, with Orch occasionally encountering connection timeouts, resets, or DNS errors
@@ -129,7 +130,6 @@ func (c *firecloudOrchClient) doJsonRequestWithRetries(method string, url string
 			count++
 			log.Warn().Err(err).Msgf("%s %s failed (attempt %d of %d): %v", method, url, n, defaultRetryAttempts, err)
 		}),
-		retry.RetryIf(isRetryableError),
 	); retryErr != nil {
 		return nil, "", retryErr
 	}

--- a/internal/thelma/clients/google/terraapi/firecloudorch.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -22,14 +21,6 @@ import (
 
 const defaultRetryAttempts = 40
 const defaultRetryDelay = 30 * time.Second
-
-var retryableErrors = []*regexp.Regexp{
-	regexp.MustCompile(`java\.net\.SocketTimeoutException`),
-	regexp.MustCompile(`java\.net\.UnknownHostException`),
-	regexp.MustCompile(`akka\.http\.impl\.engine\.client\.OutgoingConnectionBlueprint\$UnexpectedConnectionClosureException`),
-	regexp.MustCompile(`(?m)503 Service Temporarily Unavailable.*nginx`),
-	regexp.MustCompile(`503 Service Unavailable`),
-}
 
 type FirecloudOrchClient interface {
 	RegisterProfile(firstName string, lastName string, title string, contactEmail string, institute string, institutionalProgram string, programLocationCity string, programLocationState string, programLocationCountry string, pi string, nonProfitStatus string) (*http.Response, string, error)
@@ -139,14 +130,4 @@ func (c *firecloudOrchClient) doJsonRequestWithRetries(method string, url string
 	}
 
 	return resp, responseBody, nil
-}
-
-func isRetryableError(err error) bool {
-	msg := err.Error()
-	for _, matcher := range retryableErrors {
-		if matcher.MatchString(msg) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/thelma/clients/google/terraapi/firecloudorch_test.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch_test.go
@@ -1,15 +1,16 @@
 package terraapi
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	googleoauth "google.golang.org/api/oauth2/v2"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
 )
 
 func Test_OrchClientRetriesFailedRequests(t *testing.T) {
@@ -24,18 +25,19 @@ func Test_OrchClientRetriesFailedRequests(t *testing.T) {
 			retryableErrCount: 0,
 			expectErr:         false,
 		},
-		{
-			name:              "1 non-retryable err",
-			retryableErrCount: 0,
-			finalErr:          "should not cause a retry",
-			expectErr:         true,
-		},
-		{
-			name:              "3 retryable, 1 non-retryable err",
-			retryableErrCount: 3,
-			finalErr:          "should not cause a retry",
-			expectErr:         true,
-		},
+		// Treat all errors as retryable for now, there are just too many different errors that can occur
+		// {
+		// 	name:              "1 non-retryable err",
+		// 	retryableErrCount: 0,
+		// 	finalErr:          "should not cause a retry",
+		// 	expectErr:         true,
+		// },
+		// {
+		// 	name:              "3 retryable, 1 non-retryable err",
+		// 	retryableErrCount: 3,
+		// 	finalErr:          "should not cause a retry",
+		// 	expectErr:         true,
+		// },
 		{
 			name:              "5 retryable, then success",
 			retryableErrCount: 5,


### PR DESCRIPTION
There are numerous different errors that happen during bee seeding that appear as errors from the orchestration. Enumerating all the different possible errors here and handling them individually is impossible they can range from errors sourced from any terra service to transient k8s networking issues. So instead we just retry any error. 

This was tested by provisioning a bee from this branch with a local build of thelma.