### PR TITLE
Rename Metric Cluster Label to Target Cluster

### DIFF
--- a/internal/thelma/app/metrics/labels/labels.go
+++ b/internal/thelma/app/metrics/labels/labels.go
@@ -41,12 +41,12 @@ func ForReleaseOrDestination(value interface{}, extra ...map[string]string) map[
 //	{
 //	  "release": "leonardo",
 //	  "env": "dev",
-//	  "cluster": "terra-dev",
+//	  "target_cluster": "terra-dev",
 //	}
 func ForRelease(release terra.Release) map[string]string {
 	labels := make(map[string]string)
 	labels["release"] = release.Name()
-	labels["cluster"] = release.Cluster().Name()
+	labels["target_cluster"] = release.Cluster().Name()
 	if release.Destination().IsEnvironment() {
 		labels["env"] = release.Destination().Name()
 	} else {
@@ -60,22 +60,22 @@ func ForRelease(release terra.Release) map[string]string {
 //
 //	{
 //	  "env": "dev",
-//	  "cluster": "",
+//	  "target_cluster": "",
 //	}
 //
 // For the terra-dev-cluster:
 //
 //	{
 //	  "env": "",
-//	  "cluster": "terra-dev",
+//	  "target_cluster": "terra-dev",
 //	}
 func ForDestination(dest terra.Destination) map[string]string {
 	labels := make(map[string]string)
 	if dest.IsCluster() {
-		labels["cluster"] = dest.Name()
+		labels["target_cluster"] = dest.Name()
 		labels["env"] = ""
 	} else if dest.IsEnvironment() {
-		labels["cluster"] = ""
+		labels["target_cluster"] = ""
 		labels["env"] = dest.Name()
 	}
 	return labels

--- a/internal/thelma/app/metrics/labels/labels_test.go
+++ b/internal/thelma/app/metrics/labels/labels_test.go
@@ -1,9 +1,10 @@
 package labels
 
 import (
+	"testing"
+
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_ForReleaseDestination(t *testing.T) {
@@ -29,63 +30,63 @@ func Test_ForReleaseDestination(t *testing.T) {
 
 	t.Run("for destination: dev env", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"env":     "dev",
-			"cluster": "",
+			"env":            "dev",
+			"target_cluster": "",
 		}, ForDestination(devEnv))
 	})
 
 	t.Run("for destination: dev cluster", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"env":     "",
-			"cluster": "terra-dev",
+			"env":            "",
+			"target_cluster": "terra-dev",
 		}, ForDestination(devCluster))
 	})
 
 	t.Run("for release: leo dev", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"release": "leonardo",
-			"env":     "dev",
-			"cluster": "terra-dev",
+			"release":        "leonardo",
+			"env":            "dev",
+			"target_cluster": "terra-dev",
 		}, ForRelease(leoDev))
 	})
 
 	t.Run("for release: yale dev cluster", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"release": "yale",
-			"env":     "",
-			"cluster": "terra-dev",
+			"release":        "yale",
+			"env":            "",
+			"target_cluster": "terra-dev",
 		}, ForRelease(yaleDev))
 	})
 
 	t.Run("for release or destination: dev env", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"release": "",
-			"env":     "dev",
-			"cluster": "",
+			"release":        "",
+			"env":            "dev",
+			"target_cluster": "",
 		}, ForReleaseOrDestination(devEnv))
 	})
 
 	t.Run("for release or destination: dev cluster", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"release": "",
-			"env":     "",
-			"cluster": "terra-dev",
+			"release":        "",
+			"env":            "",
+			"target_cluster": "terra-dev",
 		}, ForReleaseOrDestination(devCluster))
 	})
 
 	t.Run("for release or destination: leonardo dev", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"release": "leonardo",
-			"env":     "dev",
-			"cluster": "terra-dev",
+			"release":        "leonardo",
+			"env":            "dev",
+			"target_cluster": "terra-dev",
 		}, ForReleaseOrDestination(leoDev))
 	})
 
 	t.Run("for release or destination: yale terra-dev", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"release": "yale",
-			"env":     "",
-			"cluster": "terra-dev",
+			"release":        "yale",
+			"env":            "",
+			"target_cluster": "terra-dev",
 		}, ForReleaseOrDestination(yaleDev))
 	})
 }


### PR DESCRIPTION
Previously Thelma was using the metric label `cluster` to report which cluster an operation was performed against. However this value was being overwritten by Thanos reporting which cluster the prometheus push gateway resides in..

This PR changes the label used by thelma to `target_cluster` so that this info will be preserved.