### PR TITLE
[DDO-3139] Optional stacktraces for Thelma errors

### DIFF
--- a/internal/thelma/app/config/config.go
+++ b/internal/thelma/app/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/mcuadros/go-defaults"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path/filepath"
@@ -66,10 +67,10 @@ func Load(opts ...Option) (Config, error) {
 	// load configuration defaults from profile. (these can be overridden by environment variables, config file, etc.)
 	profile, err := loadProfile(options)
 	if err != nil {
-		return nil, fmt.Errorf("error loading configuration profile: %v", err)
+		return nil, errors.Errorf("error loading configuration profile: %v", err)
 	}
 	if err = _koanf.Load(rawbytes.Provider(profile), yaml.Parser()); err != nil {
-		return nil, fmt.Errorf("error loading configuration profile: %v", err)
+		return nil, errors.Errorf("error loading configuration profile: %v", err)
 	}
 
 	// load config from file ~/.thelma/config.yaml
@@ -77,10 +78,10 @@ func Load(opts ...Option) (Config, error) {
 		if _, err := os.Stat(options.ConfigFile); os.IsNotExist(err) {
 			// no config file found, don't try to load it.
 		} else if err != nil {
-			return nil, fmt.Errorf("error checking if configuration file %s exists: %v", options.ConfigFile, err)
+			return nil, errors.Errorf("error checking if configuration file %s exists: %v", options.ConfigFile, err)
 		} else {
 			if err := _koanf.Load(file.Provider(options.ConfigFile), yaml.Parser()); err != nil {
-				return nil, fmt.Errorf("error loading configuration from file %s: %v", options.ConfigFile, err)
+				return nil, errors.Errorf("error loading configuration from file %s: %v", options.ConfigFile, err)
 			}
 		}
 	}
@@ -89,23 +90,23 @@ func Load(opts ...Option) (Config, error) {
 	if options.EnvPrefix != "" {
 		envProvider := env.Provider(options.EnvPrefix, keyDelimiter, envVarReplacer(options.EnvPrefix))
 		if err := _koanf.Load(envProvider, nil); err != nil {
-			return nil, fmt.Errorf("error reading configuration from environment: %v", err)
+			return nil, errors.Errorf("error reading configuration from environment: %v", err)
 		}
 	}
 
 	// apply configuration overrides (these are used in tests)
 	overrideProvider := confmap.Provider(options.Overrides, keyDelimiter)
 	if err := _koanf.Load(overrideProvider, nil); err != nil {
-		return nil, fmt.Errorf("error applying configuration overrides: %v", err)
+		return nil, errors.Errorf("error applying configuration overrides: %v", err)
 	}
 
 	// validate configuration
 	if !_koanf.Exists(HomeKey) || _koanf.Get(HomeKey) == "" {
-		return nil, fmt.Errorf("please specify path to terra-helmfile clone, via the THELMA_HOME environment variable or via the `home:` setting in %s", options.ConfigFile)
+		return nil, errors.Errorf("please specify path to terra-helmfile clone, via the THELMA_HOME environment variable or via the `home:` setting in %s", options.ConfigFile)
 	}
 	home, err := filepath.Abs(_koanf.String(HomeKey))
 	if err != nil {
-		return nil, fmt.Errorf("error expanding home path %q to absoluate path: %v", home, err)
+		return nil, errors.Errorf("error expanding home path %q to absoluate path: %v", home, err)
 	}
 
 	return &config{
@@ -120,20 +121,20 @@ func (c *config) Unmarshal(configPrefix string, into interface{}) error {
 	// Make sure we were passed a struct pointer
 	value := reflect.ValueOf(into)
 	if value.Kind() != reflect.Ptr {
-		panic(fmt.Errorf("expected struct pointer, got %v: %v", value.Kind(), into))
+		panic(errors.Errorf("expected struct pointer, got %v: %v", value.Kind(), into))
 	}
 	if value.Elem().Kind() != reflect.Struct {
-		panic(fmt.Errorf("expected struct pointer, got %v pointer: %v", value.Elem().Kind(), into))
+		panic(errors.Errorf("expected struct pointer, got %v pointer: %v", value.Elem().Kind(), into))
 	}
 
 	// Set defaults and make sure they pass validation
 	defaults.SetDefaults(into)
 	if err := c.validator.Struct(into); err != nil {
-		panic(fmt.Errorf("struct defaults do not pass validation: %v", err))
+		panic(errors.Errorf("struct defaults do not pass validation: %v", err))
 	}
 
 	if err := c.koanf.Unmarshal(configPrefix, into); err != nil {
-		return fmt.Errorf("error unmarshalling config key %s into struct: %v", configPrefix, err)
+		return errors.Errorf("error unmarshalling config key %s into struct: %v", configPrefix, err)
 	}
 	// Verify configuration passes validation constraints
 	return c.validateStruct(into, configPrefix)
@@ -153,7 +154,7 @@ func (c *config) validateStruct(s interface{}, configPrefix string) error {
 	// if we got an unexpected error back, return it as-is
 	validationErrors, ok := err.(validator.ValidationErrors)
 	if !ok {
-		return fmt.Errorf("%s %v", errHeader, err)
+		return errors.Errorf("%s %v", errHeader, err)
 	}
 
 	// for some reason the validation library does not include the validation constraint in error messages,
@@ -179,7 +180,7 @@ func (c *config) validateStruct(s interface{}, configPrefix string) error {
 		// append to list of all errors
 		msgs = append(msgs, fmt.Sprintf("  %s", msg))
 	}
-	return fmt.Errorf("%s\n%s", errHeader, strings.Join(msgs, "\n"))
+	return errors.Errorf("%s\n%s", errHeader, strings.Join(msgs, "\n"))
 }
 
 // convert struct field name like "logConfig.File.Level" to configuration key like

--- a/internal/thelma/app/config/config_test.go
+++ b/internal/thelma/app/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/testutils"
 	"github.com/mcuadros/go-defaults"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
@@ -69,7 +70,7 @@ func (s Season) String() string {
 	case Winter:
 		return "winter"
 	default:
-		panic(fmt.Errorf("unknown season: %#v", s))
+		panic(errors.Errorf("unknown season: %#v", s))
 	}
 }
 
@@ -85,7 +86,7 @@ func (s *Season) UnmarshalText(text []byte) error {
 	case "winter":
 		*s = Winter
 	default:
-		return fmt.Errorf("invalid season: %q", str)
+		return errors.Errorf("invalid season: %q", str)
 	}
 	return nil
 }

--- a/internal/thelma/app/config/profiles/ci.yaml
+++ b/internal/thelma/app/config/profiles/ci.yaml
@@ -34,6 +34,9 @@ logging:
   file:
     # disable file logging
     enabled: false
+  # enable stacktraces for errors in CI
+  errtrace:
+    enabled: true
 
 vault:
   # do not manage ~/.vault-token in ArgoCD/Jenkins/GitHub actions, treat vault token like a regular credential

--- a/internal/thelma/app/config/profiles/ci.yaml
+++ b/internal/thelma/app/config/profiles/ci.yaml
@@ -34,9 +34,6 @@ logging:
   file:
     # disable file logging
     enabled: false
-  # enable stacktraces for errors in CI
-  errtrace:
-    enabled: true
 
 vault:
   # do not manage ~/.vault-token in ArgoCD/Jenkins/GitHub actions, treat vault token like a regular credential

--- a/internal/thelma/app/logging/logging_test.go
+++ b/internal/thelma/app/logging/logging_test.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
 	"github.com/broadinstitute/thelma/internal/thelma/app/root"
 	"github.com/leaanthony/go-ansi-parser"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -321,7 +321,7 @@ func parseLogFile(logFile string) ([]testMessage, error) {
 			log.Warn().Msgf("log file %s does not exist, returning empty message list", logFile)
 			return messages, nil
 		} else {
-			return nil, fmt.Errorf("error reading log file %s: %v", logFile, err)
+			return nil, errors.Errorf("error reading log file %s: %v", logFile, err)
 		}
 	}
 
@@ -341,7 +341,7 @@ func parseLogFile(logFile string) ([]testMessage, error) {
 		var m testMessage
 		content := scanner.Bytes()
 		if err := json.Unmarshal(scanner.Bytes(), &m); err != nil {
-			return nil, fmt.Errorf("error parsing message on line %d of %s as JSON: %q", lineNumber, logFile, string(content))
+			return nil, errors.Errorf("error parsing message on line %d of %s as JSON: %q", lineNumber, logFile, string(content))
 		}
 		messages = append(messages, m)
 		lineNumber++

--- a/internal/thelma/cli/entrypoint/entrypoint.go
+++ b/internal/thelma/cli/entrypoint/entrypoint.go
@@ -1,13 +1,12 @@
 package entrypoint
 
 import (
-	"os"
-
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/repo"
 	repoCreate "github.com/broadinstitute/thelma/internal/thelma/cli/commands/repo/create"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/update"
 	"github.com/rs/zerolog/log"
+	"os"
 
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/argocd"
 	argocd_sync "github.com/broadinstitute/thelma/internal/thelma/cli/commands/argocd/sync"
@@ -63,7 +62,7 @@ func Execute() {
 	_cli := cli.New(withCommands)
 
 	if err := _cli.Execute(); err != nil {
-		log.Error().Msgf("%v", err)
+		log.Error().Err(err).Send()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I was struggling to trace a mysterious error today (seemed to be related to networking struggles), so decided to bite the bullet and add stack traces for errors in Thelma.

Error traces are disabled by default. They can be turned using the `logging.errtrace.enabled` config key, for example by setting the env var `THELMA_LOGGING_ERRTRACE_ENABLED=true`.

Note that in order for stacktraces to work, errors need to be created using the `github.com/pkg/errors` packge. See ZeroLog docs for more details. I will submit a future PR to bulk find-replace all instances of `fmt.Errorf` with `errors.Errorf`.

Here's example console log output:
```
1:24PM ERR test error=test stack=[{"func":"foo","line":"62","source":"entrypoint.go"},{"func":"bar","line":"72","source":"entrypoint.go"},{"func":"baz","line":"77","source":"entrypoint.go"},{"func":"Execute","line":"89","source":"entrypoint.go"},{"func":"main","line":"8","source":"main.go"},{"func":"main","line":"250","source":"proc.go"},{"func":"goexit","line":"1172","source":"asm_arm64.s"}]
```