### PR TITLE
[DDO-3130] Allow passing X-GHA-OIDC-JWT header to Sherlock

### DIFF
--- a/internal/thelma/clients/sherlock/sherlock_test.go
+++ b/internal/thelma/clients/sherlock/sherlock_test.go
@@ -35,8 +35,12 @@ func Test_NewClient(t *testing.T) {
 		thelmaConfig, err := config.Load(config.WithTestDefaults(t), config.WithOverride("sherlock.addr", mockSherlockServer.URL))
 		require.NoError(t, err)
 
+		// Don't assume that the environment variable will be empty... clear it and then clean up the side effect.
+		oldEnv := os.Getenv(githubActionsOidcTokenEnvVar)
+		_ = os.Setenv(githubActionsOidcTokenEnvVar, "")
 		client, err := New(thelmaConfig, testIapToken)
 		require.NoError(t, err)
+		_ = os.Setenv(githubActionsOidcTokenEnvVar, oldEnv)
 
 		err = client.getStatus()
 		require.NoError(t, err)


### PR DESCRIPTION
Makes it so that if you set a `SHERLOCK_GHA_OIDC_TOKEN` environment variable, Thelma will pass the value of it in all requests made to Sherlock in the `X-GHA-OIDC-JWT` header.

We can use this in terra-helmfile to make new chart versions be deployed to dev as the people who merge the PRs, instead of the SA that Thelma runs as.

## Testing

Added tests for both cases and improved testing around validating that the IAP token is getting passed to.

## Risk

Very low