### PR TITLE
[DDO-3042] Replace a panic with a warning

### DIFF
--- a/internal/thelma/ops/status/event_matcher.go
+++ b/internal/thelma/ops/status/event_matcher.go
@@ -33,7 +33,7 @@ func newEventMatcher(apiClient kubernetes.Interface, namespace string) (*eventMa
 // annotateResource with any matching events
 func (e *eventMatcher) annotateResourceWithMatchingEvents(resource *Resource) error {
 	if resource.Namespace != e.namespace {
-		log.Warn().Msgf("Unexpected data inconsistency: resource namespace %s does not match event cache namespace %s", resource.Namespace, e.namespace)
+		log.Warn().Msgf("Unexpected inconsistency: resource namespace %s does not match event cache namespace %s", resource.Namespace, e.namespace)
 		return nil
 	}
 

--- a/internal/thelma/ops/status/event_matcher.go
+++ b/internal/thelma/ops/status/event_matcher.go
@@ -33,7 +33,8 @@ func newEventMatcher(apiClient kubernetes.Interface, namespace string) (*eventMa
 // annotateResource with any matching events
 func (e *eventMatcher) annotateResourceWithMatchingEvents(resource *Resource) error {
 	if resource.Namespace != e.namespace {
-		panic(fmt.Errorf("resource namespace %s does not match event cache namespace %s", resource.Namespace, e.namespace))
+		log.Warn().Msgf("Unexpected data inconsistency: resource namespace %s does not match event cache namespace %s", resource.Namespace, e.namespace)
+		return nil
 	}
 
 	var podSelector *metav1.LabelSelector

--- a/internal/thelma/ops/status/event_matcher.go
+++ b/internal/thelma/ops/status/event_matcher.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"context"
-	"fmt"
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
[This panic](https://github.com/broadinstitute/thelma/blob/a25c94b1764d3e396949f4c6a3f0535da2dcc13a/internal/thelma/ops/status/event_matcher.go#L36) was triggered by a Jenkins job today:
https://fc-jenkins.dsp-techops.broadinstitute.org/job/fiab-start/96310/console

```
15:36:26 19:36 INF martha:           queued
15:36:26 19:36 INF mongodb:          queued
15:36:26 19:36 INF ncbiaccess:       queued
15:36:26 19:36 INF ontology:         queued
15:36:26 19:36 INF rawls:            queued
15:36:26 19:36 INF sam:              queued
15:36:26 19:36 INF terraui:          queued
15:36:26 19:36 INF thurloe:          queued
15:36:26 19:36 INF tsps:             queued
15:36:26 19:36 INF workspacemanager: queued
15:36:26 19:36 INF Check status in ArgoCD at https://ap-argocd.dsp-devops.broadinstitute.org/applications?labels=env%3Djenkins-swat-leo-10202
15:36:48 panic: resource namespace  does not match event cache namespace terra-jenkins-swat-leo-10202
15:36:48 
15:36:48 goroutine 266 [running]:
15:36:48 github.com/broadinstitute/thelma/internal/thelma/ops/status.(*eventMatcher).annotateResourceWithMatchingEvents(0xc0008b0ec0, 0xc000d3b7d8)
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/ops/status/event_matcher.go:36 +0x101e
15:36:48 github.com/broadinstitute/thelma/internal/thelma/ops/status.(*reporter).buildUnhealthyResourceList(0x29f9a70?, {{0x5}, {0x2}, {0xc0007a1800, 0x1f, 0x1f}}, {0x29f9a70, 0xc000a854a0})
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/ops/status/reporter.go:98 +0x20c
15:36:48 github.com/broadinstitute/thelma/internal/thelma/ops/status.(*reporter).Status(0xc0015c41e0, {0x29f9a70, 0xc000a854a0})
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/ops/status/reporter.go:40 +0x105
15:36:48 github.com/broadinstitute/thelma/internal/thelma/ops/sync.(*syncer).waitHealthy(0xc0015c4200, {0x29f9a70, 0xc000a854a0}, 0x1a3185c5000, {0x29cd760, 0xc0015c4340})
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/ops/sync/sync.go:111 +0x6a
15:36:48 github.com/broadinstitute/thelma/internal/thelma/ops/sync.(*syncer).Sync.func2({0x29cd760?, 0xc0015c4340})
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/ops/sync/sync.go:69 +0x21b
15:36:48 github.com/broadinstitute/thelma/internal/thelma/utils/pool.(*workItemImpl).execute(0xc0001af8c0)
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/utils/pool/work_item.go:80 +0x3d
15:36:48 github.com/broadinstitute/thelma/internal/thelma/utils/pool.(*pool).spawnWorker.func1()
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/utils/pool/pool.go:158 +0x47b
15:36:48 created by github.com/broadinstitute/thelma/internal/thelma/utils/pool.(*pool).spawnWorker
15:36:48 	/home/runner/work/thelma/thelma/internal/thelma/utils/pool/pool.go:141 +0x3d1
15:36:48 Build step 'Conditional steps (multiple)' marked build as failure
```

It was immediately after the BEE's Argo apps were created, so I guess it's some rare timing issue we haven't encountered before. This PR replaces the panic with a warning.