### PR TITLE
[DDO-3139] Add new `--exit-zero-no-matching-releases` flag to `thelma render`

### DIFF
--- a/internal/thelma/cli/commands/render/render_command.go
+++ b/internal/thelma/cli/commands/render/render_command.go
@@ -210,6 +210,7 @@ func (cmd *renderCommand) Run(app app.ThelmaApp, _ cli.RunContext) error {
 	if len(cmd.renderOptions.Releases) == 0 {
 		if cmd.flagVals.exitZeroNoMatchingReleases {
 			log.Info().Msg("0 releases matched command-line arguments, nothing to render")
+			return nil
 		} else {
 			return errors.Errorf("0 releases matched command-line arguments, nothing to render")
 		}

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -217,28 +218,12 @@ func TestRenderArgParsing(t *testing.T) {
 			},
 		},
 		{
-			description: "--changed-files-list should set release name",
+			description: "no releases match command line arguments but --exit-zero-no-matching-releases is set",
 			setupFn: func(tc *testConfig) error {
 				changedFilesList := t.TempDir() + "/changed-files.txt"
-				require.NoError(t, os.WriteFile(changedFilesList, []byte("values/app/datarepo/live/alpha.yaml"), 0644))
+				require.NoError(t, os.WriteFile(changedFilesList, []byte(".an-irrelevant-change.txt"), 0644))
 
-				tc.options.SetArgs(Args("render --changed-files-list=%s", changedFilesList))
-				tc.expected.renderOptions.Scope = scope.Release
-				tc.expected.renderOptions.Releases = []terra.Release{
-					fixture.Release("datarepo", "alpha"),
-					fixture.Release("datarepo", "staging"),
-					fixture.Release("datarepo", "prod"),
-				}
-				return nil
-			},
-		},
-		{
-			description: "--changed-files-list should not return an error if no matching releases are found",
-			setupFn: func(tc *testConfig) error {
-				changedFilesList := t.TempDir() + "/changed-files.txt"
-				require.NoError(t, os.WriteFile(changedFilesList, []byte(".some-irrelevant-change.txt"), 0644))
-
-				tc.options.SetArgs(Args("render --changed-files-list=%s", changedFilesList))
+				tc.options.SetArgs(Args("render --changed-files-list=%s --exit-zero-no-matching-releases", changedFilesList))
 				tc.expected.renderOptions.Scope = scope.Release
 				tc.expected.renderOptions.Releases = []terra.Release{}
 				return nil
@@ -509,10 +494,6 @@ func TestRenderArgParsing(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			options := cli.DefaultOptions()
 
-			// Replace render's RunE with a noop function,
-			// We're just testing argument parsing, so only test pre-/post- run hooks here
-			options.SkipRun(true)
-
 			expected := &expectedAttrs{
 				renderOptions: &render.Options{},
 				helmfileArgs:  &helmfile.Args{},
@@ -552,9 +533,10 @@ func TestRenderArgParsing(t *testing.T) {
 			}
 
 			// execute the test parsing code
-			cmd := NewRenderCommand().(*renderCommand)
+			wrapper := newTestWrapper()
+			cmd := newRenderCommand(wrapper)
 			options.AddCommand("render", cmd)
-			err := cli.NewWithOptions(options).Execute()
+			err = cli.NewWithOptions(options).Execute()
 
 			// if error was expected, check it
 			if testCase.expectedError != nil {
@@ -602,4 +584,14 @@ func defaultReleases(fixture statefixtures.Fixture) []terra.Release {
 			filter.Destinations().IsEnvironmentMatching(filter.Environments().HasLifecycleName("static", "template"))),
 	)
 	return f.Filter(fixture.AllReleases())
+}
+
+func newTestWrapper() renderWrapper {
+	return &testWrapper{}
+}
+
+type testWrapper struct{}
+
+func (t *testWrapper) doRender(_ app.ThelmaApp, _ *render.Options, _ *helmfile.Args) error {
+	return nil
 }

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -233,6 +233,18 @@ func TestRenderArgParsing(t *testing.T) {
 			},
 		},
 		{
+			description: "--changed-files-list should not return an error if no matching releases are found",
+			setupFn: func(tc *testConfig) error {
+				changedFilesList := t.TempDir() + "/changed-files.txt"
+				require.NoError(t, os.WriteFile(changedFilesList, []byte(".some-irrelevant-change.txt"), 0644))
+
+				tc.options.SetArgs(Args("render --changed-files-list=%s", changedFilesList))
+				tc.expected.renderOptions.Scope = scope.Release
+				tc.expected.renderOptions.Releases = []terra.Release{}
+				return nil
+			},
+		},
+		{
 			description: "first positional should set release name",
 			setupFn: func(tc *testConfig) error {
 				tc.options.SetArgs(Args("render -r datarepo"))

--- a/internal/thelma/cli/commands/render/wrapper.go
+++ b/internal/thelma/cli/commands/render/wrapper.go
@@ -1,0 +1,24 @@
+package render
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app"
+	"github.com/broadinstitute/thelma/internal/thelma/render"
+	"github.com/broadinstitute/thelma/internal/thelma/render/helmfile"
+)
+
+// renderWrapper a simple wrapper around render.DoRender that allows to intercept calls for tests
+// if I rewrote this code today the render package would have a mockable interface but this is a quick fix
+type renderWrapper interface {
+	// doRender Delegates to render.DoRender
+	doRender(app app.ThelmaApp, globalOptions *render.Options, helmfileArgs *helmfile.Args) error
+}
+
+func newRenderWrapper() renderWrapper {
+	return realWrapper{}
+}
+
+type realWrapper struct{}
+
+func (r realWrapper) doRender(app app.ThelmaApp, globalOptions *render.Options, helmfileArgs *helmfile.Args) error {
+	return render.DoRender(app, globalOptions, helmfileArgs)
+}


### PR DESCRIPTION
Add new `--exit-zero-no-matching-releases` option to `thelma render`.

### Why?

This is a follow-up to #159. By default, `thelma render` exits with an error if no Sherlock releases match its command-line arguments. This is good default behavior -- it's clear for users, and it's a backstop that prevents ArgoCD from deleting resources in the event of a misconfiguration. However, this is not the behavior we want on a terra-helmfile pull request -- if the PR doesn't update any chart or values files, `thelma render` should simply render nothing and exit instead of returning an error.

### Testing

This PR includes unit tests. I also tested manually locally:
```
$ ./output/bin/thelma render --changed-files-list=/tmp/empty.txt
09:50 ERR error="0 releases matched command-line arguments, nothing to render"

$ echo $?
1

$ ./output/bin/thelma render --changed-files-list=/tmp/empty.txt --exit-zero-no-matching-releases
09:50 INF 0 releases matched command-line arguments, nothing to render

$ echo $?
0
```

### Related

* https://github.com/broadinstitute/terra-helmfile/pull/4624