### PR TITLE
[DDO-3139] New `--changed-files-list` argument

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,2 +1,2 @@
 skip-dirs:
-  - "**/mocks"
+  - ".*/mocks"

--- a/internal/thelma/charts/changedfiles/changedfiles.go
+++ b/internal/thelma/charts/changedfiles/changedfiles.go
@@ -1,0 +1,248 @@
+// Package changedfiles maps a list of updated files in the terra-helmfile repo to a list of charts that need to be published.
+//
+// The logic is as follows:
+// * Changes to charts/<chartname>/* or values/(app|cluster)/<chartname>* will trigger a publish of the affected chart
+// * Changes to values/app/global* will trigger a publish of all app release charts
+// * Changes to values/cluster/global* will trigger a publish of all cluster release charts
+// * Changes to helmfile.yaml will trigger a publish/render of all charts that have at least one chart release
+// * Finally, any charts that are transitive dependencies of charts in the above list will be published as well
+package changedfiles
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/filter"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/set"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const FlagName = "changed-files-list"
+
+type ChangedFiles interface {
+	// ChartList returns a list of charts that need to be published/released based on the list of changed files
+	//
+	// Note that inputFile should be path to a file that contains a newline-separated list of files
+	// that were updated by a PR.
+	//
+	// All paths in the file should be relative to the root of the terra-helmfile repo.
+	//
+	// Example contents:
+	//   charts/agora/templates/deployment.yaml
+	//   helmfile.yaml
+	//   values/cluster/yale/terra.yaml
+	//
+	// Note that charts that depend on global values, but don't exist in the chart source directory (i.e., datarepo),
+	// are excluded from the list.
+	ChartList(inputFile string) ([]string, error)
+	// ReleaseFilter is like ChartList, except it returns a filter that matches all terra.Release instances that
+	// use a chart that would be published, based on the given list of changed files
+	//
+	// Note that releases that depend on global values, but don't exist in the chart source directory (i.e., datarepo),
+	// will be included by the filter.
+	ReleaseFilter(inputFile string) (terra.ReleaseFilter, error)
+}
+
+func New(chartsDir source.ChartsDir, state terra.State) ChangedFiles {
+	return &changedFiles{
+		chartsDir: chartsDir,
+		state:     state,
+	}
+}
+
+type changedFiles struct {
+	chartsDir source.ChartsDir
+	state     terra.State
+}
+
+// globalFileMatches used internally to track which global files were updated
+type globalFileMatches struct {
+	// include releases that belong to an environment
+	includeEnvReleases bool
+	// include cluster releases (releases that don't belong to an environment)
+	includeClusterReleases bool
+	// include all releases
+	includeAllReleases bool
+}
+
+func (c *changedFiles) ChartList(inputFile string) ([]string, error) {
+	chartList, err := c.identifyImpactedCharts(inputFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// filter out any charts that don't exist in the chart source directory
+	var exist []string
+	for _, chartName := range chartList.Elements() {
+		if c.chartsDir.Exists(chartName) {
+			exist = append(exist, chartName)
+		}
+	}
+
+	sort.Strings(exist)
+	return exist, nil
+}
+
+func (c *changedFiles) ReleaseFilter(inputFile string) (terra.ReleaseFilter, error) {
+	charts, err := c.identifyImpactedCharts(inputFile)
+	if err != nil {
+		return nil, err
+	}
+	return filter.Releases().HasChartName(charts.Elements()...), nil
+}
+
+// identifyImpactedCharts will build a list of charts that are impacted by updated files.
+// this includes:
+// * charts with chart or values files that have changed
+// * charts for releases that are impacted by changes to global values files
+// * and the transitive dependents of the above.
+// note that the result can include the names of charts that do not exist in the chart
+// source directory (for example, datarepo).
+func (c *changedFiles) identifyImpactedCharts(inputFile string) (set.Set[string], error) {
+	updatedFiles, err := parseChangedList(inputFile)
+	if err != nil {
+		return nil, errors.Errorf("error parsing %s: %v", inputFile, err)
+	}
+
+	var matches globalFileMatches
+	chartNames := set.NewSet[string]()
+
+	for _, updatedFileName := range updatedFiles {
+		// remove . and .. components in path
+		cleaned := path.Clean(updatedFileName)
+
+		// loop through files and update filter options based on which files are included
+		if regexp.MustCompile("^charts/[^/]").MatchString(cleaned) {
+			chartName := pathIndex(cleaned, 1)
+			chartNames.Add(chartName)
+
+		} else if regexp.MustCompile("^values/(app|cluster)/global").MatchString(cleaned) {
+			kind := pathIndex(cleaned, 1)
+			if kind == "app" {
+				matches.includeEnvReleases = true
+			} else {
+				matches.includeClusterReleases = true
+			}
+
+		} else if regexp.MustCompile("^values/[^/]").MatchString(cleaned) {
+			component := pathIndex(cleaned, 2)
+			// remove any . extensions like .yaml, .yaml.gotmpl
+			chartName := strings.Split(component, ".")[0]
+			chartNames.Add(chartName)
+
+		} else if regexp.MustCompile("^helmfile.yaml$").MatchString(cleaned) {
+			matches.includeAllReleases = true
+		}
+	}
+
+	// identify releases that are impacted by global values files, and add all their charts to the list
+	_filter := matchesToReleaseFilter(matches)
+	matchingReleases, err := c.state.Releases().Filter(_filter)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range matchingReleases {
+		chartNames.Add(r.ChartName())
+	}
+
+	// for any charts currently in the list, add their transitive dependents.
+	// this means that if an upstream common dependency chart like foundation or ingress is updated,
+	// all downstream charts will be included as well
+	if err = c.addDependents(chartNames); err != nil {
+		return nil, err
+	}
+
+	return chartNames, nil
+}
+
+func (c *changedFiles) addDependents(chartNames set.Set[string]) error {
+	var exists []string
+	for _, chartName := range chartNames.Elements() {
+		if c.chartsDir.Exists(chartName) {
+			exists = append(exists, chartName)
+		}
+	}
+
+	asCharts, err := c.chartsDir.GetCharts(exists...)
+	if err != nil {
+		return err
+	}
+
+	withDependents, err := c.chartsDir.WithTransitiveDependents(asCharts)
+	if err != nil {
+		return err
+	}
+	for _, chartName := range withDependents {
+		chartNames.Add(chartName.Name())
+	}
+	return nil
+}
+
+func matchesToReleaseFilter(matches globalFileMatches) terra.ReleaseFilter {
+	// match all releases
+	if matches.includeAllReleases {
+		return filter.Releases().Any()
+	}
+
+	// start by matching no releases
+	_filter := filter.Releases().Any().Negate()
+
+	// include all env releases if needed
+	if matches.includeEnvReleases {
+		_filter = _filter.Or(filter.Releases().DestinationMatches(filter.Destinations().IsEnvironment()))
+	}
+
+	// include all cluster releases if needed
+	if matches.includeClusterReleases {
+		_filter = _filter.Or(filter.Releases().DestinationMatches(filter.Destinations().IsCluster()))
+	}
+
+	return _filter
+}
+
+// parse changed files into a list of changed files
+func parseChangedList(inputFile string) ([]string, error) {
+	var updatedFiles []string
+
+	content, err := os.ReadFile(inputFile)
+	if err != nil {
+		return nil, errors.Errorf("error reading changed list %s: %v", inputFile, err)
+	}
+
+	buf := bytes.NewBuffer(content)
+	scanner := bufio.NewScanner(buf)
+	var lineno int
+	for scanner.Scan() {
+		lineno++
+		if err := scanner.Err(); err != nil {
+			return nil, errors.Errorf("error scanning changed list %s (line %d): %v", inputFile, lineno, err)
+		}
+		entry := strings.TrimSpace(scanner.Text())
+		if entry == "" {
+			continue
+		}
+		if path.IsAbs(entry) {
+			return nil, errors.Errorf("changed list file %s contains absolute path but all paths should be relative to terra-helmfile root (line %d): %s", inputFile, lineno, entry)
+		}
+		updatedFiles = append(updatedFiles, entry)
+	}
+
+	log.Debug().Msgf("Found %d entries in %s", len(updatedFiles), inputFile)
+
+	return updatedFiles, nil
+}
+
+// split a filepath into a list of components and return the component at the given index
+// eg. pathIndex("my/file/path", 1) -> "file"
+func pathIndex(file string, index int) string {
+	components := strings.Split(file, string(os.PathSeparator))
+	return components[index]
+}

--- a/internal/thelma/charts/changedfiles/changedfiles_test.go
+++ b/internal/thelma/charts/changedfiles/changedfiles_test.go
@@ -103,7 +103,7 @@ values/cluster/global.yaml.gotmpl
 		{
 			name: "app global values and yale value",
 			input: `
-values/app/yale/bee.yaml.gotmpl
+values/cluster/yale/bee.yaml.gotmpl
 values/app/global/bee.yaml.gotmpl
 `,
 			expectCharts:   []string{"rawls", "sam", "workspacemanager", "yale"},

--- a/internal/thelma/charts/changedfiles/changedfiles_test.go
+++ b/internal/thelma/charts/changedfiles/changedfiles_test.go
@@ -1,0 +1,204 @@
+package changedfiles
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
+	"github.com/broadinstitute/thelma/internal/thelma/state/testing/statefixtures"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"sort"
+	"testing"
+)
+
+func Test_ChangedList(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		expectCharts   []string
+		expectReleases []string
+		errMatcher     string
+	}{
+		{
+			name:           "empty input",
+			input:          "",
+			expectCharts:   nil,
+			expectReleases: nil,
+		},
+		{
+			name:           "sam files only",
+			input:          "charts/sam/templates/sam-deployment.yaml",
+			expectCharts:   []string{"sam"},
+			expectReleases: []string{"sam-dev"},
+		},
+		{
+			name: "sam and rawls files",
+			input: `
+charts/sam/templates/deployment.yaml
+charts/rawls/values.yaml
+`,
+			expectCharts:   []string{"rawls", "sam"},
+			expectReleases: []string{"rawls-staging", "sam-dev"},
+		},
+		{
+			name: "values files",
+			input: `
+values/app/rawls.yaml.gotmpl
+values/app/sam/live.yaml.gotmpl
+values/cluster/yale/terra.yaml
+`,
+			expectCharts:   []string{"rawls", "sam", "yale"},
+			expectReleases: []string{"rawls-staging", "sam-dev", "yale-terra-dev", "yale-terra-staging"},
+		},
+		{
+			name: "global app release values - root file",
+			input: `
+values/app/global.yaml.gotmpl
+`,
+			expectCharts:   []string{"rawls", "sam", "workspacemanager"},
+			expectReleases: []string{"datarepo-my-bee", "rawls-staging", "sam-dev", "workspacemanager-swatomation"},
+		},
+		{
+			name: "global app release values - env override file",
+			input: `
+values/app/global/live.yaml.gotmpl
+`,
+			expectCharts:   []string{"rawls", "sam", "workspacemanager"},
+			expectReleases: []string{"datarepo-my-bee", "rawls-staging", "sam-dev", "workspacemanager-swatomation"},
+		},
+		{
+			name: "all cluster releases",
+			input: `
+values/cluster/global/terra.yaml
+`,
+			expectCharts:   []string{"secrets-manager", "yale"},
+			expectReleases: []string{"secrets-manager-terra-dev", "yale-terra-dev", "yale-terra-staging"},
+		},
+		{
+			name: "helmfile.yaml",
+			input: `
+helmfile.yaml
+`,
+			expectCharts:   []string{"rawls", "sam", "secrets-manager", "workspacemanager", "yale"},
+			expectReleases: []string{"datarepo-my-bee", "rawls-staging", "sam-dev", "secrets-manager-terra-dev", "workspacemanager-swatomation", "yale-terra-dev", "yale-terra-staging"},
+		},
+		{
+			name: "app and cluster globals",
+			input: `
+values/app/global/live/dev.yaml
+values/cluster/global.yaml.gotmpl
+`,
+			expectCharts:   []string{"rawls", "sam", "secrets-manager", "workspacemanager", "yale"},
+			expectReleases: []string{"datarepo-my-bee", "rawls-staging", "sam-dev", "secrets-manager-terra-dev", "workspacemanager-swatomation", "yale-terra-dev", "yale-terra-staging"},
+		},
+		{
+			name: "cluster global values and rawls value",
+			input: `
+values/app/rawls.yaml.gotmpl
+values/cluster/global.yaml.gotmpl
+`,
+			expectCharts:   []string{"rawls", "secrets-manager", "yale"},
+			expectReleases: []string{"rawls-staging", "secrets-manager-terra-dev", "yale-terra-dev", "yale-terra-staging"},
+		},
+		{
+			name: "app global values and yale value",
+			input: `
+values/app/yale/bee.yaml.gotmpl
+values/app/global/bee.yaml.gotmpl
+`,
+			expectCharts:   []string{"rawls", "sam", "workspacemanager", "yale"},
+			expectReleases: []string{"datarepo-my-bee", "rawls-staging", "sam-dev", "workspacemanager-swatomation", "yale-terra-dev", "yale-terra-staging"},
+		},
+		{
+			name: "error on non-relative path",
+			input: `
+/Users/jdoe/terra-helmfile/helmfile.yaml
+`,
+			errMatcher: "contains absolute path",
+		},
+		{
+			name: "chart with downstream dependents - ingress",
+			input: `
+charts/ingress/some/file.txt
+`,
+			expectCharts:   []string{"agora", "foundation", "ingress", "rawls", "sam", "workspacemanager"},
+			expectReleases: []string{"rawls-staging", "sam-dev", "workspacemanager-swatomation"},
+		},
+		{
+			name: "chart with downstream dependents - postgres",
+			input: `
+charts/postgres/some/file.txt
+`,
+			expectCharts:   []string{"foundation", "postgres", "sam", "workspacemanager"},
+			expectReleases: []string{"sam-dev", "workspacemanager-swatomation"},
+		},
+		{
+			name: "chart with downstream dependents - mysql",
+			input: `
+charts/mysql/some/file.txt
+`,
+			expectCharts:   []string{"agora", "mysql", "rawls"},
+			expectReleases: []string{"rawls-staging"},
+		},
+		{
+			name: "chart with downstream dependents - foundation",
+			input: `
+charts/foundation/some/file.txt
+`,
+			expectCharts:   []string{"foundation", "workspacemanager"},
+			expectReleases: []string{"workspacemanager-swatomation"},
+		},
+		{
+			name: "release with chart that lives outside terra-helmfile - i.e. datarepo",
+			input: `
+values/app/datarepo.yaml
+`,
+			expectCharts:   nil,
+			expectReleases: []string{"datarepo-my-bee"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRunner := shell.DefaultMockRunner()
+
+			fixture, err := statefixtures.LoadFixtureFromFile("testdata/statefixture.yaml")
+			require.NoError(t, err)
+
+			chartsDir, err := source.NewChartsDir("testdata/charts", mockRunner)
+			require.NoError(t, err)
+
+			changed := New(chartsDir, fixture.Mocks().State)
+
+			inputFile := t.TempDir() + "/input.txt"
+			require.NoError(t, os.WriteFile(inputFile, []byte(tc.input), 0600))
+
+			actualCharts, err := changed.ChartList(inputFile)
+
+			if tc.errMatcher != "" {
+				require.Error(t, err, "expected error matching %s", tc.errMatcher)
+				assert.ErrorContains(t, err, tc.errMatcher)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectCharts, actualCharts)
+			}
+
+			actualReleaseFilter, err := changed.ReleaseFilter(inputFile)
+			if tc.errMatcher != "" {
+				require.Error(t, err, "expected error matching %s", tc.errMatcher)
+				assert.ErrorContains(t, err, tc.errMatcher)
+			} else {
+				require.NoError(t, err)
+				matches, err := fixture.Mocks().Releases.Filter(actualReleaseFilter)
+				require.NoError(t, err)
+				var releaseNames []string
+				for _, r := range matches {
+					releaseNames = append(releaseNames, r.FullName())
+				}
+				sort.Strings(releaseNames)
+				assert.Equal(t, tc.expectReleases, releaseNames)
+			}
+
+		})
+	}
+}

--- a/internal/thelma/charts/changedfiles/testdata/charts/agora/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/agora/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: agora
+version: 1.2.3
+type: application
+dependencies:
+  - name: ingress
+    version: 1.2.3
+    repository: file://../ingress
+  - name: mysql
+    version: 1.2.3
+    condition: mysql.enabled
+    repository: file://../mysql

--- a/internal/thelma/charts/changedfiles/testdata/charts/foundation/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/foundation/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: foundation
+version: 1.2.3
+type: application
+dependencies:
+  - name: ingress
+    version: 1.2.3
+    repository: file://../ingress
+  - name: postgres
+    version: 1.2.3
+    repository: file://../postgres

--- a/internal/thelma/charts/changedfiles/testdata/charts/ingress/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/ingress/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: ingress
+version: 1.2.3
+type: application

--- a/internal/thelma/charts/changedfiles/testdata/charts/mysql/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/mysql/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: mysql
+version: 1.2.3
+type: application

--- a/internal/thelma/charts/changedfiles/testdata/charts/postgres/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/postgres/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: postgres
+version: 1.2.3
+type: application

--- a/internal/thelma/charts/changedfiles/testdata/charts/rawls/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/rawls/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: rawls
+version: 1.2.3
+type: application
+dependencies:
+  - name: ingress
+    version: 1.2.3
+    repository: file://../ingress
+  - name: mysql
+    version: 1.2.3
+    condition: mysql.enabled
+    repository: file://../mysql

--- a/internal/thelma/charts/changedfiles/testdata/charts/sam/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/sam/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: sam
+version: 1.2.3
+type: application
+dependencies:
+  - name: ingress
+    version: 1.2.3
+    repository: file://../ingress
+  - name: postgres
+    version: 1.2.3
+    condition: postgres.enabled
+    repository: file://../postgres

--- a/internal/thelma/charts/changedfiles/testdata/charts/secrets-manager/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/secrets-manager/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: secrets-manager
+version: 1.2.3
+type: application

--- a/internal/thelma/charts/changedfiles/testdata/charts/workspacemanager/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/workspacemanager/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: workspacemanager
+version: 1.2.3
+type: application
+dependencies:
+  - name: foundation
+    version: 1.2.3
+    repository: file://../foundation

--- a/internal/thelma/charts/changedfiles/testdata/charts/yale/Chart.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/charts/yale/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: yale
+version: 1.2.3
+type: application

--- a/internal/thelma/charts/changedfiles/testdata/statefixture.yaml
+++ b/internal/thelma/charts/changedfiles/testdata/statefixture.yaml
@@ -1,0 +1,132 @@
+clusters:
+  - name: terra-dev
+    base: terra
+    address: https://ignored
+    project: fake-project
+    location: us-central1-a
+    requiresuitable: false
+  - name: terra-staging
+    base: terra
+    address: https://ignored
+    project: fake-project
+    location: us-central1-a
+    requiresuitable: false
+  - name: terra-qa-bees
+    base: terra
+    address: https://ignored
+    project: fake-project
+    location: us-central1-a
+    requiresuitable: false
+environments:
+  - name: dev
+    base: live
+    template: ""
+    lifecycle: static
+    uniqueresourceprefix: ""
+    defaultcluster: terra-dev
+  - name: staging
+    base: live
+    template: ""
+    lifecycle: static
+    uniqueresourceprefix: ""
+    defaultcluster: terra-staging
+  - name: swatomation
+    base: bee
+    template: ""
+    lifecycle: template
+    uniqueresourceprefix: ""
+    defaultcluster: terra-qa-bees
+    requiresuitable: false
+  - name: my-bee
+    base: bee
+    template: swatomation
+    lifecycle: dynamic
+    uniqueresourceprefix: abcd
+    defaultcluster: terra-qa-bees
+    requiresuitable: false
+charts:
+  - name: agora
+    repo: terra-helm
+  - name: datarepo
+    repo: datarepo-helm
+  - name: leonardo
+    repo: terra-helm
+  - name: rawls
+    repo: terra-helm
+  - name: sam
+    repo: terra-helm
+  - name: workspacemanager
+    repo: terra-helm
+  - name: yale
+    repo: terra-helm
+  - name: secrets-manager
+    repo: terra-helm
+releases:
+    - fullname: sam-dev
+      repo: terra-helm
+      chart: sam
+      cluster: terra-dev
+      namespace: terra-dev
+      environment: dev
+      appversion: some-sha
+      chartversion: 4.5.6
+      subdomain: sam
+      protocol: sam
+      port: 443
+    - fullname: rawls-staging
+      repo: terra-helm
+      chart: rawls
+      cluster: terra-staging
+      namespace: terra-staging
+      environment: staging
+      appversion: some-sha
+      chartversion: 2.20.1
+      subdomain: rawls
+      protocol: rawls
+      port: 443
+    - fullname: workspacemanager-swatomation
+      repo: terra-helm
+      chart: workspacemanager
+      cluster: terra-qa-bees
+      namespace: terra-swatomation
+      environment: swatomation
+      appversion: some-sha
+      chartversion: 13.14.15
+      subdomain: workspacemanager
+      protocol: workspacemanager
+      port: 443
+    - fullname: yale-terra-dev
+      repo: terra-helm
+      chart: yale
+      cluster: terra-dev
+      namespace: yale
+      environment:
+      appversion: some-sha
+      chartversion: 10.11.12
+    - fullname: yale-terra-staging
+      repo: terra-helm
+      chart: yale
+      cluster: terra-staging
+      namespace: yale
+      environment:
+      appversion:
+      chartversion: 10.11.12
+    - fullname: secrets-manager-terra-dev
+      repo: terra-helm
+      chart: secrets-manager
+      cluster: terra-dev
+      namespace: default
+      environment:
+      appversion:
+      chartversion: 1.2.3
+    - fullname: datarepo-my-bee
+      repo: terra-helm
+      chart: datarepo
+      cluster: terra-qa-bees
+      namespace: terra-my-bee
+      environment: my-bee
+      appversion: some-sha
+      chartversion: 7.8.9
+      subdomain: datarepo
+      protocol: datarepo
+      port: 443

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -217,6 +217,22 @@ func TestRenderArgParsing(t *testing.T) {
 			},
 		},
 		{
+			description: "--changed-files-list should set release name",
+			setupFn: func(tc *testConfig) error {
+				changedFilesList := t.TempDir() + "/changed-files.txt"
+				require.NoError(t, os.WriteFile(changedFilesList, []byte("values/app/datarepo/live/alpha.yaml"), 0644))
+
+				tc.options.SetArgs(Args("render --changed-files-list=%s", changedFilesList))
+				tc.expected.renderOptions.Scope = scope.Release
+				tc.expected.renderOptions.Releases = []terra.Release{
+					fixture.Release("datarepo", "alpha"),
+					fixture.Release("datarepo", "staging"),
+					fixture.Release("datarepo", "prod"),
+				}
+				return nil
+			},
+		},
+		{
 			description: "first positional should set release name",
 			setupFn: func(tc *testConfig) error {
 				tc.options.SetArgs(Args("render -r datarepo"))

--- a/internal/thelma/cli/selector/changed_files_flag.go
+++ b/internal/thelma/cli/selector/changed_files_flag.go
@@ -1,0 +1,39 @@
+package selector
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/charts/changedfiles"
+	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type changedFilesListFlag struct {
+	changedFilesList string
+}
+
+func (c *changedFilesListFlag) addToCobraCommand(cobraCommand *cobra.Command) {
+	cobraCommand.Flags().StringVar(
+		&c.changedFilesList,
+		flagNames.changedFilesList,
+		"path/to/changed-files.txt",
+		`Run for releases matching a newline-separated list of updated files in terra-helmfile`,
+	)
+}
+
+func (c *changedFilesListFlag) processInput(f *filterBuilder, state terra.State, chartsDir source.ChartsDir, _ []string, pflags *pflag.FlagSet) error {
+	if !pflags.Changed(flagNames.changedFilesList) {
+		return nil
+	}
+	changedFiles := changedfiles.New(chartsDir, state)
+	releaseFilter, err := changedFiles.ReleaseFilter(c.changedFilesList)
+	if err != nil {
+		return err
+	}
+	f.addReleaseFilter(releaseFilter)
+	return nil
+}
+
+func newChangedFilesList() *changedFilesListFlag {
+	return &changedFilesListFlag{}
+}

--- a/internal/thelma/cli/selector/enum_flags.go
+++ b/internal/thelma/cli/selector/enum_flags.go
@@ -25,7 +25,7 @@ func newReleasesFlag() *enumFlag {
 				return flagValues, nil
 			} else if len(args) > 0 {
 				return []string{args[0]}, nil
-			} else if pflags.Changed(flagNames.exactRelease) {
+			} else if pflags.Changed(flagNames.exactRelease) || pflags.Changed(flagNames.changedFilesList) {
 				// If there's no releases specified but there are exact releases specified, or a changed file list, act
 				// as if this flag had been set to ALL so we don't filter on it
 				return []string{allSelector}, nil

--- a/internal/thelma/cli/selector/selector.go
+++ b/internal/thelma/cli/selector/selector.go
@@ -1,6 +1,7 @@
 package selector
 
 import (
+	"github.com/broadinstitute/thelma/internal/thelma/charts/changedfiles"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -25,6 +26,7 @@ var flagNames = struct {
 	environmentTemplate  string
 	destinationType      string
 	destinationBase      string
+	changedFilesList     string
 }{
 	release:              ReleasesFlagName,
 	exactRelease:         "exact-release",
@@ -34,6 +36,7 @@ var flagNames = struct {
 	environmentTemplate:  "environment-template",
 	destinationBase:      "destination-base",
 	destinationType:      "destination-type",
+	changedFilesList:     changedfiles.FlagName,
 }
 
 type Selector struct {

--- a/internal/thelma/state/api/terra/filter.go
+++ b/internal/thelma/state/api/terra/filter.go
@@ -12,6 +12,8 @@ type ReleaseFilter interface {
 	And(ReleaseFilter) ReleaseFilter
 	// Or returns a new filter that matches this filter or another
 	Or(ReleaseFilter) ReleaseFilter
+	// Negate returns a new filter that matches the opposite of this filter
+	Negate() ReleaseFilter
 	// Filter given a list of releases, return the sublist that match this filter
 	Filter([]Release) []Release
 }
@@ -26,6 +28,8 @@ type DestinationFilter interface {
 	And(DestinationFilter) DestinationFilter
 	// Or returns a new filter that matches this filter or another
 	Or(DestinationFilter) DestinationFilter
+	// Negate returns a new filter that matches the opposite of this filter
+	Negate() DestinationFilter
 	// Filter given a list of destinations, return the sublist that match this filter
 	Filter([]Destination) []Destination
 }
@@ -40,6 +44,8 @@ type EnvironmentFilter interface {
 	And(EnvironmentFilter) EnvironmentFilter
 	// Or returns a new filter that matches this filter or another
 	Or(EnvironmentFilter) EnvironmentFilter
+	// Negate returns a new filter that matches the opposite of this filter
+	Negate() EnvironmentFilter
 	// Filter given a list of environments, return the sublist that match this filter
 	Filter([]Environment) []Environment
 }

--- a/internal/thelma/state/api/terra/filter/destination_filter.go
+++ b/internal/thelma/state/api/terra/filter/destination_filter.go
@@ -39,6 +39,15 @@ func (f destinationFilter) Or(other terra.DestinationFilter) terra.DestinationFi
 	}
 }
 
+func (f destinationFilter) Negate() terra.DestinationFilter {
+	return destinationFilter{
+		string: fmt.Sprintf(notFormat, f.String()),
+		matcher: func(destination terra.Destination) bool {
+			return !f.Matches(destination)
+		},
+	}
+}
+
 func (f destinationFilter) Filter(destinations []terra.Destination) []terra.Destination {
 	var result []terra.Destination
 	for _, destination := range destinations {

--- a/internal/thelma/state/api/terra/filter/environment_filter.go
+++ b/internal/thelma/state/api/terra/filter/environment_filter.go
@@ -39,6 +39,15 @@ func (f environmentFilter) Or(other terra.EnvironmentFilter) terra.EnvironmentFi
 	}
 }
 
+func (f environmentFilter) Negate() terra.EnvironmentFilter {
+	return environmentFilter{
+		string: fmt.Sprintf(notFormat, f.String()),
+		matcher: func(env terra.Environment) bool {
+			return !f.Matches(env)
+		},
+	}
+}
+
 func (f environmentFilter) Filter(environments []terra.Environment) []terra.Environment {
 	var result []terra.Environment
 	for _, environment := range environments {

--- a/internal/thelma/state/api/terra/filter/release_filter.go
+++ b/internal/thelma/state/api/terra/filter/release_filter.go
@@ -39,6 +39,15 @@ func (f releaseFilter) Or(other terra.ReleaseFilter) terra.ReleaseFilter {
 	}
 }
 
+func (f releaseFilter) Negate() terra.ReleaseFilter {
+	return releaseFilter{
+		string: fmt.Sprintf(notFormat, f.String()),
+		matcher: func(release terra.Release) bool {
+			return !f.Matches(release)
+		},
+	}
+}
+
 func (f releaseFilter) Filter(releases []terra.Release) []terra.Release {
 	var result []terra.Release
 	for _, release := range releases {

--- a/internal/thelma/state/api/terra/filter/release_filters.go
+++ b/internal/thelma/state/api/terra/filter/release_filters.go
@@ -11,6 +11,8 @@ type ReleaseFilters interface {
 	Any() terra.ReleaseFilter
 	// HasName returns a filter that matches releases with the given name(s)
 	HasName(releaseName ...string) terra.ReleaseFilter
+	// HasChartName returns a filter that matches releases with the given chart name(s)
+	HasChartName(releaseName ...string) terra.ReleaseFilter
 	// HasFullName returns a filter that matches release with the given full name(s)
 	HasFullName(releaseFullName ...string) terra.ReleaseFilter
 	// HasDestinationName returns a filter that matches releases with the given destination
@@ -48,6 +50,20 @@ func (r releaseFilters) HasName(releaseNames ...string) terra.ReleaseFilter {
 		matcher: func(r terra.Release) bool {
 			for _, name := range releaseNames {
 				if r.Name() == name {
+					return true
+				}
+			}
+			return false
+		},
+	}
+}
+
+func (r releaseFilters) HasChartName(chartNames ...string) terra.ReleaseFilter {
+	return releaseFilter{
+		string: fmt.Sprintf("hasChartName(%s)", join(quote(chartNames)...)),
+		matcher: func(r terra.Release) bool {
+			for _, name := range chartNames {
+				if r.ChartName() == name {
 					return true
 				}
 			}

--- a/internal/thelma/state/api/terra/filter/strings.go
+++ b/internal/thelma/state/api/terra/filter/strings.go
@@ -8,6 +8,7 @@ import (
 // this file constants and helpers for string representations of filters
 const andFormat = "and(%s)"
 const orFormat = "or(%s)"
+const notFormat = "not(%s)"
 const anyString = "any()"
 
 func quote(strings []string) []string {


### PR DESCRIPTION
This PR adds a new flag, `--changed-files-list=path/to/list.txt`, to the `thelma render` and `thelma charts publish` commands. A changed files list is file that contains a newline-separated list of files that have been changed by a PR. Example contents:
```
charts/leonardo/templates/deployment.yaml
helmfile.yaml
values/app/datarepo/live.yaml.gotmpl
```
Paths in the changed files list should be relative to the root of terra-helmfile.

In the case of `thelma charts publish`, the changed files list will be used to determine a list of charts that should be published from a given PR. In the case of `thelma render`, the changed files list will be used to determine the set of manifests that should be rendered.

### Logic

* Changes to `charts/<chartname>/*` or `values/(app|cluster)/<chartname>*` will trigger a publish of the affected chart
* Changes to `values/app/global*` will trigger a publish of all app release charts (releases that belong to an environment)
* Changes to `values/cluster/global*` will trigger a publish of all cluster release charts (releases that **do not** belong to an environment)
* Changes to `helmfile.yaml` will trigger a publish/render of all charts that have at least one chart release

### Testing

This PR includes unit tests.