### PR TITLE
[DDO-3177] Bump default number of argo apps Thelma syncs in parallel

### DIFF
--- a/internal/thelma/cli/commands/argocd/sync/sync_command.go
+++ b/internal/thelma/cli/commands/argocd/sync/sync_command.go
@@ -35,7 +35,7 @@ func (cmd *syncCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 	// Release selector flags -- these flags determine which Argo apps will be synced
 	cmd.selector.AddFlags(cobraCommand)
 
-	cobraCommand.Flags().IntVarP(&cmd.options.maxParallel, "max-parallel", "p", 15, "Max number of ArgoCD apps to sync simultaneously")
+	cobraCommand.Flags().IntVarP(&cmd.options.maxParallel, "max-parallel", "p", 30, "Max number of ArgoCD apps to sync simultaneously")
 	cobraCommand.Flags().BoolVar(&cmd.options.refreshOnly, "refresh-only", false, "If set, only hard-refresh ArgoCD instead of also syncing it")
 }
 


### PR DESCRIPTION
Gary and I noticed queueing during today's staging promotion, which slows down the release process. I think I originally picked the number 15 based on "number of services we currently have in Terra prod". This PR doubles to 30, we can always reduce if ArgoCD starts to fall over.