### PR TITLE
[DDO-3176] Clean up noisy warning

### DIFF
--- a/internal/thelma/ops/status/reporter.go
+++ b/internal/thelma/ops/status/reporter.go
@@ -90,7 +90,7 @@ func (r *reporter) buildUnhealthyResourceList(appStatus argocd.ApplicationStatus
 
 	_eventMatcher, err := r.buildEventMatcher(release)
 	if err != nil {
-		log.Warn().Err(err).Msgf("failed to load events from Kubernetes API for %s; disabling rich status reports", release.FullName())
+		log.Debug().Err(err).Msgf("failed to load events from Kubernetes API for %s; disabling rich status reports", release.FullName())
 		return unhealthyResources
 	}
 


### PR DESCRIPTION
The ignoreable "disabling rich status reports" warning adds a ton of noise to sync-release logs for live environments. It would be great to figure out a solution to connecting to the live clusters from GHA some day, but in the mean time let's address the noise.

<img width="1055" alt="Screenshot 2023-09-27 at 4 25 52 PM" src="https://github.com/broadinstitute/thelma/assets/60902147/50f90766-4534-4d8d-8b6d-889b2aebe5a0">
