### PR TITLE
[DDO-3139] Use errors.Errorf everywhere

### DIFF
--- a/internal/thelma/app/autoupdate/autoupdate.go
+++ b/internal/thelma/app/autoupdate/autoupdate.go
@@ -2,7 +2,6 @@
 package autoupdate
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/autoupdate/bootstrap"
 	"github.com/broadinstitute/thelma/internal/thelma/app/autoupdate/installer"
 	"github.com/broadinstitute/thelma/internal/thelma/app/autoupdate/releasebucket"
@@ -14,6 +13,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/clients/api"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/lazy"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/pkg/errors"
 	"k8s.io/utils/strings/slices"
 	"os"
 	"strings"
@@ -89,7 +89,7 @@ func (a *autoupdate) Update() error {
 
 func (a *autoupdate) UpdateTo(versionOrTag string) error {
 	if a.config.Enabled {
-		return fmt.Errorf("auto-update is enabled; please disable by " +
+		return errors.Errorf("auto-update is enabled; please disable by " +
 			"setting THELMA_AUTOUPDATE_ENABLED=false or adding autoupdate.enabled=false " +
 			"to ~/.thelma/config.yaml and re-run (otherwise this change will be overwritten!)")
 	}
@@ -114,11 +114,11 @@ func (a *autoupdate) StartBackgroundUpdateIfEnabled() error {
 
 	_installer, err := a.installer.Get()
 	if err != nil {
-		return fmt.Errorf("error initializing installer: %v", err)
+		return errors.Errorf("error initializing installer: %v", err)
 	}
 	resolved, err := _installer.ResolveVersions(a.config.Tag)
 	if err != nil {
-		return fmt.Errorf("error preparing background Thelma updates: %v", err)
+		return errors.Errorf("error preparing background Thelma updates: %v", err)
 	}
 	if !resolved.UpdateNeeded() {
 		return nil
@@ -137,7 +137,7 @@ func (a *autoupdate) Bootstrap() error {
 func (a *autoupdate) updateTo(versionOrTag string) error {
 	_installer, err := a.installer.Get()
 	if err != nil {
-		return fmt.Errorf("error initializing installer: %v", err)
+		return errors.Errorf("error initializing installer: %v", err)
 	}
 	return _installer.UpdateThelma(versionOrTag)
 }

--- a/internal/thelma/app/autoupdate/bootstrap/bootstrap.go
+++ b/internal/thelma/app/autoupdate/bootstrap/bootstrap.go
@@ -22,13 +22,13 @@ package bootstrap
 
 import (
 	_ "embed"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/autoupdate/releases"
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
 	"github.com/broadinstitute/thelma/internal/thelma/app/root"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/prompt"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path"
@@ -174,12 +174,12 @@ func (b *bootstrapper) writeThelmaShellCompletionFile() error {
 	file := b.completionFile
 	f, err := os.OpenFile(file, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0755)
 	if err != nil {
-		return fmt.Errorf("error generating shell complation file %s: %v", file, err)
+		return errors.Errorf("error generating shell complation file %s: %v", file, err)
 	}
 
 	executable, err := utils.PathToRunningThelmaExecutable()
 	if err != nil {
-		return fmt.Errorf("error generating shell completion file %s: %v", file, err)
+		return errors.Errorf("error generating shell completion file %s: %v", file, err)
 	}
 
 	log.Info().Msgf("Writing shell completion script to %s...", file)
@@ -191,7 +191,7 @@ func (b *bootstrapper) writeThelmaShellCompletionFile() error {
 	})
 
 	if err != nil {
-		err = fmt.Errorf("error generating shell completion file %s: %v", file, err)
+		err = errors.Errorf("error generating shell completion file %s: %v", file, err)
 	}
 
 	return utils.CloseWarn(f, err)
@@ -202,7 +202,7 @@ func (b *bootstrapper) writeSkeletonConfigFile() error {
 	configFile := config.DefaultConfigFilePath(b.root)
 	exists, err := utils.FileExists(configFile)
 	if err != nil {
-		return fmt.Errorf("error generating skeleton Thelma config file: %v", err)
+		return errors.Errorf("error generating skeleton Thelma config file: %v", err)
 	}
 	if exists {
 		log.Warn().Msgf("%s exists; won't generate skeleton config file", configFile)
@@ -223,17 +223,17 @@ func renderTemplateToFile(templateString string, ctx interface{}, file string) e
 	templateName := path.Base(file)
 	tmpl, err := template.New(templateName).Parse(templateString)
 	if err != nil {
-		panic(fmt.Errorf("failed to parse embedded template %s: %v", templateName, err))
+		panic(errors.Errorf("failed to parse embedded template %s: %v", templateName, err))
 	}
 
 	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
-		return fmt.Errorf("error opening %s for rendering: %v", file, err)
+		return errors.Errorf("error opening %s for rendering: %v", file, err)
 	}
 
 	err = tmpl.Execute(f, ctx)
 	if err != nil {
-		err = fmt.Errorf("failed to render file %s from template: %v", file, err)
+		err = errors.Errorf("failed to render file %s from template: %v", file, err)
 	}
 
 	return utils.CloseWarn(f, err)

--- a/internal/thelma/app/autoupdate/bootstrap/zshrc.go
+++ b/internal/thelma/app/autoupdate/bootstrap/zshrc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/app/name"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/prompt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path"
@@ -27,7 +28,7 @@ func newZshrcWriter(zshrcPath string, thelmaInitFile string, prompt prompt.Promp
 	if zshrcPath == "" {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return nil, fmt.Errorf("could not identify user home directory: %v", err)
+			return nil, errors.Errorf("could not identify user home directory: %v", err)
 		}
 		zshrcPath = path.Join(homeDir, zshrcFile)
 	}
@@ -71,7 +72,7 @@ func (z *zshrcWriterImpl) addThelmaInitialization() error {
 func (z *zshrcWriterImpl) renderZshrcFragment() ([]byte, error) {
 	zshrcTemplate, err := template.New(zshrcFile).Parse(zshrcFragmentTemplate)
 	if err != nil {
-		panic(fmt.Errorf("failed to parse template for %s: %v", zshrcFile, err))
+		panic(errors.Errorf("failed to parse template for %s: %v", zshrcFile, err))
 	}
 
 	ctx := struct {
@@ -83,7 +84,7 @@ func (z *zshrcWriterImpl) renderZshrcFragment() ([]byte, error) {
 	var buf bytes.Buffer
 	err = zshrcTemplate.Execute(&buf, ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error rendering template for %s: %v", zshrcFile, err)
+		return nil, errors.Errorf("error rendering template for %s: %v", zshrcFile, err)
 	}
 
 	return buf.Bytes(), nil
@@ -93,14 +94,14 @@ func (z *zshrcWriterImpl) renderZshrcFragment() ([]byte, error) {
 func (z *zshrcWriterImpl) createEmptyZshrcIfDoesNotExist() error {
 	exists, err := utils.FileExists(z.file)
 	if err != nil {
-		return fmt.Errorf("error adding thelma initialization to %s: %v", z.file, err)
+		return errors.Errorf("error adding thelma initialization to %s: %v", z.file, err)
 	}
 
 	if !exists {
 		log.Warn().Msgf("%s does not exist; creating empty file", z.file)
 
 		if err = os.WriteFile(z.file, []byte{}, 0644); err != nil {
-			return fmt.Errorf("error adding thelma initialization to %s: %v", z.file, err)
+			return errors.Errorf("error adding thelma initialization to %s: %v", z.file, err)
 		}
 	}
 
@@ -112,7 +113,7 @@ func (z *zshrcWriterImpl) alreadyContainsThelmaInitialization(fragment []byte) (
 	// read zshrc and scan to see if it already includes the fragment
 	content, err := os.ReadFile(z.file)
 	if err != nil {
-		return false, fmt.Errorf("error adding thelma initialization to %s: %v", z.file, err)
+		return false, errors.Errorf("error adding thelma initialization to %s: %v", z.file, err)
 	}
 
 	if bytes.Contains(content, fragment) {
@@ -138,14 +139,14 @@ func (z *zshrcWriterImpl) alreadyContainsThelmaInitialization(fragment []byte) (
 func (z *zshrcWriterImpl) backupZshrc() error {
 	content, err := os.ReadFile(z.file)
 	if err != nil {
-		return fmt.Errorf("error backing up %s: %v", z.file, err)
+		return errors.Errorf("error backing up %s: %v", z.file, err)
 	}
 
 	backupFile := fmt.Sprintf("%s.%s", z.file, time.Now().Format("20060102.150405"))
 	log.Info().Msgf("Backing up %s to %s", z.file, backupFile)
 
 	if err = os.WriteFile(backupFile, content, 0644); err != nil {
-		return fmt.Errorf("error backing up %s: %v", z.file, err)
+		return errors.Errorf("error backing up %s: %v", z.file, err)
 	}
 
 	return nil
@@ -155,13 +156,13 @@ func (z *zshrcWriterImpl) backupZshrc() error {
 func (z *zshrcWriterImpl) appendFragmentToZshrc(fragment []byte) error {
 	f, err := os.OpenFile(z.file, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
-		return fmt.Errorf("error updating %s: %v", z.file, err)
+		return errors.Errorf("error updating %s: %v", z.file, err)
 	}
 
 	log.Info().Msgf("Adding Thelma initialization to %s", z.file)
 	_, err = f.Write(fragment)
 	if err != nil {
-		err = fmt.Errorf("error updating %s: %v", z.file, err)
+		err = errors.Errorf("error updating %s: %v", z.file, err)
 	}
 
 	return utils.CloseWarn(f, err)

--- a/internal/thelma/app/autoupdate/installer/installer.go
+++ b/internal/thelma/app/autoupdate/installer/installer.go
@@ -1,10 +1,10 @@
 package installer
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/autoupdate/releasebucket"
 	"github.com/broadinstitute/thelma/internal/thelma/app/autoupdate/releases"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -73,7 +73,7 @@ func (i *installer) ResolveVersions(versionOrTag string) (ResolvedVersions, erro
 func (i *installer) UpdateThelma(versionOrTag string) error {
 	resolved, err := i.ResolveVersions(versionOrTag)
 	if err != nil {
-		return fmt.Errorf("error updating Thelma: %v", err)
+		return errors.Errorf("error updating Thelma: %v", err)
 	}
 
 	if !resolved.UpdateNeeded() {
@@ -93,7 +93,7 @@ func (i *installer) updateThelmaUnsafe(versionOrTag string) error {
 	// (b) a new version of Thelma was released
 	resolved, err := i.ResolveVersions(versionOrTag)
 	if err != nil {
-		return fmt.Errorf("error updating Thelma: %v", err)
+		return errors.Errorf("error updating Thelma: %v", err)
 	}
 
 	if !resolved.UpdateNeeded() {
@@ -112,19 +112,19 @@ func (i *installer) updateThelmaUnsafe(versionOrTag string) error {
 	targetArchive := releasebucket.NewArchive(targetVersion)
 	unpackDir, err := i.bucket.DownloadAndUnpack(targetArchive)
 	if err != nil {
-		return fmt.Errorf("error installing Thelma %s: %v", targetVersion, err)
+		return errors.Errorf("error installing Thelma %s: %v", targetVersion, err)
 	}
 
 	if err = i.dir.CopyUnpackedArchive(unpackDir); err != nil {
-		return fmt.Errorf("error installing Thelma %s: %v", targetVersion, err)
+		return errors.Errorf("error installing Thelma %s: %v", targetVersion, err)
 	}
 
 	if err = i.dir.UpdateCurrentReleaseSymlink(targetVersion); err != nil {
-		return fmt.Errorf("error installing Thelma %s: %v", targetVersion, err)
+		return errors.Errorf("error installing Thelma %s: %v", targetVersion, err)
 	}
 
 	if err = i.dir.CleanupOldReleases(i.options.KeepReleases); err != nil {
-		return fmt.Errorf("error cleaning up release directory: %v", err)
+		return errors.Errorf("error cleaning up release directory: %v", err)
 	}
 
 	log.Info().Msgf("Thelma has been updated to %s", targetVersion)

--- a/internal/thelma/app/autoupdate/manifest/manifest.go
+++ b/internal/thelma/app/autoupdate/manifest/manifest.go
@@ -3,7 +3,7 @@ package manifest
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path"
 )
@@ -18,7 +18,7 @@ func EnsureMatches(releaseDirectory string, version string) error {
 	}
 
 	if manifestVersion != version {
-		return fmt.Errorf("error verifying release directory %s: build manifest version %s does not match desired Thelma version %s", releaseDirectory, manifestVersion, version)
+		return errors.Errorf("error verifying release directory %s: build manifest version %s does not match desired Thelma version %s", releaseDirectory, manifestVersion, version)
 	}
 
 	return nil
@@ -29,7 +29,7 @@ func Version(releaseDirectory string) (string, error) {
 	manifestFile := path.Join(releaseDirectory, filename)
 	content, err := os.ReadFile(manifestFile)
 	if err != nil {
-		return "", fmt.Errorf("error reading build manifest %s: %v", manifestFile, err)
+		return "", errors.Errorf("error reading build manifest %s: %v", manifestFile, err)
 	}
 
 	type manifest struct {
@@ -37,10 +37,10 @@ func Version(releaseDirectory string) (string, error) {
 	}
 	var m manifest
 	if err = json.Unmarshal(content, &m); err != nil {
-		return "", fmt.Errorf("error parsing build manifest %s: %v", manifestFile, err)
+		return "", errors.Errorf("error parsing build manifest %s: %v", manifestFile, err)
 	}
 	if m.Version == "" {
-		return "", fmt.Errorf("error parsing build manifest %s (version field not found): %v", manifestFile, err)
+		return "", errors.Errorf("error parsing build manifest %s (version field not found): %v", manifestFile, err)
 	}
 
 	return m.Version, nil

--- a/internal/thelma/app/autoupdate/releases/dir_test.go
+++ b/internal/thelma/app/autoupdate/releases/dir_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
 	"github.com/broadinstitute/thelma/internal/thelma/app/root"
 	"github.com/broadinstitute/thelma/internal/thelma/app/scratch"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -111,7 +112,7 @@ func (suite *DirSuite) TestWithInstallerLock() {
 
 	err := suite.dir.WithInstallerLock(func() error {
 		count++
-		return fmt.Errorf("fake error")
+		return errors.Errorf("fake error")
 	})
 
 	require.Error(suite.T(), err)

--- a/internal/thelma/app/config/profiles/ci.yaml
+++ b/internal/thelma/app/config/profiles/ci.yaml
@@ -34,6 +34,9 @@ logging:
   file:
     # disable file logging
     enabled: false
+  # enable stacktraces for errors in CI
+  errtrace:
+    enabled: true
 
 vault:
   # do not manage ~/.vault-token in ArgoCD/Jenkins/GitHub actions, treat vault token like a regular credential

--- a/internal/thelma/app/config/profiles/ci.yaml
+++ b/internal/thelma/app/config/profiles/ci.yaml
@@ -34,9 +34,6 @@ logging:
   file:
     # disable file logging
     enabled: false
-  # enable stacktraces for errors in CI
-  errtrace:
-    enabled: true
 
 vault:
   # do not manage ~/.vault-token in ArgoCD/Jenkins/GitHub actions, treat vault token like a regular credential

--- a/internal/thelma/app/credentials/token_provider_test.go
+++ b/internal/thelma/app/credentials/token_provider_test.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/credentials/stores"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -51,7 +52,7 @@ func Test_Token_Get(t *testing.T) {
 			key:  "my-token",
 			option: func(options *TokenOptions) {
 				options.ValidateFn = func(v []byte) error {
-					return fmt.Errorf("this token is super invalid")
+					return errors.Errorf("this token is super invalid")
 				}
 			},
 			setup: func(t *testing.T, tmpDir string) {
@@ -75,7 +76,7 @@ func Test_Token_Get(t *testing.T) {
 			key:  "my-token",
 			option: func(options *TokenOptions) {
 				options.IssueFn = func() ([]byte, error) {
-					return []byte{}, fmt.Errorf("totally failed to issue new token")
+					return []byte{}, errors.Errorf("totally failed to issue new token")
 				}
 			},
 			expectErr: "totally failed to issue new token",
@@ -92,7 +93,7 @@ func Test_Token_Get(t *testing.T) {
 				}
 				options.ValidateFn = func(v []byte) error {
 					if string(v) == "old-token-value" {
-						return fmt.Errorf("this token expired")
+						return errors.Errorf("this token expired")
 					}
 					return nil
 				}
@@ -110,7 +111,7 @@ func Test_Token_Get(t *testing.T) {
 					return []byte("new-token-value"), nil
 				}
 				options.ValidateFn = func(_ []byte) error {
-					return fmt.Errorf("token is not valid for some reason")
+					return errors.Errorf("token is not valid for some reason")
 				}
 			},
 			expectErr: "token is not valid for some reason",
@@ -127,7 +128,7 @@ func Test_Token_Get(t *testing.T) {
 				}
 				options.ValidateFn = func(v []byte) error {
 					if string(v) == "old-token-value" {
-						return fmt.Errorf("this token expired")
+						return errors.Errorf("this token expired")
 					}
 					return nil
 				}
@@ -145,7 +146,7 @@ func Test_Token_Get(t *testing.T) {
 					return []byte("refreshed-token-value"), nil
 				}
 				options.ValidateFn = func(v []byte) error {
-					return fmt.Errorf("token is invalid")
+					return errors.Errorf("token is invalid")
 				}
 			},
 			expectErr: "refresh for MY_TOKEN returned invalid token: token is invalid",
@@ -158,14 +159,14 @@ func Test_Token_Get(t *testing.T) {
 			},
 			option: func(options *TokenOptions) {
 				options.RefreshFn = func(_ []byte) ([]byte, error) {
-					return nil, fmt.Errorf("token too old to be refreshed")
+					return nil, errors.Errorf("token too old to be refreshed")
 				}
 				options.IssueFn = func() ([]byte, error) {
 					return []byte("new-token-value"), nil
 				}
 				options.ValidateFn = func(v []byte) error {
 					if string(v) == "old-token-value" {
-						return fmt.Errorf("this token expired")
+						return errors.Errorf("this token expired")
 					}
 					return nil
 				}

--- a/internal/thelma/app/metrics/labels/labels.go
+++ b/internal/thelma/app/metrics/labels/labels.go
@@ -5,9 +5,9 @@
 package labels
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 )
 
 var reservedLabelNames = set.NewStringSet("job")
@@ -26,7 +26,7 @@ func ForReleaseOrDestination(value interface{}, extra ...map[string]string) map[
 			ForDestination(t),
 		)
 	default:
-		panic(fmt.Errorf("unexpected type: %#v", t))
+		panic(errors.Errorf("unexpected type: %#v", t))
 	}
 
 	var all []map[string]string

--- a/internal/thelma/app/metrics/metrics_test.go
+++ b/internal/thelma/app/metrics/metrics_test.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
@@ -128,7 +128,7 @@ thelma_counter{_job="fixme",a="1",b="2",platform="jenkins"} 123
 					Name:   "fake_task",
 					Help:   "A fake task",
 					Labels: map[string]string{"id": "23"},
-				}, 1800*time.Millisecond, fmt.Errorf("this one failed"))
+				}, 1800*time.Millisecond, errors.Errorf("this one failed"))
 
 			},
 			expected: `# HELP thelma_fake_task_count A fake task

--- a/internal/thelma/app/platform/platform.go
+++ b/internal/thelma/app/platform/platform.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 	"os/user"
@@ -80,7 +81,7 @@ func (p Platform) String() string {
 	case Jenkins:
 		return "jenkins"
 	}
-	panic(fmt.Errorf("unrecognized platform: %#v", p))
+	panic(errors.Errorf("unrecognized platform: %#v", p))
 }
 
 // Link returns a link to the CI/CD logs for this Thelma run, if applicable
@@ -109,7 +110,7 @@ func (p *Platform) UnmarshalText(text []byte) error {
 	case "jenkins":
 		*p = Jenkins
 	default:
-		return fmt.Errorf("invalid platform: %q", s)
+		return errors.Errorf("invalid platform: %q", s)
 	}
 	return nil
 }

--- a/internal/thelma/app/root/root.go
+++ b/internal/thelma/app/root/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/env"
 	"github.com/broadinstitute/thelma/internal/thelma/app/name"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path"
@@ -124,7 +125,7 @@ func (r root) CreateDirectories() error {
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0700); err != nil {
-			return fmt.Errorf("error creating directory %s: %v", dir, err)
+			return errors.Errorf("error creating directory %s: %v", dir, err)
 		}
 	}
 

--- a/internal/thelma/app/scratch/scratch.go
+++ b/internal/thelma/app/scratch/scratch.go
@@ -1,8 +1,8 @@
 package scratch
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 )
@@ -41,7 +41,7 @@ func NewScratch(config config.Config) (Scratch, error) {
 	}
 	scratchRoot, err := os.MkdirTemp(cfg.TmpDir, rootPattern)
 	if err != nil {
-		return nil, fmt.Errorf("error creating scratch directory in %s for process: %v", cfg.TmpDir, err)
+		return nil, errors.Errorf("error creating scratch directory in %s for process: %v", cfg.TmpDir, err)
 	}
 
 	return &scratch{

--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -9,6 +9,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/ops/artifacts"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/logs"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/status"
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/broadinstitute/thelma/internal/thelma/bee/seed"
@@ -148,7 +149,7 @@ func (b *bees) ProvisionWith(name string, options ProvisionOptions) (*Bee, error
 	}
 	if env == nil {
 		// don't think this could ever happen, but let's provide a useful error anyway
-		return nil, fmt.Errorf("error provisioning environment %q: missing from state", env.Name())
+		return nil, errors.Errorf("error provisioning environment %q: missing from state", env.Name())
 	}
 
 	bee := &Bee{
@@ -273,7 +274,7 @@ func (b *bees) DeleteWith(name string, options DeleteOptions) (*Bee, error) {
 		return nil, err
 	}
 	if env.PreventDeletion() {
-		return nil, fmt.Errorf("won't delete environment %s, deletion protection is enabled", env.Name())
+		return nil, errors.Errorf("won't delete environment %s, deletion protection is enabled", env.Name())
 	}
 
 	bee := &Bee{
@@ -340,7 +341,7 @@ func (b *bees) StartStopWith(name string, offline bool, options StartStopOptions
 	}
 	if env == nil {
 		// don't think this could ever happen, but let's provide a useful error anyway
-		return nil, fmt.Errorf("error re-loading environment %q: missing from state", env.Name())
+		return nil, errors.Errorf("error re-loading environment %q: missing from state", env.Name())
 	}
 
 	bee := &Bee{
@@ -471,10 +472,10 @@ func (b *bees) GetBee(name string) (terra.Environment, error) {
 		return nil, err
 	}
 	if env == nil {
-		return nil, fmt.Errorf("no BEE by the name %q exists", name)
+		return nil, errors.Errorf("no BEE by the name %q exists", name)
 	}
 	if env.Lifecycle() != terra.Dynamic {
-		return nil, fmt.Errorf("environment %s is not a BEE (lifecycle is %s)", name, env.Lifecycle())
+		return nil, errors.Errorf("environment %s is not a BEE (lifecycle is %s)", name, env.Lifecycle())
 	}
 	return env, nil
 }
@@ -492,7 +493,7 @@ func (b *bees) GetTemplate(name string) (terra.Environment, error) {
 	if err != nil {
 		return nil, err
 	}
-	return nil, fmt.Errorf("no template by the name %q exists, valid templates are: %s", name, strings.Join(names, ", "))
+	return nil, errors.Errorf("no template by the name %q exists, valid templates are: %s", name, strings.Join(names, ", "))
 }
 
 func (b *bees) ResetStatefulSets(env terra.Environment) (map[terra.Release]*status.Status, error) {

--- a/internal/thelma/bee/seed/config.go
+++ b/internal/thelma/bee/seed/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"strings"
 )
@@ -115,7 +116,7 @@ func (s *seeder) googleAuthAs(appRelease terra.AppRelease) (google.Clients, erro
 		vaultPath = config.Auth.WorkspaceManager.VaultPath
 		vaultKey = config.Auth.WorkspaceManager.VaultKey
 	default:
-		return nil, fmt.Errorf("thelma doesn't know how to authenticate as %s", appRelease.Name())
+		return nil, errors.Errorf("thelma doesn't know how to authenticate as %s", appRelease.Name())
 	}
 	if strings.ContainsRune(vaultPath, '%') {
 		vaultPath = fmt.Sprintf(vaultPath, appRelease.Cluster().ProjectSuffix())
@@ -130,7 +131,7 @@ func (s *seeder) configWithBasicDefaults() (seedConfig, error) {
 	var config seedConfig
 	err := s.config.Unmarshal(configKey, &config)
 	if err != nil {
-		return config, fmt.Errorf("error reading seed config: %v", err)
+		return config, errors.Errorf("error reading seed config: %v", err)
 	}
 	return config, nil
 }

--- a/internal/thelma/bee/seed/seed_step_1_create_elasticsearch.go
+++ b/internal/thelma/bee/seed/seed_step_1_create_elasticsearch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"io"
 	"net/http"
@@ -19,7 +20,7 @@ func (s *seeder) seedStep1CreateElasticsearch(appReleases map[string]terra.AppRe
 		}
 		localPort, stopFunc, err := s.kubectl.PortForward(elasticsearch, fmt.Sprintf("service/%s", config.Elasticsearch.Service), elasticsearch.Port())
 		if err != nil {
-			return fmt.Errorf("error port-forwarding to Elasticsearch: %v", err)
+			return errors.Errorf("error port-forwarding to Elasticsearch: %v", err)
 		}
 		defer func() { _ = stopFunc() }()
 
@@ -46,7 +47,7 @@ func _createIndex(client http.Client, protocol string, localElasticsearchPort in
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("error creating %s: %v", index, err)
+		return errors.Errorf("error creating %s: %v", index, err)
 	}
 	respBody, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
@@ -55,7 +56,7 @@ func _createIndex(client http.Client, protocol string, localElasticsearchPort in
 	}
 	respBodyString := string(respBody)
 	if resp.StatusCode > 299 {
-		return fmt.Errorf("%s status creating %s (%s)", resp.Status, index, respBodyString)
+		return errors.Errorf("%s status creating %s (%s)", resp.Status, index, respBodyString)
 	}
 	return nil
 }
@@ -77,7 +78,7 @@ func _setElasticsearchReplicas(client http.Client, protocol string, localElastic
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("error setting replica count: %v", err)
+		return errors.Errorf("error setting replica count: %v", err)
 	}
 	respBody, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
@@ -86,7 +87,7 @@ func _setElasticsearchReplicas(client http.Client, protocol string, localElastic
 	}
 	respBodyString := string(respBody)
 	if resp.StatusCode > 299 {
-		return fmt.Errorf("%s status setting replica count (%s)", resp.Status, respBodyString)
+		return errors.Errorf("%s status setting replica count (%s)", resp.Status, respBodyString)
 	}
 	return nil
 }

--- a/internal/thelma/bee/seed/seed_step_2_register_sa_profiles.go
+++ b/internal/thelma/bee/seed/seed_step_2_register_sa_profiles.go
@@ -1,7 +1,7 @@
 package seed
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"regexp"
 
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
@@ -98,7 +98,7 @@ func _ignore409Conflict(maybe409Err error) error {
 	matches, err := regexp.MatchString(pattern, maybe409Err.Error())
 
 	if err != nil {
-		panic(fmt.Errorf("invalid regular expression %q: %v", pattern, err))
+		panic(errors.Errorf("invalid regular expression %q: %v", pattern, err))
 	}
 
 	if !matches {

--- a/internal/thelma/bee/seed/seed_step_4_register_test_users.go
+++ b/internal/thelma/bee/seed/seed_step_4_register_test_users.go
@@ -1,8 +1,8 @@
 package seed
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -20,7 +20,7 @@ func (s *seeder) seedStep4RegisterTestUsers(appReleases map[string]terra.AppRele
 			} else if sam.Cluster().ProjectSuffix() == "qa" {
 				users = seedConfig.TestUsers.QA
 			} else {
-				return fmt.Errorf("suffix %s of project %s maps to no test users", sam.Cluster().ProjectSuffix(), sam.Cluster().Project())
+				return errors.Errorf("suffix %s of project %s maps to no test users", sam.Cluster().ProjectSuffix(), sam.Cluster().Project())
 			}
 
 			googleClient, err := s.googleAuthAs(orch)

--- a/internal/thelma/bee/seed/seed_step_5_create_agora.go
+++ b/internal/thelma/bee/seed/seed_step_5_create_agora.go
@@ -1,8 +1,8 @@
 package seed
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -20,7 +20,7 @@ func (s *seeder) seedStep5CreateAgora(appReleases map[string]terra.AppRelease, o
 			} else if orch.Cluster().ProjectSuffix() == "qa" {
 				acls = seedConfig.Agora.Permissions.QA
 			} else {
-				err = fmt.Errorf("suffix %s of project %s maps to not Agora ACLs", orch.Cluster().ProjectSuffix(), orch.Cluster().Project())
+				err = errors.Errorf("suffix %s of project %s maps to not Agora ACLs", orch.Cluster().ProjectSuffix(), orch.Cluster().Project())
 				if err = opts.handleErrorWithForce(err); err != nil {
 					return err
 				}

--- a/internal/thelma/charts/dependency/dependency.go
+++ b/internal/thelma/charts/dependency/dependency.go
@@ -1,7 +1,7 @@
 package dependency
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"sort"
 	"strings"
 )
@@ -174,7 +174,7 @@ func searchForCycles(node *graphNode, path map[string]string, checked map[string
 	}
 	for _, dep := range node.dependencies {
 		if _, exists := path[dep.chartName]; exists {
-			return fmt.Errorf("cycle detected: %s", pathToString(path, node.chartName, dep.chartName))
+			return errors.Errorf("cycle detected: %s", pathToString(path, node.chartName, dep.chartName))
 		}
 
 		path[dep.chartName] = node.chartName

--- a/internal/thelma/charts/repo/index/index.go
+++ b/internal/thelma/charts/repo/index/index.go
@@ -1,8 +1,8 @@
 package index
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/charts/semver"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -33,12 +33,12 @@ type index struct {
 func LoadFromFile(filePath string) (*index, error) {
 	indexContent, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading index file %s: %v", filePath, err)
+		return nil, errors.Errorf("error reading index file %s: %v", filePath, err)
 	}
 
 	var _index index
 	if err := yaml.Unmarshal(indexContent, &_index); err != nil {
-		return nil, fmt.Errorf("error parsing index file %s: %v", filePath, err)
+		return nil, errors.Errorf("error parsing index file %s: %v", filePath, err)
 	}
 
 	return &_index, nil

--- a/internal/thelma/charts/repo/repo.go
+++ b/internal/thelma/charts/repo/repo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket/lock"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket/object"
+	"github.com/pkg/errors"
 	"path"
 	"time"
 )
@@ -90,7 +91,7 @@ func (r *repo) IsLocked() bool {
 // Unlock unlocks the repository
 func (r *repo) Unlock() error {
 	if !r.IsLocked() {
-		return fmt.Errorf("repo is not locked")
+		return errors.Errorf("repo is not locked")
 	}
 
 	if err := r.locker.Unlock(r.lockId); err != nil {
@@ -105,7 +106,7 @@ func (r *repo) Unlock() error {
 // Lock locks the repository
 func (r *repo) Lock() error {
 	if r.IsLocked() {
-		return fmt.Errorf("repo is already locked")
+		return errors.Errorf("repo is already locked")
 	}
 
 	lockId, err := r.locker.Lock()

--- a/internal/thelma/charts/semver/semver.go
+++ b/internal/thelma/charts/semver/semver.go
@@ -2,6 +2,7 @@ package semver
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 	"strconv"
 	"strings"
@@ -24,17 +25,17 @@ func Compare(v string, w string) int {
 // MinorBump("1.2.3") -> "1.3.0"
 func MinorBump(version string) (string, error) {
 	if !IsValid(version) {
-		return "", fmt.Errorf("invalid semantic version %q", version)
+		return "", errors.Errorf("invalid semantic version %q", version)
 	}
 
 	tokens := strings.SplitN(version, ".", 3)
 	if len(tokens) < 2 {
-		return "", fmt.Errorf("invalid semantic version %q", version)
+		return "", errors.Errorf("invalid semantic version %q", version)
 	}
 	major := tokens[0]
 	minor, err := strconv.Atoi(tokens[1])
 	if err != nil {
-		return "", fmt.Errorf("invalid semantic version %q: %v", version, err)
+		return "", errors.Errorf("invalid semantic version %q: %v", version, err)
 	}
 
 	return fmt.Sprintf("%s.%d.0", major, minor+1), nil

--- a/internal/thelma/charts/source/autoreleaser.go
+++ b/internal/thelma/charts/source/autoreleaser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/sherlock"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -74,7 +75,7 @@ func (a *AutoReleaser) UpdateReleaseVersion(chart Chart, newVersion string, last
 			if sherlockCanAlwaysSoftFail {
 				log.Warn().Err(err).Msgf("autorelease error on sherlock updater %d: %v", index, err)
 			} else {
-				return fmt.Errorf("autorelease error on sherlock updater %d: %v", index, err)
+				return errors.Errorf("autorelease error on sherlock updater %d: %v", index, err)
 			}
 		}
 	}

--- a/internal/thelma/charts/source/chart.go
+++ b/internal/thelma/charts/source/chart.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path"
 	"strings"
@@ -105,7 +106,7 @@ func (c *chart) BumpChartVersion(latestPublishedVersion string) (string, error) 
 		return nextVersion, err
 	}
 	if c.manifest.Version != nextVersion {
-		return nextVersion, fmt.Errorf("error updating %s chart version to %s in %s: version is still %s after update", c.name, nextVersion, manifestFile, c.manifest.Version)
+		return nextVersion, errors.Errorf("error updating %s chart version to %s in %s: version is still %s after update", c.name, nextVersion, manifestFile, c.manifest.Version)
 	}
 	return nextVersion, nil
 }
@@ -182,12 +183,12 @@ func (c *chart) SetDependencyVersion(dependencyName string, newVersion string) e
 				log.Debug().Msgf("updated version for dependency %s to %s in %s", dependencyName, newVersion, manifestFile)
 				return nil
 			} else {
-				return fmt.Errorf("error setting dependency %s to version %s in %s: dependency not found", dependencyName, newVersion, manifestFile)
+				return errors.Errorf("error setting dependency %s to version %s in %s: dependency not found", dependencyName, newVersion, manifestFile)
 			}
 		}
 	}
 
-	return fmt.Errorf("error setting dependency %s to version %s in %s: dependency not found", dependencyName, newVersion, manifestFile)
+	return errors.Errorf("error setting dependency %s to version %s in %s: dependency not found", dependencyName, newVersion, manifestFile)
 }
 
 func (c *chart) ManifestVersion() string {
@@ -227,7 +228,7 @@ func (c *chart) reloadManifest() error {
 	manifestFile := path.Join(c.path, chartManifestFile)
 	manifest, err := loadManifest(manifestFile)
 	if err != nil {
-		return fmt.Errorf("manifest reload failed: %v", err)
+		return errors.Errorf("manifest reload failed: %v", err)
 	}
 	log.Debug().Msgf("chart %s: reloaded manifest file %s", c.name, manifestFile)
 	c.manifest = manifest
@@ -239,11 +240,11 @@ func loadManifest(manifestFile string) (ChartManifest, error) {
 
 	content, err := os.ReadFile(manifestFile)
 	if err != nil {
-		return manifest, fmt.Errorf("error reading chart manifest %s: %v", manifestFile, err)
+		return manifest, errors.Errorf("error reading chart manifest %s: %v", manifestFile, err)
 	}
 
 	if err := yaml.Unmarshal(content, &manifest); err != nil {
-		return manifest, fmt.Errorf("error parsing chart manifest %s: %v", manifestFile, err)
+		return manifest, errors.Errorf("error parsing chart manifest %s: %v", manifestFile, err)
 	}
 	log.Debug().Msgf("loaded chart manifest from %s: %v", manifestFile, manifest)
 

--- a/internal/thelma/charts/source/charts_dir.go
+++ b/internal/thelma/charts/source/charts_dir.go
@@ -1,7 +1,7 @@
 package source
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"path"
 	"path/filepath"
 	"strings"
@@ -69,7 +69,7 @@ func (d *chartsDir) PublishAndRelease(chartNames []string, description string) (
 	chartsToPublish := chartNames
 	for _, chartName := range chartsToPublish {
 		if _, exists := d.charts[chartName]; !exists {
-			return nil, fmt.Errorf("chart %q does not exist in source dir %s", chartName, d.sourceDir)
+			return nil, errors.Errorf("chart %q does not exist in source dir %s", chartName, d.sourceDir)
 		}
 	}
 
@@ -177,7 +177,7 @@ func loadCharts(sourceDir string, shellRunner shell.Runner) (map[string]Chart, e
 	glob := path.Join(sourceDir, path.Join("*", chartManifestFile))
 	manifestFiles, err := filepath.Glob(glob)
 	if err != nil {
-		return nil, fmt.Errorf("error globbing charts with %q: %v", glob, err)
+		return nil, errors.Errorf("error globbing charts with %q: %v", glob, err)
 	}
 
 	// For each chart.yaml file, parse it and store in collection of chart objects
@@ -187,7 +187,7 @@ func loadCharts(sourceDir string, shellRunner shell.Runner) (map[string]Chart, e
 		// Create node for this chart
 		_chart, err := NewChart(path.Dir(manifestFile), shellRunner)
 		if err != nil {
-			return nil, fmt.Errorf("error creating chart from %s: %v", manifestFile, err)
+			return nil, errors.Errorf("error creating chart from %s: %v", manifestFile, err)
 		}
 		charts[_chart.Name()] = _chart
 	}

--- a/internal/thelma/cli/command_key.go
+++ b/internal/thelma/cli/command_key.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"regexp"
 	"strings"
 )
@@ -34,10 +34,10 @@ func validateCommandName(fullName string) error {
 	components := strings.Fields(fullName)
 	for _, component := range components {
 		if component == reservedRootCommandName {
-			return fmt.Errorf("invalid command key (%q is reserved): %v", reservedRootCommandName, fullName)
+			return errors.Errorf("invalid command key (%q is reserved): %v", reservedRootCommandName, fullName)
 		}
 		if !validCommandName.MatchString(component) {
-			return fmt.Errorf("invalid command key (each component must match %q): %v", validCommandName.String(), fullName)
+			return errors.Errorf("invalid command key (each component must match %q): %v", validCommandName.String(), fullName)
 		}
 	}
 	return nil
@@ -46,8 +46,9 @@ func validateCommandName(fullName string) error {
 // description returns a string description of the command, suitable for use in log and error messages. Identical
 // to longName except "root" is returned for the root command instead of the empty string.
 // eg. [] (root) -> "root"
-//     ["render"] -> "render"
-//     ["charts", "import"] -> "charts import"
+//
+//	["render"] -> "render"
+//	["charts", "import"] -> "charts import"
 func (n commandKey) description() string {
 	if n.isRoot() {
 		return reservedRootCommandName
@@ -57,26 +58,29 @@ func (n commandKey) description() string {
 
 // depth returns nest level for this command
 // eg. [] (root) -> 0
-//     ["render"] -> 1,
-//     ["charts", "import"] -> 2
+//
+//	["render"] -> 1,
+//	["charts", "import"] -> 2
 func (n commandKey) depth() int {
 	return len(n.nameComponents)
 }
 
 // longName returns unique long key for this command, including ancestors. Suitable for use as a hash key.
 // eg. [] (root) -> ""
-//     ["render"] -> "render"
-//     ["charts", "import"] -> "charts import"
-//     ["data", "import"] -> "data import"
+//
+//	["render"] -> "render"
+//	["charts", "import"] -> "charts import"
+//	["data", "import"] -> "data import"
 func (n commandKey) longName() string {
 	return strings.Join(n.nameComponents, " ")
 }
 
 // shortName returns short / leaf key of this command, without ancestors.
 // eg. [] (root) -> ""
-//     ["render"] -> "render"
-//     ["charts", "import"] -> "import"
-//     ["bee", "import"] -> "import"
+//
+//	["render"] -> "render"
+//	["charts", "import"] -> "import"
+//	["bee", "import"] -> "import"
 func (n commandKey) shortName() string {
 	if n.isRoot() { // avoid out of bounds for root command
 		return ""
@@ -91,9 +95,10 @@ func (n commandKey) isRoot() bool {
 
 // ancestors returns ancestor components of the command name
 // eg. ["render"] -> []
-//     ["charts", "import"] -> ["charts"]
-//     [] (root) -> []
-//     ["a", "b", "c"] -> ["a", "b"]
+//
+//	["charts", "import"] -> ["charts"]
+//	[] (root) -> []
+//	["a", "b", "c"] -> ["a", "b"]
 func (n commandKey) ancestors() []string {
 	if n.isRoot() {
 		return []string{}

--- a/internal/thelma/cli/command_tree.go
+++ b/internal/thelma/cli/command_tree.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sort"
 	"strings"
@@ -53,7 +54,7 @@ func newTree(commands map[string]ThelmaCommand) *node {
 			for i, k := range entries {
 				cmdNames[i] = fmt.Sprintf("%q", k.key.description())
 			}
-			panic(fmt.Errorf("could not find parent command for command %q, registered command names are:\n%v", entry.key.description(), strings.Join(cmdNames, "\n")))
+			panic(errors.Errorf("could not find parent command for command %q, registered command names are:\n%v", entry.key.description(), strings.Join(cmdNames, "\n")))
 		}
 
 		// add a node for this entry

--- a/internal/thelma/cli/commands/auth/argocd/argocd_command.go
+++ b/internal/thelma/cli/commands/auth/argocd/argocd_command.go
@@ -1,10 +1,10 @@
 package argocd
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/argocd"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +31,7 @@ func (cmd *argocdCommand) PreRun(_ app.ThelmaApp, _ cli.RunContext) error {
 func (cmd *argocdCommand) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 	iapToken, err := app.Clients().IAPToken()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve IAP token: %v", err)
+		return errors.Errorf("failed to retrieve IAP token: %v", err)
 	}
 	if err = argocd.BrowserLogin(app.Config(), app.ShellRunner(), iapToken); err != nil {
 		return err

--- a/internal/thelma/cli/commands/auth/auth_command.go
+++ b/internal/thelma/cli/commands/auth/auth_command.go
@@ -1,10 +1,10 @@
 package auth
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/app/credentials"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +23,7 @@ func NewAuthCommand() cli.ThelmaCommand {
 func ForProvider(provider credentials.TokenProvider, rc cli.RunContext) error {
 	cmd, ok := rc.Parent().(*authCommand)
 	if !ok {
-		panic(fmt.Errorf("unexpected parent command type: %v", rc.Parent()))
+		panic(errors.Errorf("unexpected parent command type: %v", rc.Parent()))
 	}
 
 	return cmd.handleAuth(provider, rc)

--- a/internal/thelma/cli/commands/bee/common/builders/builders.go
+++ b/internal/thelma/cli/commands/bee/common/builders/builders.go
@@ -1,11 +1,11 @@
 package builders
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
 	"github.com/broadinstitute/thelma/internal/thelma/bee/cleanup"
 	"github.com/broadinstitute/thelma/internal/thelma/bee/seed"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -43,7 +43,7 @@ func NewBees(thelmaApp app.ThelmaApp) (bee.Bees, error) {
 func newSeeder(thelma app.ThelmaApp) (seed.Seeder, error) {
 	_kubectl, err := thelma.Clients().Kubernetes().Kubectl()
 	if err != nil {
-		return nil, fmt.Errorf("error getting kubectl client: %v", err)
+		return nil, errors.Errorf("error getting kubectl client: %v", err)
 	}
 
 	return seed.New(_kubectl, thelma.Clients(), thelma.Config(), thelma.ShellRunner()), nil

--- a/internal/thelma/cli/commands/bee/common/filterflags/filterflags.go
+++ b/internal/thelma/cli/commands/bee/common/filterflags/filterflags.go
@@ -1,11 +1,11 @@
 package filterflags
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/flags"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/filter"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"time"
@@ -69,7 +69,7 @@ func (f *filterFlags) GetFilter(thelmaApp app.ThelmaApp) (terra.EnvironmentFilte
 			return nil, err
 		}
 		if template == nil {
-			return nil, fmt.Errorf("--%s: no template by the name %q exists", flagNames.template, f.flagVals.template)
+			return nil, errors.Errorf("--%s: no template by the name %q exists", flagNames.template, f.flagVals.template)
 		}
 		filters = append(filters, filter.Environments().HasTemplate(template))
 	}

--- a/internal/thelma/cli/commands/bee/common/pinflags/parsing.go
+++ b/internal/thelma/cli/commands/bee/common/pinflags/parsing.go
@@ -4,9 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 	"regexp"
@@ -26,7 +26,7 @@ var versionsParsers = map[string]versionsParser{
 func parseVersions(format string, input []byte) (map[string]terra.VersionOverride, error) {
 	parser, exists := versionsParsers[format]
 	if !exists {
-		return nil, fmt.Errorf("--%s: invalid format %q (valid formats are: %s)", flagNames.versionsFormat, format, utils.QuoteJoin(versionFormats()))
+		return nil, errors.Errorf("--%s: invalid format %q (valid formats are: %s)", flagNames.versionsFormat, format, utils.QuoteJoin(versionFormats()))
 	}
 	overrides, err := parser(input)
 	if err != nil {
@@ -57,10 +57,10 @@ func normalizeImageTags(input map[string]terra.VersionOverride) map[string]terra
 
 // this is needed for backwards-compatibility with old/legacy Jenkins pipelines. Original code:
 //
-//    BRANCH_NAME=$(get_image_name $CONFIG)
-//    REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES="s/[^a-zA-Z0-9_.\-]/-/g"
-//    REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING="s/^[.\-]*//g"
-//    IMAGE=$(echo $BRANCH_NAME | sed -e $REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES -e $REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
+//	BRANCH_NAME=$(get_image_name $CONFIG)
+//	REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES="s/[^a-zA-Z0-9_.\-]/-/g"
+//	REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING="s/^[.\-]*//g"
+//	IMAGE=$(echo $BRANCH_NAME | sed -e $REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES -e $REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
 //
 // https://github.com/broadinstitute/firecloud-develop/blob/a8573a38698890031444166320db1a857f8a0834/run-context/fiab/scripts/FiaB_configs.sh#L125
 func normalizeImageTag(imageTag string) string {

--- a/internal/thelma/cli/commands/bee/common/pinflags/pinflags.go
+++ b/internal/thelma/cli/commands/bee/common/pinflags/pinflags.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -78,7 +79,7 @@ func (p *pinFlags) loadReleaseOverrides(thelmaApp app.ThelmaApp, rc cli.RunConte
 	flags := rc.CobraCommand().Flags()
 	if flags.Changed(flagNames.fromEnv) {
 		if flags.Changed(flagNames.versionsFile) {
-			return nil, fmt.Errorf("either %s or %s can be specified, but not both", flagNames.versionsFile, flagNames.fromEnv)
+			return nil, errors.Errorf("either %s or %s can be specified, but not both", flagNames.versionsFile, flagNames.fromEnv)
 		}
 		return p.loadReleaseOverridesFromEnv(thelmaApp)
 	} else if flags.Changed(flagNames.versionsFile) {
@@ -114,7 +115,7 @@ func (p *pinFlags) loadReleaseOverridesFromEnv(thelmaApp app.ThelmaApp) (map[str
 		return nil, err
 	}
 	if env == nil {
-		return nil, fmt.Errorf("--%s: no such environment %q", flagNames.fromEnv, p.options.fromEnv)
+		return nil, errors.Errorf("--%s: no such environment %q", flagNames.fromEnv, p.options.fromEnv)
 	}
 
 	result := make(map[string]terra.VersionOverride)

--- a/internal/thelma/cli/commands/bee/create/create_command.go
+++ b/internal/thelma/cli/commands/bee/create/create_command.go
@@ -1,7 +1,7 @@
 package create
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"time"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app"
@@ -114,12 +114,12 @@ func (cmd *createCommand) PreRun(thelmaApp app.ThelmaApp, ctx cli.RunContext) er
 	// if --name not specified, generate a name for this BEE
 	if ctx.CobraCommand().Flags().Changed(flagNames.name) {
 		if err := validate.EnvironmentName(cmd.options.Name); err != nil {
-			return fmt.Errorf("--%s: %q is not a valid environment name: %v", flagNames.name, cmd.options.Name, err)
+			return errors.Errorf("--%s: %q is not a valid environment name: %v", flagNames.name, cmd.options.Name, err)
 		}
 		cmd.options.GenerateName = false
 	} else {
 		if err := validate.EnvironmentNamePrefix(cmd.options.NamePrefix); err != nil {
-			return fmt.Errorf("--%s: %q is not a valid environment name prefix: %v", flagNames.namePrefix, cmd.options.NamePrefix, err)
+			return errors.Errorf("--%s: %q is not a valid environment name prefix: %v", flagNames.namePrefix, cmd.options.NamePrefix, err)
 		}
 		cmd.options.GenerateName = true
 	}
@@ -133,7 +133,7 @@ func (cmd *createCommand) PreRun(thelmaApp app.ThelmaApp, ctx cli.RunContext) er
 		cmd.options.StopSchedule.Enabled = true
 		t, err := time.Parse(time.RFC3339, cmd.options.dailyStopTime)
 		if err != nil {
-			return fmt.Errorf("%s was an invalid time: %v", cmd.options.dailyStopTime, err)
+			return errors.Errorf("%s was an invalid time: %v", cmd.options.dailyStopTime, err)
 		}
 		cmd.options.StopSchedule.RepeatingTime = t
 	}
@@ -142,7 +142,7 @@ func (cmd *createCommand) PreRun(thelmaApp app.ThelmaApp, ctx cli.RunContext) er
 		cmd.options.StartSchedule.Enabled = true
 		t, err := time.Parse(time.RFC3339, cmd.options.dailyStartTime)
 		if err != nil {
-			return fmt.Errorf("%s was an invalid time: %v", cmd.options.dailyStartTime, err)
+			return errors.Errorf("%s was an invalid time: %v", cmd.options.dailyStartTime, err)
 		}
 		cmd.options.StartSchedule.RepeatingTime = t
 		cmd.options.StartSchedule.Weekends = cmd.options.dailyStartWeekends
@@ -155,7 +155,7 @@ func (cmd *createCommand) PreRun(thelmaApp app.ThelmaApp, ctx cli.RunContext) er
 	}
 	_, err = bees.GetTemplate(cmd.options.Template)
 	if err != nil {
-		return fmt.Errorf("--%s: %v", flagNames.template, err)
+		return errors.Errorf("--%s: %v", flagNames.template, err)
 	}
 
 	// validate/load pin and seed options

--- a/internal/thelma/cli/commands/bee/delete/delete_command.go
+++ b/internal/thelma/cli/commands/bee/delete/delete_command.go
@@ -1,12 +1,12 @@
 package delete
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -52,11 +52,11 @@ func (cmd *deleteCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 func (cmd *deleteCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 	// validate --name
 	if !ctx.CobraCommand().Flags().Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 	return nil
 }

--- a/internal/thelma/cli/commands/bee/describe/describe_command.go
+++ b/internal/thelma/cli/commands/bee/describe/describe_command.go
@@ -1,11 +1,11 @@
 package list
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +45,7 @@ func (cmd *describeCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 func (cmd *describeCommand) PreRun(_ app.ThelmaApp, rc cli.RunContext) error {
 	// validate --name
 	if !rc.CobraCommand().Flags().Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	return nil
 }

--- a/internal/thelma/cli/commands/bee/pin/pin_command.go
+++ b/internal/thelma/cli/commands/bee/pin/pin_command.go
@@ -1,12 +1,12 @@
 package pin
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/pinflags"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/argocd"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -95,11 +95,11 @@ func (cmd *pinCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 
 	// validate --name
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.options.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/provision/provision_command.go
+++ b/internal/thelma/cli/commands/bee/provision/provision_command.go
@@ -1,7 +1,6 @@
 package provision
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
@@ -9,6 +8,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/pinflags"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/seedflags"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -76,11 +76,11 @@ func (cmd *provisionCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 
 func (cmd *provisionCommand) PreRun(app app.ThelmaApp, ctx cli.RunContext) error {
 	if !ctx.CobraCommand().Flags().Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 	// validate/load pin and seed options
 	pinOptions, err := cmd.pinFlags.GetPinOptions(app, ctx)

--- a/internal/thelma/cli/commands/bee/reset/reset_command.go
+++ b/internal/thelma/cli/commands/bee/reset/reset_command.go
@@ -1,11 +1,11 @@
 package reset
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -45,11 +45,11 @@ func (cmd *resetCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 
 	// validate --name
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.options.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/seed/seed/seed_command.go
+++ b/internal/thelma/cli/commands/bee/seed/seed/seed_command.go
@@ -1,11 +1,11 @@
 package seed
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/seedflags"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -79,11 +79,11 @@ func (cmd *seedCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 
 	// validate --name
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.options.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/seed/unseed/unseed_command.go
+++ b/internal/thelma/cli/commands/bee/seed/unseed/unseed_command.go
@@ -1,11 +1,11 @@
 package unseed
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/unseedflags"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -75,11 +75,11 @@ func (cmd *unseedCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 
 	// validate --name
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.options.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/start/start_command.go
+++ b/internal/thelma/cli/commands/bee/start/start_command.go
@@ -1,12 +1,12 @@
 package start
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +55,7 @@ func (cmd *startCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 	flags := ctx.CobraCommand().Flags()
 
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/stop/stop_command.go
+++ b/internal/thelma/cli/commands/bee/stop/stop_command.go
@@ -1,12 +1,12 @@
 package stop
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +55,7 @@ func (cmd *stopCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 	flags := ctx.CobraCommand().Flags()
 
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/sync/sync_command.go
+++ b/internal/thelma/cli/commands/bee/sync/sync_command.go
@@ -1,12 +1,12 @@
 package provision
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/bee"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/views"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -60,11 +60,11 @@ func (cmd *syncCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 
 func (cmd *syncCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 	if !ctx.CobraCommand().Flags().Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/unpin/unpin_command.go
+++ b/internal/thelma/cli/commands/bee/unpin/unpin_command.go
@@ -1,10 +1,10 @@
 package unpin
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/bee/common/builders"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -48,11 +48,11 @@ func (cmd *unpinCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 func (cmd *unpinCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 	// validate --name
 	if !ctx.CobraCommand().Flags().Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.options.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bee/vars/vars_command.go
+++ b/internal/thelma/cli/commands/bee/vars/vars_command.go
@@ -5,6 +5,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -44,11 +45,11 @@ func (cmd *varsCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 
 	// validate --name
 	if !flags.Changed(flagNames.name) {
-		return fmt.Errorf("no environment name specified; --%s is required", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s is required", flagNames.name)
 	}
 	if strings.TrimSpace(cmd.options.name) == "" {
 		log.Warn().Msg("Is Thelma running in CI? Check that you're setting the name of your environment when running your job")
-		return fmt.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
+		return errors.Errorf("no environment name specified; --%s was passed but no name was given", flagNames.name)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/bees/apply_schedule/apply_schedule_command.go
+++ b/internal/thelma/cli/commands/bees/apply_schedule/apply_schedule_command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/schedule"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"sync"
@@ -220,7 +221,7 @@ func (cmd *command) Run(app app.ThelmaApp, rc cli.RunContext) error {
 	}
 	state, err = stateLoader.Reload()
 	if err != nil {
-		return fmt.Errorf("flipped BEEs but couldn't reload state: %v", err)
+		return errors.Errorf("flipped BEEs but couldn't reload state: %v", err)
 	}
 
 	var successfullyFlippedEnvs []terra.Environment

--- a/internal/thelma/cli/commands/bees/delete/delete_command.go
+++ b/internal/thelma/cli/commands/bees/delete/delete_command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/filter"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"strings"
@@ -97,7 +98,7 @@ func (cmd *command) Run(app app.ThelmaApp, rc cli.RunContext) error {
 
 	slackClient, err := app.Clients().Slack()
 	if err != nil {
-		return fmt.Errorf("failed to construct Slack client: %v", err)
+		return errors.Errorf("failed to construct Slack client: %v", err)
 	}
 
 	var names []string

--- a/internal/thelma/cli/commands/charts/import/import_command.go
+++ b/internal/thelma/cli/commands/charts/import/import_command.go
@@ -1,13 +1,13 @@
 package _import
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/charts/mirror"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/charts/builders"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/charts/views"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"path"
@@ -55,7 +55,7 @@ func (cmd *importCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 
 func (cmd *importCommand) PreRun(app app.ThelmaApp, ctx cli.RunContext) error {
 	if len(ctx.Args()) != 0 {
-		return fmt.Errorf("expected no positional arguments, got %v", ctx.Args())
+		return errors.Errorf("expected no positional arguments, got %v", ctx.Args())
 	}
 
 	if ctx.CobraCommand().Flags().Changed(flagNames.configFile) {

--- a/internal/thelma/cli/commands/charts/publish/publish_command.go
+++ b/internal/thelma/cli/commands/charts/publish/publish_command.go
@@ -1,7 +1,6 @@
 package publish
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
@@ -10,6 +9,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/clients/sherlock"
 	"github.com/broadinstitute/thelma/internal/thelma/render/helmfile"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -123,7 +123,7 @@ func publishCharts(options *options, app app.ThelmaApp) ([]views.ChartRelease, e
 		ShellRunner: app.ShellRunner(),
 	}
 	if err := helmfile.NewConfigRepo(stubHelmfileOptions).HelmUpdate(); err != nil {
-		return nil, fmt.Errorf("error using helmfile for `helmfile repos`: %v", err)
+		return nil, errors.Errorf("error using helmfile for `helmfile repos`: %v", err)
 	}
 
 	pb, err := builders.Publisher(app, options.bucketName, options.dryRun)

--- a/internal/thelma/cli/commands/logs/logs_command.go
+++ b/internal/thelma/cli/commands/logs/logs_command.go
@@ -1,13 +1,13 @@
 package logs
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/commands/common"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/selector"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/artifacts/artifactsflags"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/logs"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +71,7 @@ func (cmd *logsCommand) Run(app app.ThelmaApp, rc cli.RunContext) error {
 
 	if !cmd.options.export {
 		if len(selection.Releases) != 1 {
-			return fmt.Errorf("please specify exactly one chart release (matched %d)", len(selection.Releases))
+			return errors.Errorf("please specify exactly one chart release (matched %d)", len(selection.Releases))
 		}
 		return _logs.Logs(selection.Releases[0])
 	}

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -1,7 +1,7 @@
 package render
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"os"
 	"path"
@@ -538,7 +538,7 @@ func TestRenderArgParsing(t *testing.T) {
 			}
 
 			// make sure no error was returned
-			if !assert.NoError(t, err, fmt.Errorf("renderCLI.execute() returned unexpected error: %v", err)) {
+			if !assert.NoError(t, err, errors.Errorf("renderCLI.execute() returned unexpected error: %v", err)) {
 				return
 			}
 

--- a/internal/thelma/cli/commands/slack/notify/notify_command.go
+++ b/internal/thelma/cli/commands/slack/notify/notify_command.go
@@ -1,9 +1,9 @@
 package notify
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +43,10 @@ func (cmd *notifyCommand) PreRun(_ app.ThelmaApp, ctx cli.RunContext) error {
 	flags := ctx.CobraCommand().Flags()
 
 	if !flags.Changed(flagNames.userEmail) {
-		return fmt.Errorf("no user email specified; --%s is required", flagNames.userEmail)
+		return errors.Errorf("no user email specified; --%s is required", flagNames.userEmail)
 	}
 	if !flags.Changed(flagNames.markdown) {
-		return fmt.Errorf("no markdown specified; --%s is required", flagNames.markdown)
+		return errors.Errorf("no markdown specified; --%s is required", flagNames.markdown)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/state/export/export_command.go
+++ b/internal/thelma/cli/commands/state/export/export_command.go
@@ -1,7 +1,7 @@
 package export
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app"
@@ -15,7 +15,7 @@ import (
 const helpMessage = `Exports thelma's internal state to a destination`
 const prodSherlockHostName = "sherlock.dsp-devops.broadinstitute.org"
 
-var ErrExportDestinationForbidden = fmt.Errorf("state export to production sherlock: %s is not allowed", prodSherlockHostName)
+var ErrExportDestinationForbidden = errors.Errorf("state export to production sherlock: %s is not allowed", prodSherlockHostName)
 
 type options struct {
 	destinationURL string
@@ -52,11 +52,11 @@ func (cmd *exportCommand) PreRun(app app.ThelmaApp, ctx cli.RunContext) error {
 
 	iapToken, err := app.Clients().IAPToken()
 	if err != nil {
-		return fmt.Errorf("error retrieving iap token for exporter client: %v", err)
+		return errors.Errorf("error retrieving iap token for exporter client: %v", err)
 	}
 	client, err := sherlock_client.NewWithHostnameOverride(cmd.options.destinationURL, iapToken)
 	if err != nil {
-		return fmt.Errorf("error building exporter sherlock client")
+		return errors.Errorf("error building exporter sherlock client")
 	}
 
 	// check to make sure destination is not prod sherlock, this should not be allowed
@@ -73,17 +73,17 @@ func (cmd *exportCommand) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 	log.Info().Msgf("exporting state to: %s", cmd.options.destinationURL)
 	state, err := app.State()
 	if err != nil {
-		return fmt.Errorf("error retrieving Thelma state: %v", err)
+		return errors.Errorf("error retrieving Thelma state: %v", err)
 	}
 
 	stateExporter := sherlock.NewSherlockStateWriter(state, cmd.sherlockClient)
 
 	if err := stateExporter.WriteClusters(); err != nil {
-		return fmt.Errorf("erorr exporting clusters: %v", err)
+		return errors.Errorf("erorr exporting clusters: %v", err)
 	}
 
 	if err := stateExporter.WriteEnvironments(); err != nil {
-		return fmt.Errorf("erorr exporting environments: %v", err)
+		return errors.Errorf("erorr exporting environments: %v", err)
 	}
 
 	return nil

--- a/internal/thelma/cli/commands/version/version_command.go
+++ b/internal/thelma/cli/commands/version/version_command.go
@@ -1,10 +1,10 @@
 package version
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/app/version"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,7 @@ func (v *versionCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 
 func (v *versionCommand) PreRun(app app.ThelmaApp, ctx cli.RunContext) error {
 	if len(ctx.Args()) != 0 {
-		return fmt.Errorf("expected 0 arguments, got: %v", ctx.Args())
+		return errors.Errorf("expected 0 arguments, got: %v", ctx.Args())
 	}
 	return nil
 }

--- a/internal/thelma/cli/printing/format/format.go
+++ b/internal/thelma/cli/printing/format/format.go
@@ -2,7 +2,7 @@ package format
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"io"
 )
@@ -59,7 +59,7 @@ func (f *Format) FromString(value string) error {
 		*f = None
 		return nil
 	}
-	return fmt.Errorf("unknown format: %q", value)
+	return errors.Errorf("unknown format: %q", value)
 }
 
 // String returns a string representation of this format

--- a/internal/thelma/cli/printing/printer.go
+++ b/internal/thelma/cli/printing/printer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/printing/format"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
 	"io"
@@ -56,7 +57,7 @@ func (p *printer) AddFlags(flags *pflag.FlagSet) {
 
 func (p *printer) VerifyFlags() error {
 	if !format.IsSupported(p.options.outputFormat) {
-		return fmt.Errorf("--%s must be one of %s; got %q", flagNames.outputFormat, utils.QuoteJoin(format.SupportedFormats()), p.options.outputFormat)
+		return errors.Errorf("--%s must be one of %s; got %q", flagNames.outputFormat, utils.QuoteJoin(format.SupportedFormats()), p.options.outputFormat)
 	}
 	return nil
 }

--- a/internal/thelma/cli/selector/enum_flag.go
+++ b/internal/thelma/cli/selector/enum_flag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"sort"
@@ -87,13 +88,13 @@ func (e *enumFlag) validate(state terra.State, inputValues []string) (*valueSet,
 	collated := collateSelectorValues(inputValues)
 
 	if collated.Empty() {
-		return nil, fmt.Errorf("--%s: at least option must be speficied", e.flagName)
+		return nil, errors.Errorf("--%s: at least option must be speficied", e.flagName)
 	}
 
 	// handle ALL selector (--releases=ALL, --cluster=ALL, etc)
 	if collated.Exists(allSelector) {
 		if collated.Size() > 1 {
-			return nil, fmt.Errorf("--%s: either %s or individual %s can be specified, but not both: %s", e.flagName, allSelector, e.flagName, strings.Join(collated.Elements(), ", "))
+			return nil, errors.Errorf("--%s: either %s or individual %s can be specified, but not both: %s", e.flagName, allSelector, e.flagName, strings.Join(collated.Elements(), ", "))
 		}
 		return &valueSet{
 			isAllSelector: true,
@@ -105,14 +106,14 @@ func (e *enumFlag) validate(state terra.State, inputValues []string) (*valueSet,
 	if e.validValues != nil {
 		valid, err := e.validValues(state)
 		if err != nil {
-			return nil, fmt.Errorf("error identifying valid values for flag --%s: %v", e.flagName, err)
+			return nil, errors.Errorf("error identifying valid values for flag --%s: %v", e.flagName, err)
 		}
 
 		diff := collated.Difference(valid)
 		if !diff.Empty() {
 			unknown := diff.Elements()
 			sort.Strings(unknown)
-			return nil, fmt.Errorf("--%s: unknown %s %s", e.flagName, maybePlural(e.flagName), strings.Join(unknown, ", "))
+			return nil, errors.Errorf("--%s: unknown %s %s", e.flagName, maybePlural(e.flagName), strings.Join(unknown, ", "))
 		}
 	}
 

--- a/internal/thelma/cli/selector/flags.go
+++ b/internal/thelma/cli/selector/flags.go
@@ -1,10 +1,10 @@
 package selector
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/filter"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -20,7 +20,7 @@ func newReleasesFlag() *enumFlag {
 			// UX: make it possible for users to specify a release as the first positional arg instead of as a flag
 			if pflags.Changed(flagNames.release) {
 				if len(args) > 0 {
-					return nil, fmt.Errorf("releases can either be specified with the --%s flag or via positional argument, not both", ReleasesFlagName)
+					return nil, errors.Errorf("releases can either be specified with the --%s flag or via positional argument, not both", ReleasesFlagName)
 				}
 				return flagValues, nil
 			} else if len(args) > 0 {
@@ -32,7 +32,7 @@ func newReleasesFlag() *enumFlag {
 			} else {
 				// We have a lot of releases, and most developers want to render for a specific service,
 				// so force users to supply --releases=ALL if they _really_ want to render for all releases and not a specific release
-				return nil, fmt.Errorf(`please specify at least one release with --%s <RELEASE>, or select all releases with --%s %s`, ReleasesFlagName, ReleasesFlagName, allSelector)
+				return nil, errors.Errorf(`please specify at least one release with --%s <RELEASE>, or select all releases with --%s %s`, ReleasesFlagName, ReleasesFlagName, allSelector)
 			}
 		},
 
@@ -64,7 +64,7 @@ func newExactReleasesFlag() *enumFlag {
 			}
 			for _, flagValue := range flagValues {
 				if flagValue == allSelector {
-					return nil, fmt.Errorf("--%s cannot be used with %s, use --%s %s instead", flagNames.exactRelease, allSelector, flagNames.release, allSelector)
+					return nil, errors.Errorf("--%s cannot be used with %s, use --%s %s instead", flagNames.exactRelease, allSelector, flagNames.release, allSelector)
 				}
 			}
 			return flagValues, nil

--- a/internal/thelma/cli/selector/selector.go
+++ b/internal/thelma/cli/selector/selector.go
@@ -1,10 +1,10 @@
 package selector
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/sort"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -144,7 +144,7 @@ func (s *Selector) checkRequiredFlags(flags *pflag.FlagSet) error {
 		// "If -e isn't provided, and -c isn't provided, and the user hasn't passed just --exact-release instead of --r"
 		if !flags.Changed(flagNames.environment) && !flags.Changed(flagNames.cluster) &&
 			!(flags.Changed(flagNames.exactRelease) && !flags.Changed(flagNames.release)) {
-			return fmt.Errorf("please specify a target environment or cluster with the -e/-c flags, or specify only full Sherlock-style release names with --exact-release")
+			return errors.Errorf("please specify a target environment or cluster with the -e/-c flags, or specify only full Sherlock-style release names with --exact-release")
 		}
 	}
 	return nil
@@ -159,7 +159,7 @@ func checkIncompatibleFlags(flags *pflag.FlagSet) error {
 		if flags.Changed(unf) {
 			for _, inf := range intersectFlags {
 				if flags.Changed(inf) {
-					return fmt.Errorf("--%s cannot be combined with --%s", unf, inf)
+					return errors.Errorf("--%s cannot be combined with --%s", unf, inf)
 				}
 			}
 		}

--- a/internal/thelma/clients/google/bucket/lock/lock.go
+++ b/internal/thelma/clients/google/bucket/lock/lock.go
@@ -3,8 +3,8 @@ package lock
 import (
 	"cloud.google.com/go/storage"
 	"context"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket/object"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/api/googleapi"
@@ -113,7 +113,7 @@ func (l *lock) waitForLock(object object.Object, logger zerolog.Logger) error {
 			attempt++
 			continue
 		case <-ctx.Done():
-			return fmt.Errorf("timed out after %s waiting for lock: %v", l.options.MaxWait, ctx.Err())
+			return errors.Errorf("timed out after %s waiting for lock: %v", l.options.MaxWait, ctx.Err())
 		}
 	}
 }
@@ -134,7 +134,7 @@ func (l *lock) deleteExpiredLock(object object.Object, logger zerolog.Logger) er
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error reading attributes of lock object: %v", err)
+		return errors.Errorf("error reading attributes of lock object: %v", err)
 	}
 
 	lockAge := time.Since(attrs.Created)
@@ -158,7 +158,7 @@ func (l *lock) deleteExpiredLock(object object.Object, logger zerolog.Logger) er
 			logger.Warn().Msgf("Another process deleted the expired lock before we could")
 			return nil
 		}
-		return fmt.Errorf("error deleting expired lock file: %v", err)
+		return errors.Errorf("error deleting expired lock file: %v", err)
 	}
 
 	return nil

--- a/internal/thelma/clients/google/bucket/lock/unlock.go
+++ b/internal/thelma/clients/google/bucket/lock/unlock.go
@@ -2,8 +2,8 @@ package lock
 
 import (
 	"cloud.google.com/go/storage"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket/object"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
 
@@ -34,7 +34,7 @@ func (u *unlock) Handler(object object.Object, logger zerolog.Logger) error {
 			logger.Warn().Msgf("Attempted to release lock, but another process has already claimed it")
 			return nil
 		}
-		return fmt.Errorf("error deleting lock: %v", err)
+		return errors.Errorf("error deleting lock: %v", err)
 	}
 
 	logger.Debug().Msgf("Successfully released lock")

--- a/internal/thelma/clients/google/bucket/logging.go
+++ b/internal/thelma/clients/google/bucket/logging.go
@@ -3,6 +3,7 @@ package bucket
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/logid"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"sync"
@@ -54,7 +55,7 @@ func (i *operationLogger) operationFinished(err error) error {
 	if err != nil {
 		event.Str("status", "error")
 		event.Err(err)
-		returnErr := fmt.Errorf("%s %q failed: %v", i.operationKind, i.objectUrl(), err)
+		returnErr := errors.Errorf("%s %q failed: %v", i.operationKind, i.objectUrl(), err)
 		event.Msgf(returnErr.Error())
 		return returnErr
 	}

--- a/internal/thelma/clients/google/bucket/object/download.go
+++ b/internal/thelma/clients/google/bucket/object/download.go
@@ -1,7 +1,7 @@
 package object
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"io"
 	"os"
@@ -31,22 +31,22 @@ func (d *download) Handler(object Object, logger zerolog.Logger) error {
 	logger.Debug().Msg("opening file for writing")
 	fileWriter, err := os.Create(d.file)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %v", err)
+		return errors.Errorf("failed to open file: %v", err)
 	}
 	objReader, err := object.Handle.NewReader(object.Ctx)
 	if err != nil {
-		return fmt.Errorf("error reading object: %v", err)
+		return errors.Errorf("error reading object: %v", err)
 	}
 
 	written, err := io.Copy(fileWriter, objReader)
 	if err != nil {
-		return fmt.Errorf("write failed: %v", err)
+		return errors.Errorf("write failed: %v", err)
 	}
 	if err = objReader.Close(); err != nil {
-		return fmt.Errorf("error closing object reader: %v", err)
+		return errors.Errorf("error closing object reader: %v", err)
 	}
 	if err = fileWriter.Close(); err != nil {
-		return fmt.Errorf("error closing file writer: %v", err)
+		return errors.Errorf("error closing file writer: %v", err)
 	}
 
 	logTransfer(logger, written)

--- a/internal/thelma/clients/google/bucket/object/read.go
+++ b/internal/thelma/clients/google/bucket/object/read.go
@@ -1,7 +1,7 @@
 package object
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"io"
 )
@@ -31,15 +31,15 @@ func (r *read) Content() []byte {
 func (r *read) Handler(object Object, logger zerolog.Logger) error {
 	reader, err := object.Handle.NewReader(object.Ctx)
 	if err != nil {
-		return fmt.Errorf("error reading object: %v", err)
+		return errors.Errorf("error reading object: %v", err)
 	}
 
 	content, err := io.ReadAll(reader)
 	if err != nil {
-		return fmt.Errorf("error reading object: %v", err)
+		return errors.Errorf("error reading object: %v", err)
 	}
 	if err = reader.Close(); err != nil {
-		return fmt.Errorf("error closing object reader: %v", err)
+		return errors.Errorf("error closing object reader: %v", err)
 	}
 
 	logTransfer(logger, int64(len(content)))

--- a/internal/thelma/clients/google/bucket/object/upload.go
+++ b/internal/thelma/clients/google/bucket/object/upload.go
@@ -1,7 +1,7 @@
 package object
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"io"
 	"os"
@@ -32,7 +32,7 @@ func (u *upload) Handler(object Object, logger zerolog.Logger) error {
 
 	fileReader, err := os.Open(u.file)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %v", err)
+		return errors.Errorf("failed to open file: %v", err)
 	}
 
 	objWriter := object.Handle.NewWriter(object.Ctx)
@@ -41,13 +41,13 @@ func (u *upload) Handler(object Object, logger zerolog.Logger) error {
 
 	written, err := io.Copy(objWriter, fileReader)
 	if err != nil {
-		return fmt.Errorf("write failed: %v", err)
+		return errors.Errorf("write failed: %v", err)
 	}
 	if err = objWriter.Close(); err != nil {
-		return fmt.Errorf("error closing object writer: %v", err)
+		return errors.Errorf("error closing object writer: %v", err)
 	}
 	if err = fileReader.Close(); err != nil {
-		return fmt.Errorf("error closing file reader: %v", err)
+		return errors.Errorf("error closing file reader: %v", err)
 	}
 
 	logTransfer(logger, written)

--- a/internal/thelma/clients/google/bucket/object/write.go
+++ b/internal/thelma/clients/google/bucket/object/write.go
@@ -1,7 +1,7 @@
 package object
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"io"
 )
@@ -41,10 +41,10 @@ func (w *write) Handler(object Object, logger zerolog.Logger) error {
 
 	written, err := w.writeContent(writer)
 	if err != nil {
-		return fmt.Errorf("error writing object: %v", err)
+		return errors.Errorf("error writing object: %v", err)
 	}
 	if err = writer.Close(); err != nil {
-		return fmt.Errorf("error closing writer: %v", err)
+		return errors.Errorf("error closing writer: %v", err)
 	}
 
 	logTransfer(logger, written)

--- a/internal/thelma/clients/google/bucket/test_bucket.go
+++ b/internal/thelma/clients/google/bucket/test_bucket.go
@@ -114,7 +114,7 @@ func (b *testBucket) Close() error {
 				log.Debug().Msgf("couldn't delete %s, likely already deleted by test: %v", objectName, err)
 				// test likely deleted the object already
 			} else {
-				return fmt.Errorf("error cleaning up test object %s: %v", objectName, err)
+				return errors.Errorf("error cleaning up test object %s: %v", objectName, err)
 			}
 		}
 	}

--- a/internal/thelma/clients/google/bucket/test_bucket.go
+++ b/internal/thelma/clients/google/bucket/test_bucket.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket/object"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"math/rand"

--- a/internal/thelma/clients/google/bucket/testing/assert/bassert.go
+++ b/internal/thelma/clients/google/bucket/testing/assert/bassert.go
@@ -4,6 +4,7 @@ package assert
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -62,7 +63,7 @@ func withMessage(msgAndArgs ...interface{}) msg {
 func headAndTail(msgAndArgs []interface{}) (string, []interface{}) {
 	format, ok := msgAndArgs[0].(string)
 	if !ok {
-		panic(fmt.Errorf("first argument should be format string: %v", msgAndArgs))
+		panic(errors.Errorf("first argument should be format string: %v", msgAndArgs))
 	}
 	return format, msgAndArgs[1:]
 }

--- a/internal/thelma/clients/google/sqladmin/sqladmin.go
+++ b/internal/thelma/clients/google/sqladmin/sqladmin.go
@@ -1,7 +1,7 @@
 package sqladmin
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/api/sqladmin/v1"
 	"time"
@@ -69,11 +69,11 @@ func (c client) ResetPassword(project string, instanceName string, username stri
 
 	op, err := req.Do()
 	if err != nil {
-		return fmt.Errorf("error resetting password for %s user %s: %v", instanceName, username, err)
+		return errors.Errorf("error resetting password for %s user %s: %v", instanceName, username, err)
 	}
 
 	if err = c.waitForOpToBeDone(op); err != nil {
-		return fmt.Errorf("error resetting password for %s: %v", username, err)
+		return errors.Errorf("error resetting password for %s: %v", username, err)
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func (c client) DeleteUser(project string, instanceName string, username string)
 		project, instanceName,
 	).Name(username).Do()
 	if err != nil {
-		return fmt.Errorf("error deleting user %s from instance %s: %v", username, instanceName, err)
+		return errors.Errorf("error deleting user %s from instance %s: %v", username, instanceName, err)
 	}
 
 	return c.waitForOpToBeDone(op)
@@ -95,7 +95,7 @@ func (c client) AddUser(project string, instanceName string, user *sqladmin.User
 		project, instanceName, user,
 	).Do()
 	if err != nil {
-		return fmt.Errorf("error adding user %s to instance %s: %v", user.Name, instanceName, err)
+		return errors.Errorf("error adding user %s to instance %s: %v", user.Name, instanceName, err)
 	}
 
 	return c.waitForOpToBeDone(op)

--- a/internal/thelma/clients/google/terraapi/firecloudorch.go
+++ b/internal/thelma/clients/google/terraapi/firecloudorch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/avast/retry-go"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"net/http"
 	"regexp"
@@ -108,7 +109,7 @@ func (c *firecloudOrchClient) doJsonRequestWithRetries(method string, url string
 
 	requestBody, err := json.Marshal(bodyData)
 	if err != nil {
-		return nil, "", fmt.Errorf("error marshalling request body for %s %s: %v", method, url, err)
+		return nil, "", errors.Errorf("error marshalling request body for %s %s: %v", method, url, err)
 	}
 
 	requestFn := func() error {

--- a/internal/thelma/clients/google/terraapi/terra.go
+++ b/internal/thelma/clients/google/terraapi/terra.go
@@ -1,8 +1,8 @@
 package terraapi
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 	googleoauth "google.golang.org/api/oauth2/v2"
 	"io"
@@ -66,7 +66,7 @@ func (c *terraClient) doJsonRequest(method string, url string, body io.Reader) (
 		return response, "", err
 	}
 	if response.StatusCode > 299 {
-		return response, string(responseBody), fmt.Errorf("%s from %s (%s)", response.Status, url, responseBody)
+		return response, string(responseBody), errors.Errorf("%s from %s (%s)", response.Status, url, responseBody)
 	}
 	return response, string(responseBody), nil
 }

--- a/internal/thelma/clients/iap/token_provider.go
+++ b/internal/thelma/clients/iap/token_provider.go
@@ -1,9 +1,9 @@
 package iap
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/credentials"
 	"github.com/broadinstitute/thelma/internal/thelma/app/logging"
+	"github.com/pkg/errors"
 )
 
 // this tokenProvider decorates the credentials.TokenProvider to extract and return the JUST identity token field to
@@ -38,7 +38,7 @@ func extractIdentityToken(serializedPersistentToken []byte) ([]byte, error) {
 
 	asString, ok := oauthToken.Extra("id_token").(string)
 	if !ok {
-		return nil, fmt.Errorf("error extracting id_token field (type assertion failed)")
+		return nil, errors.Errorf("error extracting id_token field (type assertion failed)")
 	}
 
 	logging.MaskSecret(asString)

--- a/internal/thelma/clients/kubernetes/kubecfg/kubecfg.go
+++ b/internal/thelma/clients/kubernetes/kubecfg/kubecfg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/pkg/errors"
 	"path"
 	"sort"
 	"sync"
@@ -262,7 +263,7 @@ func (c *kubeconfig) writeContext(ctx kubectx) error {
 		return c.writeContextUnsafe(ctx)
 	})
 	if err != nil {
-		return fmt.Errorf("error generating kubectx for cluster %s: %v", ctx.cluster.Name(), err)
+		return errors.Errorf("error generating kubectx for cluster %s: %v", ctx.cluster.Name(), err)
 	}
 	return nil
 }
@@ -390,7 +391,7 @@ func contextNameForRelease(release terra.Release) string {
 	}
 	appRelease, ok := release.(terra.AppRelease)
 	if !ok {
-		panic(fmt.Errorf("failed to cast to AppRelease: %v", appRelease))
+		panic(errors.Errorf("failed to cast to AppRelease: %v", appRelease))
 	}
 	if appRelease.Cluster().Name() != appRelease.Environment().DefaultCluster().Name() {
 		return appRelease.Environment().Name() + ctxDelimiter + release.Name()

--- a/internal/thelma/clients/vault/vault.go
+++ b/internal/thelma/clients/vault/vault.go
@@ -1,11 +1,11 @@
 package vault
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/config"
 	"github.com/broadinstitute/thelma/internal/thelma/app/credentials"
 	"github.com/broadinstitute/thelma/internal/thelma/app/credentials/stores"
 	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 )
@@ -117,11 +117,11 @@ func buildVaultTokenProvider(unauthedClient *vaultapi.Client, creds credentials.
 					}
 				}
 
-				return nil, fmt.Errorf("could not issue new Vault token, failed to load Github PAT: %v", err)
+				return nil, errors.Errorf("could not issue new Vault token, failed to load Github PAT: %v", err)
 			}
 			vaultToken, err := login(unauthedClient, string(githubPAT))
 			if err != nil {
-				return nil, fmt.Errorf("failed to issue new Vault token: %v", err)
+				return nil, errors.Errorf("failed to issue new Vault token: %v", err)
 			}
 			return []byte(vaultToken), nil
 		}
@@ -193,7 +193,7 @@ func login(client *vaultapi.Client, githubToken string) (string, error) {
 
 	secret, err := _client.Logical().Write(githubLoginPath, map[string]interface{}{"token": githubToken})
 	if err != nil {
-		return "", fmt.Errorf("login request failed: %v", err)
+		return "", errors.Errorf("login request failed: %v", err)
 	}
 	return secret.Auth.ClientToken, nil
 }
@@ -211,7 +211,7 @@ func approleLogin(client *vaultapi.Client, roleId string, secretId string) (stri
 		"secret_id": secretId,
 	})
 	if err != nil {
-		return "", fmt.Errorf("approle login request failed: %v", err)
+		return "", errors.Errorf("approle login request failed: %v", err)
 	}
 	return secret.Auth.ClientToken, nil
 }

--- a/internal/thelma/ops/artifacts/artifactsflags/artifactsflags.go
+++ b/internal/thelma/ops/artifacts/artifactsflags/artifactsflags.go
@@ -1,9 +1,9 @@
 package artifactsflags
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/cli/flags"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/artifacts"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -42,7 +42,7 @@ func (s *artifactsFlags) AddFlags(cobraCommand *cobra.Command) {
 
 func (s *artifactsFlags) GetOptions() (artifacts.Options, error) {
 	if s.options.Dir == "" && !s.options.Upload {
-		return s.options, fmt.Errorf("either --%s or --%s must be specified",
+		return s.options, errors.Errorf("either --%s or --%s must be specified",
 			s.flagOptions.NormalizedFlagName(flagNames.upload),
 			s.flagOptions.NormalizedFlagName(flagNames.dir),
 		)

--- a/internal/thelma/ops/artifacts/manager.go
+++ b/internal/thelma/ops/artifacts/manager.go
@@ -1,11 +1,11 @@
 package artifacts
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/api"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/bucket"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"io"
 	"os"
@@ -83,11 +83,11 @@ func (m *manager) Writer(release terra.Release, _path string) (io.WriteCloser, e
 		outputFile := path.Join(m.options.Dir, relativePath)
 		parentDir := path.Dir(outputFile)
 		if err := os.MkdirAll(parentDir, 0755); err != nil {
-			return nil, fmt.Errorf("error creating artifact dir %s: %v", parentDir, err)
+			return nil, errors.Errorf("error creating artifact dir %s: %v", parentDir, err)
 		}
 		file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		if err != nil {
-			return nil, fmt.Errorf("error creating artifact file %s: %v", outputFile, err)
+			return nil, errors.Errorf("error creating artifact file %s: %v", outputFile, err)
 		}
 		writeClosers = append(writeClosers, file)
 	}

--- a/internal/thelma/ops/logs/logs.go
+++ b/internal/thelma/ops/logs/logs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/kubectl"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"strings"
 	"time"
@@ -83,7 +84,7 @@ func (l *logs) Logs(release terra.Release, opts ...LogsOption) error {
 	containers = filterContainers(containers, options.ContainerFilter)
 
 	if len(containers) == 0 {
-		return fmt.Errorf("found no matching containers for %s in %s", release.Name(), release.Destination().Name())
+		return errors.Errorf("found no matching containers for %s in %s", release.Name(), release.Destination().Name())
 	}
 	var _container container
 	if len(containers) == 1 {
@@ -238,7 +239,7 @@ func tryToPickCorrectContainer(containers []container) (container, error) {
 	for _, _container := range containers {
 		list = append(list, fmt.Sprintf("%s in %s", _container.containerName, _container.resourceName))
 	}
-	return container{}, fmt.Errorf("found multiple matching containers, please use flags to specify:\n%s", strings.Join(list, "\n"))
+	return container{}, errors.Errorf("found multiple matching containers, please use flags to specify:\n%s", strings.Join(list, "\n"))
 }
 
 func defaultLogsOptions() LogsOptions {

--- a/internal/thelma/ops/sql/api/api.go
+++ b/internal/thelma/ops/sql/api/api.go
@@ -1,8 +1,8 @@
 package api
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"strings"
 )
 
@@ -29,7 +29,7 @@ func (c Connection) Instance() Instance {
 	case Kubernetes:
 		return c.KubernetesInstance
 	default:
-		panic(fmt.Errorf("unknown platform: %#v", c.Provider))
+		panic(errors.Errorf("unknown platform: %#v", c.Provider))
 	}
 }
 

--- a/internal/thelma/ops/sql/api/dbms.go
+++ b/internal/thelma/ops/sql/api/dbms.go
@@ -1,6 +1,8 @@
 package api
 
-import "fmt"
+import (
+	"github.com/pkg/errors"
+)
 
 // DBMS kind of database (MySQL or Postgres)
 type DBMS int64
@@ -17,7 +19,7 @@ func (d DBMS) String() string {
 	case MySQL:
 		return "MySQL"
 	default:
-		panic(fmt.Errorf("unknown dbms type: %#v", d))
+		panic(errors.Errorf("unknown dbms type: %#v", d))
 	}
 }
 
@@ -28,7 +30,7 @@ func (d DBMS) AdminUser() string {
 	case MySQL:
 		return "root"
 	default:
-		panic(fmt.Errorf("unknown dbms type: %#v", d))
+		panic(errors.Errorf("unknown dbms type: %#v", d))
 	}
 }
 
@@ -39,6 +41,6 @@ func (d DBMS) CLIClient() string {
 	case MySQL:
 		return "mysql"
 	default:
-		panic(fmt.Errorf("unknown dbms type: %#v", d))
+		panic(errors.Errorf("unknown dbms type: %#v", d))
 	}
 }

--- a/internal/thelma/ops/sql/connector/connector.go
+++ b/internal/thelma/ops/sql/connector/connector.go
@@ -1,7 +1,6 @@
 package connector
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/dbms"
@@ -10,6 +9,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/provider/google"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/provider/kubernetes"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -48,7 +48,7 @@ func New(conn api.Connection, clients clients.Clients) (Connector, error) {
 		panic("TODO")
 
 	default:
-		panic(fmt.Errorf("unsupported provider: %#v", conn.Provider))
+		panic(errors.Errorf("unsupported provider: %#v", conn.Provider))
 	}
 
 	_dbms, err := buildDBMSForProvider(conn, _provider)
@@ -126,7 +126,7 @@ func (c *connector) ensureInitialized() error {
 	}
 	if c.conn.Provider != api.Kubernetes {
 		// require explicit initialization for non-K8s dbs
-		return fmt.Errorf("database instance %s has not been initialized; please run `thelma sql init` and try again", c.conn.Instance().Name())
+		return errors.Errorf("database instance %s has not been initialized; please run `thelma sql init` and try again", c.conn.Instance().Name())
 	}
 	log.Info().Msgf("Auto-initializing database for Thelma connections")
 	return c.Init()

--- a/internal/thelma/ops/sql/dbms/dbms.go
+++ b/internal/thelma/ops/sql/dbms/dbms.go
@@ -1,9 +1,9 @@
 package dbms
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/podrun"
+	"github.com/pkg/errors"
 )
 
 // things we need to know:
@@ -67,6 +67,6 @@ func New(t api.DBMS, conn api.Connection) DBMS {
 	case api.MySQL:
 		return mysql{}
 	default:
-		panic(fmt.Errorf("unsupported DBMS: %#v", t))
+		panic(errors.Errorf("unsupported DBMS: %#v", t))
 	}
 }

--- a/internal/thelma/ops/sql/dbms/postgres.go
+++ b/internal/thelma/ops/sql/dbms/postgres.go
@@ -3,9 +3,9 @@ package dbms
 import (
 	"bytes"
 	_ "embed"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/podrun"
+	"github.com/pkg/errors"
 	"path"
 	"strconv"
 	"text/template"
@@ -86,7 +86,7 @@ func (p postgres) ensureTargetDatabaseSelected() error {
 	// thelma-sql-ro and thelma-sql-srw do not have default databases; if we try
 	// to connect without specifying one, psql will return an error
 	if p.conn.Options.Database == "" {
-		return fmt.Errorf("please specify a target database")
+		return errors.Errorf("please specify a target database")
 	}
 	return nil
 }
@@ -109,11 +109,11 @@ func (p postgres) renderPsqlrc(settings ClientSettings) ([]byte, error) {
 
 	t, err := template.New(scriptNames.psqlrc).Parse(psqlrcTemplate)
 	if err != nil {
-		panic(fmt.Errorf("error parsing internal template %s: %v", scriptNames.psqlrc, err))
+		panic(errors.Errorf("error parsing internal template %s: %v", scriptNames.psqlrc, err))
 	}
 	var buf bytes.Buffer
 	if err = t.Execute(&buf, ctx); err != nil {
-		return nil, fmt.Errorf("error rendering %s: %v", scriptNames.psqlrc, err)
+		return nil, errors.Errorf("error rendering %s: %v", scriptNames.psqlrc, err)
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/thelma/ops/sql/podrun/meta/decoder.go
+++ b/internal/thelma/ops/sql/podrun/meta/decoder.go
@@ -2,8 +2,8 @@ package meta
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"k8s.io/utils/strings/slices"
 	"reflect"
 	"strings"
@@ -54,11 +54,11 @@ func (d Decoder[T]) FromMap(m map[string]string) (*T, error) {
 		Result:     &a,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error decoding annotations: %v", err)
+		return nil, errors.Errorf("error decoding annotations: %v", err)
 	}
 
 	if err = decoder.Decode(withoutPrefix); err != nil {
-		return nil, fmt.Errorf("error decoding annotations: %v", err)
+		return nil, errors.Errorf("error decoding annotations: %v", err)
 	}
 	return &a, nil
 }
@@ -68,7 +68,7 @@ func (d Decoder[T]) ToMap(s T) (map[string]string, error) {
 
 	v := reflect.ValueOf(s)
 	if v.Kind() != reflect.Struct {
-		panic(fmt.Errorf("require struct, got %T", s))
+		panic(errors.Errorf("require struct, got %T", s))
 	}
 
 	for i := 0; i < v.NumField(); i++ {
@@ -93,7 +93,7 @@ func (d Decoder[T]) ToMap(s T) (map[string]string, error) {
 		} else {
 			data, err := json.Marshal(val.Interface())
 			if err != nil {
-				return nil, fmt.Errorf("error marshalling to JSON: %v", err)
+				return nil, errors.Errorf("error marshalling to JSON: %v", err)
 			}
 			s = string(data)
 		}
@@ -133,13 +133,13 @@ func UnmarshalNonStringFieldsFromJSON() mapstructure.DecodeHookFunc {
 
 		s, ok := data.(string)
 		if !ok {
-			return nil, fmt.Errorf("expected data to be a string, got %T", data)
+			return nil, errors.Errorf("expected data to be a string, got %T", data)
 		}
 
 		v := reflect.New(t)
 		p := v.Interface()
 		if err := json.Unmarshal([]byte(s), p); err != nil {
-			return nil, fmt.Errorf("error unmarshalling data: %v", err)
+			return nil, errors.Errorf("error unmarshalling data: %v", err)
 		}
 
 		return p, nil

--- a/internal/thelma/ops/sql/podrun/metadata.go
+++ b/internal/thelma/ops/sql/podrun/metadata.go
@@ -1,9 +1,9 @@
 package podrun
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	metadecoder "github.com/broadinstitute/thelma/internal/thelma/ops/sql/podrun/meta"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	gomaps "golang.org/x/exp/maps"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,11 +60,11 @@ func (c *commonMetadata) write(obj *metav1.ObjectMeta) {
 func createMetadata(conn api.Connection) (*commonMetadata, error) {
 	_labels, err := createLabels()
 	if err != nil {
-		return nil, fmt.Errorf("error encoding labels: %v", err)
+		return nil, errors.Errorf("error encoding labels: %v", err)
 	}
 	_annotations, err := createAnnotations(conn)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding annotations: %v", err)
+		return nil, errors.Errorf("error encoding annotations: %v", err)
 	}
 
 	return &commonMetadata{

--- a/internal/thelma/ops/sql/podrun/pod.go
+++ b/internal/thelma/ops/sql/podrun/pod.go
@@ -2,10 +2,10 @@ package podrun
 
 import (
 	"context"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/kubernetes/kubecfg"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/kubectl"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,17 +71,17 @@ func (p *pod) Delete() error {
 
 	log.Info().Msgf("Deleting pod: %s", p.name)
 	if err = p.client.CoreV1().Pods(thelmaWorkloadsNamespace).Delete(context.Background(), p.name, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("error deleting pod: %v", err)
+		return errors.Errorf("error deleting pod: %v", err)
 	}
 
 	log.Info().Msgf("Deleting scripts secret: %s", p.scriptsSecret)
 	if err = p.client.CoreV1().Secrets(thelmaWorkloadsNamespace).Delete(context.Background(), p.scriptsSecret, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("error deleting cm: %v", err)
+		return errors.Errorf("error deleting cm: %v", err)
 	}
 
 	log.Info().Msgf("Deleting env secret: %s", p.envSecret)
 	if err = p.client.CoreV1().Secrets(thelmaWorkloadsNamespace).Delete(context.Background(), p.envSecret, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("error deleting secret: %v", err)
+		return errors.Errorf("error deleting secret: %v", err)
 	}
 
 	return nil

--- a/internal/thelma/ops/sql/podrun/runner.go
+++ b/internal/thelma/ops/sql/podrun/runner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/kubectl"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +82,7 @@ func (r *runner) Create(spec Spec) (Pod, error) {
 		metav1.CreateOptions{},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating env secret: %v", err)
+		return nil, errors.Errorf("error creating env secret: %v", err)
 	}
 	log.Debug().Msgf("created env secret: %q", envSecret.Name)
 
@@ -99,7 +100,7 @@ func (r *runner) Create(spec Spec) (Pod, error) {
 		metav1.CreateOptions{},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating scripts secret: %v", err)
+		return nil, errors.Errorf("error creating scripts secret: %v", err)
 	}
 	log.Debug().Msgf("created scripts secret: %q", scriptSecret.Name)
 
@@ -160,13 +161,13 @@ func (r *runner) Create(spec Spec) (Pod, error) {
 		metav1.CreateOptions{},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating pod: %v", err)
+		return nil, errors.Errorf("error creating pod: %v", err)
 	}
 	log.Debug().Msgf("created pod: %q", _pod.Name)
 
 	log.Info().Msgf("Launched pod %s, waiting for it to become ready...", _pod.Name)
 	if err = r.waitForPodToBeReady(_pod, podReadinessTimeout); err != nil {
-		return nil, fmt.Errorf("error waiting for pod %s to be ready: %v", _pod.Name, err)
+		return nil, errors.Errorf("error waiting for pod %s to be ready: %v", _pod.Name, err)
 	}
 
 	return &pod{
@@ -189,7 +190,7 @@ func (r *runner) waitForPodToBeReady(_pod *v1.Pod, timeout time.Duration) error 
 		FieldSelector: fmt.Sprintf("metadata.name=%s", _pod.Name),
 	})
 	if err != nil {
-		return fmt.Errorf("error creating watch for pod %s: %v", _pod.Name, err)
+		return errors.Errorf("error creating watch for pod %s: %v", _pod.Name, err)
 	}
 
 	for event := range watch.ResultChan() {
@@ -224,7 +225,7 @@ func (r *runner) waitForPodToBeReady(_pod *v1.Pod, timeout time.Duration) error 
 		}
 	}
 
-	return fmt.Errorf("timed out after %s waiting for pod %s to be ready", timeout, _pod.Name)
+	return errors.Errorf("timed out after %s waiting for pod %s to be ready", timeout, _pod.Name)
 }
 
 func (r *runner) Cleanup() error {

--- a/internal/thelma/ops/sql/provider/google/features.go
+++ b/internal/thelma/ops/sql/provider/google/features.go
@@ -1,8 +1,8 @@
 package google
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
+	"github.com/pkg/errors"
 	"google.golang.org/api/sqladmin/v1"
 	"strings"
 )
@@ -50,5 +50,5 @@ func parseCloudSQLVersion(version string) (api.DBMS, error) {
 	if strings.HasPrefix(version, "MYSQL") {
 		return api.MySQL, nil
 	}
-	return -1, fmt.Errorf("unsupported CloudSQL version: %q", version)
+	return -1, errors.Errorf("unsupported CloudSQL version: %q", version)
 }

--- a/internal/thelma/ops/sql/provider/google/google.go
+++ b/internal/thelma/ops/sql/provider/google/google.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/google/sqladmin"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/dbms"
@@ -10,6 +9,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/utils/lazy"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
 	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	googlesqladmin "google.golang.org/api/sqladmin/v1"
 	v1 "k8s.io/api/core/v1"
@@ -94,7 +94,7 @@ func (g *google) ClientSettings(overrides ...provider.ConnectionOverride) (dbms.
 	case api.Admin:
 		creds, err = g.getLocalAdminCredentials()
 	default:
-		panic(fmt.Errorf("unsupported permission level: %#v", g.connection.Options.PrivilegeLevel))
+		panic(errors.Errorf("unsupported permission level: %#v", g.connection.Options.PrivilegeLevel))
 	}
 
 	if err != nil {
@@ -348,7 +348,7 @@ func (g *google) addThelmaUsers(features features) error {
 			user.Type = cloudSqlAccountTypeBuiltIn
 			password := g.passwordStore.generate()
 			if err = g.passwordStore.save(g.connection.GoogleInstance, username, password); err != nil {
-				return fmt.Errorf("error saving generated password to Vault: %v", err)
+				return errors.Errorf("error saving generated password to Vault: %v", err)
 			}
 			user.Password = password
 		}
@@ -387,7 +387,7 @@ func (g *google) kubernetesServiceAccount() string {
 		// admin level uses password auth, not iam, so the SA doesn't actually matter
 		return googleSATemplates.readOnly.kubernetesSA
 	default:
-		panic(fmt.Errorf("unsupported permission level: %#v", g.connection.Options.PrivilegeLevel))
+		panic(errors.Errorf("unsupported permission level: %#v", g.connection.Options.PrivilegeLevel))
 	}
 }
 

--- a/internal/thelma/ops/sql/provider/google/password_store.go
+++ b/internal/thelma/ops/sql/provider/google/password_store.go
@@ -5,6 +5,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/ops/sql/api"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pwgen"
 	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
 	"path"
 	"time"
 )
@@ -58,11 +59,11 @@ func (p *passwordStoreImpl) fetch(instance api.GoogleInstance, username string) 
 	}
 	password, exists := secret.Data[passwordSecretKey]
 	if !exists {
-		return "", fmt.Errorf("vault secret at %s has no %s field; try re-running thelma sql init for this database", secretPath, passwordSecretKey)
+		return "", errors.Errorf("vault secret at %s has no %s field; try re-running thelma sql init for this database", secretPath, passwordSecretKey)
 	}
 	s, ok := password.(string)
 	if !ok {
-		return "", fmt.Errorf("vault secret at %s has unexpected value type for field %s (want string); try re-running thelma sql init for this database", secretPath, passwordSecretKey)
+		return "", errors.Errorf("vault secret at %s has unexpected value type for field %s (want string); try re-running thelma sql init for this database", secretPath, passwordSecretKey)
 	}
 	return s, nil
 }

--- a/internal/thelma/ops/sql/provider/kubernetes/kubernetes.go
+++ b/internal/thelma/ops/sql/provider/kubernetes/kubernetes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/utils/lazy"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/maps"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pwgen"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,7 +167,7 @@ func (k *kubernetes) getCredentialsForConnection(options api.ConnectionOptions) 
 	case api.ReadOnly:
 		return k.getLocalThelmaUserCredentials(readonlyUsername)
 	default:
-		panic(fmt.Errorf("unsupported permission level: %#v", options.PrivilegeLevel))
+		panic(errors.Errorf("unsupported permission level: %#v", options.PrivilegeLevel))
 	}
 }
 
@@ -185,11 +186,11 @@ func (k *kubernetes) resetPassword(username string) (*api.Credentials, error) {
 	case api.MySQL:
 		panic("TODO")
 	default:
-		panic(fmt.Errorf("unsupported dbms type: %#v", f.dbms))
+		panic(errors.Errorf("unsupported dbms type: %#v", f.dbms))
 	}
 
 	if err = k.kubectl.Exec(k.kubectx, f.container, command); err != nil {
-		return nil, fmt.Errorf("error resetting password for %s: %v", username, err)
+		return nil, errors.Errorf("error resetting password for %s: %v", username, err)
 	}
 
 	return &api.Credentials{
@@ -214,7 +215,7 @@ func (k *kubernetes) getLocalThelmaUserCredentials(username string) (*api.Creden
 	}
 	password, exists := s[username]
 	if !exists {
-		return nil, fmt.Errorf("no password found for %s in secret %s", username, k.secretName())
+		return nil, errors.Errorf("no password found for %s in secret %s", username, k.secretName())
 	}
 	return &api.Credentials{
 		Username: username,
@@ -253,7 +254,7 @@ func (k *kubernetes) secretExists() (bool, error) {
 		return true, nil
 	}
 	// multiple secrets with the same name in the same namespace should be impossible
-	panic(fmt.Errorf("found multiple secrets with name %s (%d)", k.secretName(), len(secrets.Items)))
+	panic(errors.Errorf("found multiple secrets with name %s (%d)", k.secretName(), len(secrets.Items)))
 }
 
 func (k *kubernetes) secretName() string {

--- a/internal/thelma/ops/status/reporter.go
+++ b/internal/thelma/ops/status/reporter.go
@@ -1,12 +1,12 @@
 package status
 
 import (
-	"fmt"
 	k8sclients "github.com/broadinstitute/thelma/internal/thelma/clients/kubernetes"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	argocdnames "github.com/broadinstitute/thelma/internal/thelma/state/api/terra/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"sync"
 )
@@ -57,7 +57,7 @@ func (r *reporter) Statuses(releases []terra.Release) (map[terra.Release]*Status
 			Run: func(_ pool.StatusReporter) error {
 				status, err := r.Status(release)
 				if err != nil {
-					return fmt.Errorf("error generating status report for %s: %v", release.Name(), err)
+					return errors.Errorf("error generating status report for %s: %v", release.Name(), err)
 				}
 				mutex.Lock()
 				statuses[release] = status

--- a/internal/thelma/ops/sync/sync.go
+++ b/internal/thelma/ops/sync/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/argocd"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"sort"
 	"sync"
@@ -130,7 +131,7 @@ func (s *syncer) waitHealthy(release terra.Release, maxWait time.Duration, statu
 		for {
 			select {
 			case <-timeout:
-				return lastStatus, fmt.Errorf("timed out waiting for healthy (%s)", lastStatus.Headline())
+				return lastStatus, errors.Errorf("timed out waiting for healthy (%s)", lastStatus.Headline())
 			case <-ticker.C:
 				lastStatus, err = s.status.Status(release)
 				if err != nil {

--- a/internal/thelma/render/helmfile/argocd/argocd.go
+++ b/internal/thelma/render/helmfile/argocd/argocd.go
@@ -1,8 +1,8 @@
 package argocd
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"sort"
 	"strings"
 )
@@ -46,7 +46,7 @@ func getArgoDestinations(destination terra.Destination) []ArgoDestination {
 	case terra.Cluster:
 		return argoDestinationsForCluster(t)
 	default:
-		panic(fmt.Errorf("error generating destination values file: unknown destination type %s: %v", destination.Type().String(), destination))
+		panic(errors.Errorf("error generating destination values file: unknown destination type %s: %v", destination.Type().String(), destination))
 	}
 }
 

--- a/internal/thelma/render/render.go
+++ b/internal/thelma/render/render.go
@@ -3,6 +3,7 @@ package render
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"strconv"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app"
@@ -124,7 +125,7 @@ func (r *multiRender) renderAll(helmfileArgs *helmfile.Args) error {
 		return err
 	}
 	if len(jobs) == 0 {
-		return fmt.Errorf("no matching releases found")
+		return errors.Errorf("no matching releases found")
 	}
 
 	_pool := pool.New(jobs, func(options *pool.Options) {

--- a/internal/thelma/render/resolver/remote_resolver.go
+++ b/internal/thelma/render/resolver/remote_resolver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/helm"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path"
@@ -40,7 +41,7 @@ func (r *remoteResolverImpl) resolverFn(chartRelease ChartRelease) (ResolvedChar
 	// Create a tmp dir for downloading and unpacking the chart
 	tmpDir := path.Join(r.scratchDir, fmt.Sprintf("%s-%s-%s", chartRelease.Repo, chartRelease.Name, chartRelease.Version))
 	if err := os.MkdirAll(tmpDir, 0775); err != nil {
-		return nil, fmt.Errorf("failed to make tmp dir in %s: %v", r.scratchDir, err)
+		return nil, errors.Errorf("failed to make tmp dir in %s: %v", r.scratchDir, err)
 	}
 	defer r.cleanupTmpDir(tmpDir)
 
@@ -59,7 +60,7 @@ func (r *remoteResolverImpl) resolverFn(chartRelease ChartRelease) (ResolvedChar
 	}
 
 	if err := r.runner.Run(cmd); err != nil {
-		return nil, fmt.Errorf("error downloading chart %s/%s version %s to %s: %v", chartRelease.Repo, chartRelease.Name, chartRelease.Version, tmpDir, err)
+		return nil, errors.Errorf("error downloading chart %s/%s version %s to %s: %v", chartRelease.Repo, chartRelease.Name, chartRelease.Version, tmpDir, err)
 	}
 
 	// Move downloaded chart to correct location in the cache directory
@@ -71,7 +72,7 @@ func (r *remoteResolverImpl) resolverFn(chartRelease ChartRelease) (ResolvedChar
 		return nil, err
 	}
 	if len(entries) != 1 {
-		return nil, fmt.Errorf("expected exactly one file in %s, got: %v", tmpDir, entries)
+		return nil, errors.Errorf("expected exactly one file in %s, got: %v", tmpDir, entries)
 	}
 	tmpChartPath := path.Join(tmpDir, entries[0].Name())
 

--- a/internal/thelma/render/resolver/resolver_test.go
+++ b/internal/thelma/render/resolver/resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path"
 	"testing"
@@ -263,7 +264,7 @@ func (tc *testCfg) expectHelmFetch(success bool) {
 		call.Run(func(args mock.Arguments) {
 			fakeChartDir := path.Join(downloadDir, tc.input.Name)
 			if err := os.MkdirAll(fakeChartDir, 0775); err != nil {
-				panic(fmt.Errorf("failed to create fake fetch dir %s: %v", fakeChartDir, err))
+				panic(errors.Errorf("failed to create fake fetch dir %s: %v", fakeChartDir, err))
 			}
 		})
 	} else {

--- a/internal/thelma/render/scope/scope.go
+++ b/internal/thelma/render/scope/scope.go
@@ -1,6 +1,8 @@
 package scope
 
-import "fmt"
+import (
+	"github.com/pkg/errors"
+)
 
 // Scope is an enum type representing different output formats
 type Scope int
@@ -24,7 +26,7 @@ func FromString(value string) (Scope, error) {
 	case "destination":
 		return Destination, nil
 	}
-	return All, fmt.Errorf("unknown format: %q", value)
+	return All, errors.Errorf("unknown format: %q", value)
 }
 
 // String returns a string representation of this format

--- a/internal/thelma/render/validator/validator.go
+++ b/internal/thelma/render/validator/validator.go
@@ -1,10 +1,9 @@
 package validator
 
 import (
-	"fmt"
-
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/kubeconform"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/pkg/errors"
 )
 
 // Mode determinations behavior of the post-render manifest validation. Default is skip.
@@ -28,7 +27,7 @@ func FromString(value string) (Mode, error) {
 	case "fail":
 		return Fail, nil
 	default:
-		return Skip, fmt.Errorf("unknown validation mode: %q", value)
+		return Skip, errors.Errorf("unknown validation mode: %q", value)
 	}
 }
 

--- a/internal/thelma/state/api/terra/argocd/argocd.go
+++ b/internal/thelma/state/api/terra/argocd/argocd.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"strings"
 )
 
@@ -37,7 +38,7 @@ func ProjectName(destination terra.Destination) string {
 	case terra.Cluster:
 		return fmt.Sprintf("cluster-%s", t.Name())
 	default:
-		panic(fmt.Errorf("error generating destination values file: unknown destination type %s: %v", destination.Type().String(), destination))
+		panic(errors.Errorf("error generating destination values file: unknown destination type %s: %v", destination.Type().String(), destination))
 	}
 }
 

--- a/internal/thelma/state/api/terra/destination_type.go
+++ b/internal/thelma/state/api/terra/destination_type.go
@@ -1,7 +1,7 @@
 package terra
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -58,7 +58,7 @@ func (t *DestinationType) FromString(value string) error {
 		return nil
 	}
 
-	return fmt.Errorf("unknown destination type: %q", value)
+	return errors.Errorf("unknown destination type: %q", value)
 }
 
 func (t DestinationType) String() string {

--- a/internal/thelma/state/api/terra/lifecycle.go
+++ b/internal/thelma/state/api/terra/lifecycle.go
@@ -1,7 +1,7 @@
 package terra
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"strings"
 )
@@ -63,7 +63,7 @@ func (l *Lifecycle) UnmarshalYAML(value *yaml.Node) error {
 	for _, l := range Lifecycles() {
 		supported = append(supported, l.String())
 	}
-	return fmt.Errorf("unknown lifecycle type %v, supported lifecycles are %s", value.Value, strings.Join(supported, ", "))
+	return errors.Errorf("unknown lifecycle type %v, supported lifecycles are %s", value.Value, strings.Join(supported, ", "))
 }
 
 // FromString will set the receiver's value to the one denoted by the given string
@@ -84,7 +84,7 @@ func (l *Lifecycle) FromString(value string) error {
 	for _, lifecycle := range Lifecycles() {
 		supported = append(supported, lifecycle.String())
 	}
-	return fmt.Errorf("unknown lifecycle type %v, supported lifecycles are %s", value, strings.Join(supported, ", "))
+	return errors.Errorf("unknown lifecycle type %v, supported lifecycles are %s", value, strings.Join(supported, ", "))
 }
 
 func (l Lifecycle) String() string {

--- a/internal/thelma/state/api/terra/release_type.go
+++ b/internal/thelma/state/api/terra/release_type.go
@@ -1,7 +1,7 @@
 package terra
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,7 +40,7 @@ func (r *ReleaseType) UnmarshalYAML(value *yaml.Node) error {
 		return nil
 	}
 
-	return fmt.Errorf("unknown release type: %v", value.Value)
+	return errors.Errorf("unknown release type: %v", value.Value)
 }
 
 func (r ReleaseType) String() string {

--- a/internal/thelma/state/api/terra/validate/validate.go
+++ b/internal/thelma/state/api/terra/validate/validate.go
@@ -1,7 +1,7 @@
 package validate
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"regexp"
 )
 
@@ -14,11 +14,11 @@ var envNameRegexp = regexp.MustCompile(`\A[a-z][a-z0-9]*(-[a-z0-9]+)*\z`)
 // EnvironmentName returns an error if the given environment name is invalid
 func EnvironmentName(name string) error {
 	if len(name) > maxEnvNameLen {
-		return fmt.Errorf("environment names must be <= %d characters in length", maxEnvNameLen)
+		return errors.Errorf("environment names must be <= %d characters in length", maxEnvNameLen)
 	}
 
 	if !envNameRegexp.MatchString(name) {
-		return fmt.Errorf("environment name must match regular expression %s", envNameRegexp.String())
+		return errors.Errorf("environment name must match regular expression %s", envNameRegexp.String())
 	}
 
 	return nil
@@ -27,11 +27,11 @@ func EnvironmentName(name string) error {
 // EnvironmentNamePrefix returns an error if the given environment prefix is invalid
 func EnvironmentNamePrefix(prefix string) error {
 	if len(prefix) > maxEnvPrefixLen {
-		return fmt.Errorf("environment name prefixes must be <= %d characters in length", maxEnvPrefixLen)
+		return errors.Errorf("environment name prefixes must be <= %d characters in length", maxEnvPrefixLen)
 	}
 
 	if !envNameRegexp.MatchString(prefix) {
-		return fmt.Errorf("environment name prefix must match regular expression %s", envNameRegexp.String())
+		return errors.Errorf("environment name prefix must match regular expression %s", envNameRegexp.String())
 	}
 
 	return nil

--- a/internal/thelma/state/providers/sherlock/environments.go
+++ b/internal/thelma/state/providers/sherlock/environments.go
@@ -1,7 +1,7 @@
 package sherlock
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
@@ -38,7 +38,7 @@ func (e *environments) Filter(filter terra.EnvironmentFilter) ([]terra.Environme
 func (e *environments) Get(name string) (terra.Environment, error) {
 	env, exists := e.state.environments[name]
 	if !exists {
-		return nil, fmt.Errorf("environment %q does not exist", name)
+		return nil, errors.Errorf("environment %q does not exist", name)
 	}
 	return env, nil
 }
@@ -58,7 +58,7 @@ func (e *environments) EnableRelease(environmentName string, releaseName string)
 		return err
 	}
 	if environment.Lifecycle() != terra.Dynamic {
-		return fmt.Errorf("enabling releases is only supported for dynamic environments")
+		return errors.Errorf("enabling releases is only supported for dynamic environments")
 	}
 	return e.state.sherlock.EnableRelease(environment, releaseName)
 }
@@ -69,7 +69,7 @@ func (e *environments) DisableRelease(environmentName string, releaseName string
 		return err
 	}
 	if environment.Lifecycle() != terra.Dynamic {
-		return fmt.Errorf("disabling releases is only supported in dynamic environments")
+		return errors.Errorf("disabling releases is only supported in dynamic environments")
 	}
 	return e.state.sherlock.DisableRelease(environmentName, releaseName)
 }

--- a/internal/thelma/state/providers/sherlock/environments_test.go
+++ b/internal/thelma/state/providers/sherlock/environments_test.go
@@ -1,7 +1,7 @@
 package sherlock
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/broadinstitute/thelma/internal/thelma/clients/sherlock/mocks"
@@ -58,7 +58,7 @@ func (suite *environmentsSuite) TestDeleteEnvironmentError() {
 	mockEnvironments := make(map[string]*environment)
 	mockEnvironments["existing-env"] = mockEnvironment
 	mockStateReadWriter := mocks.NewStateReadWriter(suite.T())
-	mockStateReadWriter.On("DeleteEnvironments", mock.AnythingOfType("[]terra.Environment")).Return(nil, fmt.Errorf("some error"))
+	mockStateReadWriter.On("DeleteEnvironments", mock.AnythingOfType("[]terra.Environment")).Return(nil, errors.Errorf("some error"))
 	mockState := state{
 		sherlock:     mockStateReadWriter,
 		environments: mockEnvironments,

--- a/internal/thelma/state/providers/sherlock/state_exporter_writer_test.go
+++ b/internal/thelma/state/providers/sherlock/state_exporter_writer_test.go
@@ -1,8 +1,8 @@
 package sherlock_test
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/testing/statefixtures"
+	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app/builder"
@@ -44,7 +44,7 @@ func (suite *sherlockStateWriterSuite) TestSuccessfulStateWriter() {
 
 func (suite *sherlockStateWriterSuite) TestErrorWriteEnvironments() {
 	mockStateWriter := mocks.NewStateWriter(suite.T())
-	mockStateWriter.On("WriteEnvironments", mock.AnythingOfType("[]terra.Environment")).Return(nil, fmt.Errorf("some error"))
+	mockStateWriter.On("WriteEnvironments", mock.AnythingOfType("[]terra.Environment")).Return(nil, errors.Errorf("some error"))
 
 	stateWriter := sherlock.NewSherlockStateWriter(suite.state, mockStateWriter)
 	err := stateWriter.WriteEnvironments()
@@ -54,7 +54,7 @@ func (suite *sherlockStateWriterSuite) TestErrorWriteEnvironments() {
 
 func (suite *sherlockStateWriterSuite) TestErrorWriteClusters() {
 	mockStateWriter := mocks.NewStateWriter(suite.T())
-	mockStateWriter.On("WriteClusters", mock.AnythingOfType("[]terra.Cluster")).Return(fmt.Errorf("some error"))
+	mockStateWriter.On("WriteClusters", mock.AnythingOfType("[]terra.Cluster")).Return(errors.Errorf("some error"))
 
 	stateWriter := sherlock.NewSherlockStateWriter(suite.state, mockStateWriter)
 	err := stateWriter.WriteClusters()

--- a/internal/thelma/state/providers/sherlock/state_loader.go
+++ b/internal/thelma/state/providers/sherlock/state_loader.go
@@ -1,9 +1,9 @@
 package sherlock
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/sherlock"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"time"
 )
@@ -175,7 +175,7 @@ retry:
 					},
 				}
 			default:
-				return nil, fmt.Errorf("unexpected destination type '%s' for release '%s'", stateRelease.DestinationType, stateRelease.Name)
+				return nil, errors.Errorf("unexpected destination type '%s' for release '%s'", stateRelease.DestinationType, stateRelease.Name)
 			}
 		}
 
@@ -187,5 +187,5 @@ retry:
 		s.cached = _state
 		return _state, nil
 	}
-	return nil, fmt.Errorf("ran out of retries trying to resolve race conditions while loading state from sherlock")
+	return nil, errors.Errorf("ran out of retries trying to resolve race conditions while loading state from sherlock")
 }

--- a/internal/thelma/state/providers/sherlock/state_loader_test.go
+++ b/internal/thelma/state/providers/sherlock/state_loader_test.go
@@ -1,7 +1,7 @@
 package sherlock
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/models"
@@ -93,7 +93,7 @@ func (suite *sherlockStateLoaderSuite) TestStateLoading() {
 func (suite *sherlockStateLoaderSuite) TestStateLoadingError() {
 	stateSource := mocks.NewStateReadWriter(suite.T())
 	errMsg := "this is an error from sherlock"
-	stateSource.On("Clusters").Return(nil, fmt.Errorf(errMsg))
+	stateSource.On("Clusters").Return(nil, errors.Errorf(errMsg))
 
 	thelmaHome := suite.T().TempDir()
 	s := NewStateLoader(thelmaHome, stateSource)

--- a/internal/thelma/state/testing/statefixtures/fixture.go
+++ b/internal/thelma/state/testing/statefixtures/fixture.go
@@ -2,9 +2,9 @@ package statefixtures
 
 import (
 	"embed"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	statemocks "github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"path"
 )
@@ -30,13 +30,13 @@ type Fixture interface {
 func LoadFixture(name FixtureName) (Fixture, error) {
 	content, err := fixturesFS.ReadFile(path.Join("fixtures", name.String()+".yaml"))
 	if err != nil {
-		return nil, fmt.Errorf("error loading %s fixture: %v", name.String(), err)
+		return nil, errors.Errorf("error loading %s fixture: %v", name.String(), err)
 	}
 
 	var data FixtureData
 	err = yaml.Unmarshal(content, &data)
 	if err != nil {
-		return nil, fmt.Errorf("error loading %s fixture: %v", name.String(), err)
+		return nil, errors.Errorf("error loading %s fixture: %v", name.String(), err)
 	}
 
 	mocks := newBuilder(&data).buildMocks()

--- a/internal/thelma/state/testing/statefixtures/fixture_name.go
+++ b/internal/thelma/state/testing/statefixtures/fixture_name.go
@@ -1,6 +1,6 @@
 package statefixtures
 
-import "fmt"
+import "github.com/pkg/errors"
 
 // FixtureName is an enum type for different fixtures in the fixtures/ directory.
 type FixtureName int
@@ -14,5 +14,5 @@ func (f FixtureName) String() string {
 	case Default:
 		return "default"
 	}
-	panic(fmt.Errorf("unknown fixture: %d", f))
+	panic(errors.Errorf("unknown fixture: %d", f))
 }

--- a/internal/thelma/toolbox/argocd/status.go
+++ b/internal/thelma/toolbox/argocd/status.go
@@ -1,7 +1,7 @@
 package argocd
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,13 +38,13 @@ func (h *HealthStatus) UnmarshalYAML(value *yaml.Node) error {
 		return nil
 	}
 
-	return fmt.Errorf("unknown health status: %v", value.Value)
+	return errors.Errorf("unknown health status: %v", value.Value)
 }
 
 func (h HealthStatus) MarshalYAML() (interface{}, error) {
 	str := h.String()
 	if str == "" {
-		return nil, fmt.Errorf("unknown health status: %v", h)
+		return nil, errors.Errorf("unknown health status: %v", h)
 	}
 	return str, nil
 }
@@ -88,13 +88,13 @@ func (s *SyncStatus) UnmarshalYAML(value *yaml.Node) error {
 		return nil
 	}
 
-	return fmt.Errorf("unknown sync status: %v", value.Value)
+	return errors.Errorf("unknown sync status: %v", value.Value)
 }
 
 func (s SyncStatus) MarshalYAML() (interface{}, error) {
 	str := s.String()
 	if str == "" {
-		return nil, fmt.Errorf("unknown sync status: %v", s)
+		return nil, errors.Errorf("unknown sync status: %v", s)
 	}
 	return str, nil
 }

--- a/internal/thelma/toolbox/kubectl/kubectl.go
+++ b/internal/thelma/toolbox/kubectl/kubectl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/clients/kubernetes/kubecfg"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"io"
 	"os"
@@ -84,7 +85,7 @@ func (k *kubectl) ShutDown(env terra.Environment) error {
 func (k *kubectl) DeletePVCs(env terra.Environment) error {
 	if env.Lifecycle() != terra.Dynamic {
 		// Guard against kabooming data in long-lived static environments (such as, for example, prod)
-		return fmt.Errorf("DeletePVCs can only be called for dynamic environments")
+		return errors.Errorf("DeletePVCs can only be called for dynamic environments")
 	}
 	log.Info().Msgf("Deleting all PVCs in %s", env.Name())
 	return k.runForEnv(env, []string{"delete", "persistentvolumeclaims", "--all", "--wait=true"})
@@ -98,7 +99,7 @@ func (k *kubectl) CreateNamespace(env terra.Environment) error {
 func (k *kubectl) DeleteNamespace(env terra.Environment) error {
 	if env.Lifecycle() != terra.Dynamic {
 		// Guard against kabooming data in long-lived static environments (such as, for example, prod)
-		return fmt.Errorf("DeleteNamespace can only be called for dynamic environments")
+		return errors.Errorf("DeleteNamespace can only be called for dynamic environments")
 	}
 	log.Info().Msgf("Deleting environment namespace: %s", env.Namespace())
 	// Note: We supply --ignore-not-found because sometimes BEE creation fails before the namespace is created.
@@ -148,7 +149,7 @@ func (k *kubectl) PortForward(targetRelease terra.Release, targetResource string
 		}, nil
 	case <-time.After(10 * time.Second):
 		_ = subprocess.Stop()
-		return 0, nil, fmt.Errorf("kubectl port-forward output didn't yield a local port within 10 seconds, output: \n%s", output.String())
+		return 0, nil, errors.Errorf("kubectl port-forward output didn't yield a local port within 10 seconds, output: \n%s", output.String())
 	}
 }
 

--- a/internal/thelma/toolbox/toolbox.go
+++ b/internal/thelma/toolbox/toolbox.go
@@ -1,9 +1,9 @@
 package toolbox
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/helm"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
+	"github.com/pkg/errors"
 	"path"
 	"path/filepath"
 )
@@ -30,12 +30,12 @@ const verifyTool = helm.ProgName
 func FindToolsDir() (string, error) {
 	exe, err := utils.PathToRunningThelmaExecutable()
 	if err != nil {
-		return "", fmt.Errorf("error resolving path to Thelma's bundled tools: %v", err)
+		return "", errors.Errorf("error resolving path to Thelma's bundled tools: %v", err)
 	}
 
 	toolsDir, err := findToolsDir(exe)
 	if err != nil {
-		return "", fmt.Errorf("error resolving path to Thelma's bundled tools: %v", err)
+		return "", errors.Errorf("error resolving path to Thelma's bundled tools: %v", err)
 	}
 
 	return toolsDir, nil
@@ -63,7 +63,7 @@ func validateToolsDir(toolsdir string) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("tools dir not found; %s does not exist", toolexe)
+		return errors.Errorf("tools dir not found; %s does not exist", toolexe)
 	}
 	return nil
 }

--- a/internal/thelma/utils/deepmerge/deepmerge.go
+++ b/internal/thelma/utils/deepmerge/deepmerge.go
@@ -1,7 +1,7 @@
 package deepmerge
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"os"
 )
@@ -16,7 +16,7 @@ func Unmarshal(result interface{}, filenames ...string) error {
 
 	err = yaml.Unmarshal(merged, result)
 	if err != nil {
-		return fmt.Errorf("error unmarshaling merged yaml: %v", err)
+		return errors.Errorf("error unmarshaling merged yaml: %v", err)
 	}
 
 	return nil
@@ -41,7 +41,7 @@ func Merge(filenames ...string) ([]byte, error) {
 	// Now that we've merged the content, serialize back to yaml so we can deserialize into the expected type.
 	marshaled, err := yaml.Marshal(merged)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling yaml for deep merge: %v", err)
+		return nil, errors.Errorf("error marshaling yaml for deep merge: %v", err)
 	}
 
 	return marshaled, nil
@@ -89,17 +89,17 @@ func unmarshalYamlFileIfExists(file string) (map[string]interface{}, error) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error reading file %s: %v", file, err)
+		return nil, errors.Errorf("error reading file %s: %v", file, err)
 	}
 
 	content, err := os.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file %s: %v", file, err)
+		return nil, errors.Errorf("error reading file %s: %v", file, err)
 	}
 
 	var parsed map[string]interface{}
 	if err := yaml.Unmarshal(content, &parsed); err != nil {
-		return nil, fmt.Errorf("failed to parse yaml file %s: %v", file, err)
+		return nil, errors.Errorf("failed to parse yaml file %s: %v", file, err)
 	}
 
 	if parsed == nil {

--- a/internal/thelma/utils/flock/flock_test.go
+++ b/internal/thelma/utils/flock/flock_test.go
@@ -1,7 +1,7 @@
 package flock
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"path"
@@ -39,7 +39,7 @@ func TestWithLockPreventsConcurrentExecution(t *testing.T) {
 				log.Debug().Msgf("[%d] got lock", id)
 				owner := atomic.LoadInt32(&lockOwner)
 				if owner != -1 {
-					return fmt.Errorf("[%d] another routine also owns the lock? %d", id, owner)
+					return errors.Errorf("[%d] another routine also owns the lock? %d", id, owner)
 				}
 				atomic.StoreInt32(&lockOwner, int32(id))
 
@@ -189,7 +189,7 @@ func TestWithLockReturnsCallbackError(t *testing.T) {
 
 	// We don't expect any timeouts here! Just want to make sure errors are correctly propagated to caller
 	err := locker.WithLock(func() error {
-		return fmt.Errorf("fake error from callback")
+		return errors.Errorf("fake error from callback")
 	})
 	assert.Error(t, err, "Expected error to propagate up from WithLock")
 	assert.Equal(t, "fake error from callback", err.Error())

--- a/internal/thelma/utils/lazy/lazy_test.go
+++ b/internal/thelma/utils/lazy/lazy_test.go
@@ -1,7 +1,7 @@
 package lazy
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -23,7 +23,7 @@ func Test_LazyE(t *testing.T) {
 	l := NewLazyE[int](func() (int, error) {
 		counter++
 		if counter < 3 {
-			return counter, fmt.Errorf("counter < 3")
+			return counter, errors.Errorf("counter < 3")
 		}
 		return counter, nil
 	})

--- a/internal/thelma/utils/pool/pool.go
+++ b/internal/thelma/utils/pool/pool.go
@@ -4,6 +4,7 @@ package pool
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"runtime"
@@ -183,7 +184,7 @@ func (p *pool) aggregateErrors() error {
 	}
 
 	if count > 0 {
-		return fmt.Errorf("%d execution errors:\n%s", count, sb.String())
+		return errors.Errorf("%d execution errors:\n%s", count, sb.String())
 	}
 
 	return nil

--- a/internal/thelma/utils/pool/pool_test.go
+++ b/internal/thelma/utils/pool/pool_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/testutils"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -220,7 +221,7 @@ func successfulJob(desc string) *testJob {
 func failingJob(desc string) *testJob {
 	return &testJob{
 		description: desc,
-		err:         fmt.Errorf("whoopsies (%s)", desc),
+		err:         errors.Errorf("whoopsies (%s)", desc),
 	}
 }
 

--- a/internal/thelma/utils/pool/summarizer_test.go
+++ b/internal/thelma/utils/pool/summarizer_test.go
@@ -3,7 +3,7 @@ package pool
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,7 +71,7 @@ func Test_Summarizer(t *testing.T) {
 				Message: "onion pending",
 			})
 			time.Sleep(5 * baseInterval)
-			return fmt.Errorf("whoopsies")
+			return errors.Errorf("whoopsies")
 		},
 	}
 

--- a/internal/thelma/utils/prompt/prompt.go
+++ b/internal/thelma/utils/prompt/prompt.go
@@ -6,6 +6,7 @@ import (
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/wordwrap"
 	"github.com/fatih/color"
+	"github.com/pkg/errors"
 	"io"
 	"os"
 	"strings"
@@ -111,11 +112,11 @@ func (p *prompt) Confirm(message string, opts ...func(*ConfirmOptions)) (bool, e
 
 	for {
 		if _, err := fmt.Fprint(p.out, p.wrap(message, options.StyleOptions)); err != nil {
-			return false, fmt.Errorf("error prompting for user input: %v", err)
+			return false, errors.Errorf("error prompting for user input: %v", err)
 		}
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			return false, fmt.Errorf("error prompting for user input: %v", err)
+			return false, errors.Errorf("error prompting for user input: %v", err)
 		}
 
 		input = strings.TrimSpace(input)
@@ -134,7 +135,7 @@ func (p *prompt) Confirm(message string, opts ...func(*ConfirmOptions)) (bool, e
 		feedback := fmt.Sprintf(`Unrecognized input %q; please enter "y" or "n"`, input)
 		feedback = p.wrap(feedback, options.StyleOptions)
 		if _, err = fmt.Fprintln(p.out, feedback); err != nil {
-			return false, fmt.Errorf("error prompting for user input: %v", err)
+			return false, errors.Errorf("error prompting for user input: %v", err)
 		}
 	}
 }
@@ -164,7 +165,7 @@ func (p *prompt) verifyInteractive() error {
 		return nil
 	}
 	if !utils.Interactive() {
-		return fmt.Errorf("can't prompt for input; try re-running in an interactive shell")
+		return errors.Errorf("can't prompt for input; try re-running in an interactive shell")
 	}
 	return nil
 }

--- a/internal/thelma/utils/pwgen/pwgen_test.go
+++ b/internal/thelma/utils/pwgen/pwgen_test.go
@@ -1,8 +1,8 @@
 package pwgen
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -159,7 +159,7 @@ func countKinds(s string) counts {
 		} else if rs.special.Exists(r) {
 			c.special++
 		} else {
-			panic(fmt.Errorf("unrecognized character: %c", r))
+			panic(errors.Errorf("unrecognized character: %c", r))
 		}
 	}
 

--- a/internal/thelma/utils/shell/logging_writer.go
+++ b/internal/thelma/utils/shell/logging_writer.go
@@ -2,7 +2,7 @@ package shell
 
 import (
 	"bytes"
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"io"
 	"strings"
@@ -56,7 +56,7 @@ func (lw *LoggingWriter) streamLinesToLog(p []byte) (n int, err error) {
 		if err == io.EOF {
 			return n, nil
 		} else if err != nil {
-			return n, fmt.Errorf("logging writer: error reading from buffer: %v", err)
+			return n, errors.Errorf("logging writer: error reading from buffer: %v", err)
 		}
 	}
 }

--- a/internal/thelma/utils/shell/mock_call.go
+++ b/internal/thelma/utils/shell/mock_call.go
@@ -1,7 +1,7 @@
 package shell
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"io"
 )
@@ -57,7 +57,7 @@ func (c *Call) WithStderr(output string) *Call {
 func (c *Call) writeMockOutput(args mock.Arguments) error {
 	runOpts, ok := args.Get(1).(RunOptions)
 	if !ok {
-		panic(fmt.Errorf("shellmock.Call: type assertion failed: expected RunOpts, got: %v", args.Get(1)))
+		panic(errors.Errorf("shellmock.Call: type assertion failed: expected RunOpts, got: %v", args.Get(1)))
 	}
 	if err := writeMockOutputToStream(runOpts.Stdout, c.mockStdout); err != nil {
 		return err

--- a/internal/thelma/utils/shell/mock_runner.go
+++ b/internal/thelma/utils/shell/mock_runner.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"os"
 	"strings"
@@ -211,7 +212,7 @@ func (m *MockRunner) addOrderingCheck(cmd Command, mockCall *mock.Call) *Call {
 		if m.options.VerifyOrder {
 			if m.runCounter != order { // this command is out of order
 				if m.runCounter < len(m.expectedCommands) { // we have remaining expectations
-					err := fmt.Errorf(
+					err := errors.Errorf(
 						"Command received out of order (%d instead of %d). Expected:\n%v\nReceived:\n%v",
 						m.runCounter,
 						order,

--- a/internal/thelma/utils/shell/mock_test.go
+++ b/internal/thelma/utils/shell/mock_test.go
@@ -2,7 +2,7 @@ package shell
 
 import (
 	"bytes"
-	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
@@ -166,7 +166,7 @@ func TestMockRunnerCanMockErrors(t *testing.T) {
 	m := DefaultMockRunner()
 	m.Test(t)
 
-	m.ExpectCmd(CmdFromArgs("echo", "1")).Fails(fmt.Errorf("my error"))
+	m.ExpectCmd(CmdFromArgs("echo", "1")).Fails(errors.Errorf("my error"))
 
 	e := m.Run(CmdFromArgs("echo", "1"))
 	assert.Error(t, e, "error should not be nil")

--- a/internal/thelma/utils/shell/real_runner.go
+++ b/internal/thelma/utils/shell/real_runner.go
@@ -2,9 +2,9 @@ package shell
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/logid"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"io"
@@ -139,7 +139,7 @@ func (s *realSubprocess) Stop() error {
 		return nil
 	}
 	if s.execCmd.Process == nil {
-		return fmt.Errorf("no process associated with command")
+		return errors.Errorf("no process associated with command")
 	} else {
 		if err := s.execCmd.Process.Signal(os.Interrupt); err != nil {
 			// Can't send SIGINT on Windows; it'll error, so send SIGKILL
@@ -159,7 +159,7 @@ func (s *realSubprocess) Stop() error {
 			return handleExecCmdError(s.cmd, err, s.logger, s.errBuf)
 		case <-time.After(3 * time.Second):
 			_ = s.execCmd.Process.Kill()
-			return fmt.Errorf("process did not exit after 3 seconds")
+			return errors.Errorf("process did not exit after 3 seconds")
 		}
 	}
 }

--- a/internal/thelma/utils/testutils/testutils.go
+++ b/internal/thelma/utils/testutils/testutils.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/app/seed"
+	"github.com/pkg/errors"
 	"math/rand"
 	"sort"
 	"strings"
@@ -35,7 +36,7 @@ func RandString(n int) string {
 // SliceIntoRandomIntervals slices a time.Duration into n random intervals
 func SliceIntoRandomIntervals(duration time.Duration, n int) []time.Duration {
 	if n < 0 {
-		panic(fmt.Errorf("can't divide duration into %d intervals", n))
+		panic(errors.Errorf("can't divide duration into %d intervals", n))
 	}
 	asInt64 := int64(duration)
 

--- a/internal/thelma/utils/utils.go
+++ b/internal/thelma/utils/utils.go
@@ -2,8 +2,8 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"net"
 	"os"
@@ -47,9 +47,9 @@ func ExpandAndVerifyExists(filePath string, description string) (string, error) 
 	}
 
 	if _, err := os.Stat(expanded); os.IsNotExist(err) {
-		return "", fmt.Errorf("%s does not exist: %s", description, expanded)
+		return "", errors.Errorf("%s does not exist: %s", description, expanded)
 	} else if err != nil {
-		return "", fmt.Errorf("error reading %s %s: %v", description, expanded, err)
+		return "", errors.Errorf("error reading %s %s: %v", description, expanded, err)
 	}
 
 	return expanded, nil
@@ -122,12 +122,12 @@ func CloseWarn(closer io.Closer, err error) error {
 func PathToRunningThelmaExecutable() (string, error) {
 	executable, err := os.Executable()
 	if err != nil {
-		return "", fmt.Errorf("error finding path to currently running executable: %v", err)
+		return "", errors.Errorf("error finding path to currently running executable: %v", err)
 	}
 
 	executable, err = filepath.EvalSymlinks(executable)
 	if err != nil {
-		return "", fmt.Errorf("error finding path to currently running executable: %v", err)
+		return "", errors.Errorf("error finding path to currently running executable: %v", err)
 	}
 
 	return executable, nil

--- a/internal/thelma/utils/wordwrap/wordwrap.go
+++ b/internal/thelma/utils/wordwrap/wordwrap.go
@@ -1,9 +1,9 @@
 package wordwrap
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/utils"
 	"github.com/leaanthony/go-ansi-parser"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"strings"
 	"unicode"
@@ -226,7 +226,7 @@ func nextQuoteState(previous quoteState, quoteCount int) quoteState {
 		} else if previous == ends || previous == outside {
 			return starts
 		} else {
-			panic(fmt.Errorf("unmatched quote state: %v", previous))
+			panic(errors.Errorf("unmatched quote state: %v", previous))
 		}
 	} else {
 		// this word is not a quote boundary - if we were previously at a boundary, transition to outside/inside


### PR DESCRIPTION
Follow-up to https://github.com/broadinstitute/thelma/pull/155.

This bulk-replaces all instances of `fmt.Errorf` with `errors.Errorf` in Thelma. (Errors created with `fmt.Errorf` do not contain stacktraces)