### PR TITLE
[DDO-3212] Supply AppVersion to cluster release charts

### DIFF
--- a/internal/thelma/cli/commands/bee/common/pinflags/pinflags.go
+++ b/internal/thelma/cli/commands/bee/common/pinflags/pinflags.go
@@ -122,7 +122,7 @@ func (p *pinFlags) loadReleaseOverridesFromEnv(thelmaApp app.ThelmaApp) (map[str
 	for _, release := range env.Releases() {
 		var appVersion string
 		if release.IsAppRelease() {
-			appVersion = release.(terra.AppRelease).AppVersion()
+			appVersion = release.AppVersion()
 		}
 		override := terra.VersionOverride{
 			AppVersion:          appVersion,

--- a/internal/thelma/cli/commands/bee/common/views/bee.go
+++ b/internal/thelma/cli/commands/bee/common/views/bee.go
@@ -74,7 +74,7 @@ func DescribeBeeEnv(bee terra.Environment, opts ...DescribeOption) BeeDetail {
 
 		if !options.OmitVersions {
 			if release.IsAppRelease() {
-				details.AppVersion = release.(terra.AppRelease).AppVersion()
+				details.AppVersion = release.AppVersion()
 			}
 			details.ChartVersion = release.ChartVersion()
 		}

--- a/internal/thelma/cli/commands/render/render_command.go
+++ b/internal/thelma/cli/commands/render/render_command.go
@@ -382,12 +382,6 @@ func (cmd *renderCommand) checkIncompatibleFlags(flags *pflag.FlagSet, selection
 		}
 	}
 
-	if !selection.AppReleasesOnly {
-		if flags.Changed(flagNames.appVersion) {
-			return errors.Errorf("--%s cannot be used for cluster releases", flagNames.appVersion)
-		}
-	}
-
 	if flags.Changed(flagNames.argocd) {
 		if flags.Changed(flagNames.chartDir) || flags.Changed(flagNames.chartVersion) || flags.Changed(flagNames.appVersion) || flags.Changed(flagNames.valuesFile) {
 			return errors.Errorf("--%s cannot be used with --%s, --%s, --%s, or --%s", flagNames.argocd, flagNames.chartDir, flagNames.chartVersion, flagNames.appVersion, flagNames.valuesFile)

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -179,11 +179,6 @@ func TestRenderArgParsing(t *testing.T) {
 			expectedError: regexp.MustCompile("--parallel-workers cannot be used with --stdout"),
 		},
 		{
-			description:   "--cluster and --app-version incompatible",
-			arguments:     Args("render --cluster terra-perf -r yale --app-version=0.0.1"),
-			expectedError: regexp.MustCompile("--app-version cannot be used for cluster releases"),
-		},
-		{
 			description:   "--exact-release ALL invalid",
 			arguments:     Args("render --exact-release ALL"),
 			expectedError: regexp.MustCompile("--exact-release cannot be used with ALL"),
@@ -347,6 +342,19 @@ func TestRenderArgParsing(t *testing.T) {
 				tc.expected.renderOptions.Scope = scope.Release
 				tc.expected.renderOptions.Releases = []terra.Release{
 					fixture.Release("leonardo", "dev"),
+				}
+				tc.expected.helmfileArgs.AppVersion = &version
+				return nil
+			},
+		},
+		{
+			description: "--app-version should set app version for cluster releases",
+			arguments:   Args("render -c terra-dev -r yale --app-version 10.20.30"),
+			setupFn: func(tc *testConfig) error {
+				version := "10.20.30"
+				tc.expected.renderOptions.Scope = scope.Release
+				tc.expected.renderOptions.Releases = []terra.Release{
+					fixture.Release("yale", "terra-dev"),
 				}
 				tc.expected.helmfileArgs.AppVersion = &version
 				return nil

--- a/internal/thelma/render/helmfile/helmfile.go
+++ b/internal/thelma/render/helmfile/helmfile.go
@@ -253,10 +253,8 @@ func (r *ConfigRepo) renderApplicationManifests(release terra.Release, args *Arg
 
 	logEvent := log.Info().
 		Str("chartVersion", resolvedChart.Version()).
-		Str("chartSource", resolvedChart.SourceDescription())
-	if release.IsAppRelease() {
-		logEvent.Str("appVersion", stateValues.Release.AppVersion)
-	}
+		Str("chartSource", resolvedChart.SourceDescription()).
+		Str("appVersion", stateValues.Release.AppVersion)
 	logEvent.Msgf("Rendering %s in %s", release.Name(), release.Destination().Name())
 
 	return r.runHelmfile(cmd)
@@ -378,14 +376,10 @@ func writeTemporaryValuesFile(values interface{}, filename string) error {
 
 // Override app version in state values if it was set on the command line with --app-version
 func overrideAppVersionIfNeeded(release terra.Release, args *Args, stateValues stateval.AppValues) stateval.AppValues {
-	if release.Type() == terra.AppReleaseType {
-		if args.AppVersion != nil {
-			originalVersion := stateValues.Release.AppVersion
-			log.Debug().Msgf("Overriding default app version %s for release %s with %s", originalVersion, release.Name(), *args.AppVersion)
-			stateValues.Release.AppVersion = *args.AppVersion
-		}
-	} else if args.AppVersion != nil {
-		log.Warn().Msgf("Ignoring --app-version %s; --app-version is not supported for cluster releases", *args.AppVersion)
+	if args.AppVersion != nil {
+		originalVersion := stateValues.Release.AppVersion
+		log.Debug().Msgf("Overriding default app version %s for release %s with %s", originalVersion, release.Name(), *args.AppVersion)
+		stateValues.Release.AppVersion = *args.AppVersion
 	}
 
 	return stateValues

--- a/internal/thelma/render/helmfile/stateval/release.go
+++ b/internal/thelma/render/helmfile/stateval/release.go
@@ -19,18 +19,12 @@ type Release struct {
 }
 
 func forRelease(release terra.Release) Release {
-	// app version is omitted for cluster releases
-	var appVersion string
-	if release.IsAppRelease() {
-		appVersion = release.(terra.AppRelease).AppVersion()
-	}
-
 	return Release{
 		Name:       release.Name(),
 		ChartName:  release.ChartName(),
 		Type:       release.Type().String(),
 		Namespace:  release.Namespace(),
-		AppVersion: appVersion,
+		AppVersion: release.AppVersion(),
 		Overlays:   release.HelmfileOverlays(),
 	}
 }

--- a/internal/thelma/state/api/terra/app_release.go
+++ b/internal/thelma/state/api/terra/app_release.go
@@ -1,7 +1,6 @@
 package terra
 
 type AppRelease interface {
-	AppVersion() string
 	Environment() Environment
 	// Subdomain returns the slug that this AppRelease uses inside its Environment. Defaults to chart Release.Name.
 	// E.g. "leonardo"

--- a/internal/thelma/state/api/terra/mocks/cluster_release.go
+++ b/internal/thelma/state/api/terra/mocks/cluster_release.go
@@ -20,6 +20,47 @@ func (_m *ClusterRelease) EXPECT() *ClusterRelease_Expecter {
 	return &ClusterRelease_Expecter{mock: &_m.Mock}
 }
 
+// AppVersion provides a mock function with given fields:
+func (_m *ClusterRelease) AppVersion() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// ClusterRelease_AppVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AppVersion'
+type ClusterRelease_AppVersion_Call struct {
+	*mock.Call
+}
+
+// AppVersion is a helper method to define mock.On call
+func (_e *ClusterRelease_Expecter) AppVersion() *ClusterRelease_AppVersion_Call {
+	return &ClusterRelease_AppVersion_Call{Call: _e.mock.On("AppVersion")}
+}
+
+func (_c *ClusterRelease_AppVersion_Call) Run(run func()) *ClusterRelease_AppVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ClusterRelease_AppVersion_Call) Return(_a0 string) *ClusterRelease_AppVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ClusterRelease_AppVersion_Call) RunAndReturn(run func() string) *ClusterRelease_AppVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ChartName provides a mock function with given fields:
 func (_m *ClusterRelease) ChartName() string {
 	ret := _m.Called()

--- a/internal/thelma/state/api/terra/mocks/release.go
+++ b/internal/thelma/state/api/terra/mocks/release.go
@@ -20,6 +20,47 @@ func (_m *Release) EXPECT() *Release_Expecter {
 	return &Release_Expecter{mock: &_m.Mock}
 }
 
+// AppVersion provides a mock function with given fields:
+func (_m *Release) AppVersion() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// Release_AppVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AppVersion'
+type Release_AppVersion_Call struct {
+	*mock.Call
+}
+
+// AppVersion is a helper method to define mock.On call
+func (_e *Release_Expecter) AppVersion() *Release_AppVersion_Call {
+	return &Release_AppVersion_Call{Call: _e.mock.On("AppVersion")}
+}
+
+func (_c *Release_AppVersion_Call) Run(run func()) *Release_AppVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Release_AppVersion_Call) Return(_a0 string) *Release_AppVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Release_AppVersion_Call) RunAndReturn(run func() string) *Release_AppVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ChartName provides a mock function with given fields:
 func (_m *Release) ChartName() string {
 	ret := _m.Called()

--- a/internal/thelma/state/api/terra/release.go
+++ b/internal/thelma/state/api/terra/release.go
@@ -18,4 +18,5 @@ type Release interface {
 	TerraHelmfileRef() string
 	FirecloudDevelopRef() string
 	HelmfileOverlays() []string
+	AppVersion() string
 }

--- a/internal/thelma/state/providers/sherlock/app_release.go
+++ b/internal/thelma/state/providers/sherlock/app_release.go
@@ -8,15 +8,10 @@ import (
 )
 
 type appRelease struct {
-	appVersion string
-	subdomain  string
-	protocol   string
-	port       int
+	subdomain string
+	protocol  string
+	port      int
 	release
-}
-
-func (r *appRelease) AppVersion() string {
-	return r.appVersion
 }
 
 func (r *appRelease) Environment() terra.Environment {

--- a/internal/thelma/state/providers/sherlock/release.go
+++ b/internal/thelma/state/providers/sherlock/release.go
@@ -20,6 +20,7 @@ type release struct {
 	helmfileRef         string
 	firecloudDevelopRef string
 	helmfileOverlays    []string
+	appVersion          string
 }
 
 // FullName provides the entire name of the chart release, globally unique as enforced by Sherlock. Name provides
@@ -92,4 +93,8 @@ func (r *release) FirecloudDevelopRef() string {
 
 func (r *release) HelmfileOverlays() []string {
 	return r.helmfileOverlays
+}
+
+func (r *release) AppVersion() string {
+	return r.appVersion
 }

--- a/internal/thelma/state/providers/sherlock/state_loader.go
+++ b/internal/thelma/state/providers/sherlock/state_loader.go
@@ -147,6 +147,7 @@ retry:
 						destination:         _clusters[stateRelease.Cluster],
 						helmfileRef:         *stateRelease.HelmfileRef,
 						firecloudDevelopRef: stateRelease.FirecloudDevelopRef,
+						appVersion:          stateRelease.AppVersionExact,
 					},
 				}
 			case "environment":
@@ -155,10 +156,9 @@ retry:
 					helmfileOverlays = []string{"offline"}
 				}
 				_environments[stateRelease.Environment].releases[stateRelease.Name] = &appRelease{
-					appVersion: stateRelease.AppVersionExact,
-					subdomain:  stateRelease.Subdomain,
-					protocol:   stateRelease.Protocol,
-					port:       int(stateRelease.Port),
+					subdomain: stateRelease.Subdomain,
+					protocol:  stateRelease.Protocol,
+					port:      int(stateRelease.Port),
 					release: release{
 						name:                stateRelease.Name,
 						enabled:             true,
@@ -172,6 +172,7 @@ retry:
 						helmfileRef:         *stateRelease.HelmfileRef,
 						firecloudDevelopRef: stateRelease.FirecloudDevelopRef,
 						helmfileOverlays:    helmfileOverlays,
+						appVersion:          stateRelease.AppVersionExact,
 					},
 				}
 			default:

--- a/internal/thelma/state/providers/sherlock/state_loader_test.go
+++ b/internal/thelma/state/providers/sherlock/state_loader_test.go
@@ -60,6 +60,7 @@ func (suite *sherlockStateLoaderSuite) TestStateLoading() {
 	suite.Assert().NoError(err)
 	prodClusterReleases := prodCluster.Releases()
 	suite.Assert().Equal("sam-prod", prodClusterReleases[0].Name())
+	suite.Assert().Equal("12.13.14", prodClusterReleases[0].AppVersion())
 
 	onlineBeeEnv, err := _environments.Get("bee-online")
 	suite.Assert().NoError(err)
@@ -227,7 +228,7 @@ func setStateExpectations(mock *mocks.StateReadWriter) {
 			sherlock.Release{
 				&models.V2controllersChartRelease{
 					DestinationType:   "cluster",
-					AppVersionExact:   "1.0.0",
+					AppVersionExact:   "12.13.14",
 					Chart:             "sam",
 					ChartVersionExact: "0.42.0",
 					Cluster:           "terra-prod",

--- a/internal/thelma/state/testing/statefixtures/builder.go
+++ b/internal/thelma/state/testing/statefixtures/builder.go
@@ -164,6 +164,7 @@ func (b *builder) addAppReleaseToSet(r Release) {
 
 func (b *builder) addClusterReleaseToSet(r Release) {
 	release := &statemocks.ClusterRelease{}
+	release.EXPECT().AppVersion().Return(r.AppVersion)
 	release.EXPECT().ChartName().Return(r.Chart)
 	release.EXPECT().ChartVersion().Return(r.ChartVersion)
 	release.EXPECT().Cluster().Return(b.clusterSet[r.Cluster])

--- a/internal/thelma/state/testing/statefixtures/fixtures/default.yaml
+++ b/internal/thelma/state/testing/statefixtures/fixtures/default.yaml
@@ -345,7 +345,7 @@ releases:
       cluster: terra-staging
       namespace: yale
       environment: ""
-      appversion: ""
+      appversion: 1.2.3
       chartversion: 0.6.0
     - fullname: diskmanager-terra-dev
       repo: terra-helm

--- a/internal/thelma/state/testing/statefixtures/tests/statefixtures_test.go
+++ b/internal/thelma/state/testing/statefixtures/tests/statefixtures_test.go
@@ -158,7 +158,7 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 		rf.HasDestinationName("dev"),
 	))
 	require.NoError(t, err)
-	assert.Equal(t, "2d309b1645a0", devSam[0].(terra.AppRelease).AppVersion())
+	assert.Equal(t, "2d309b1645a0", devSam[0].AppVersion())
 	assert.Equal(t, "0.34.0", devSam[0].ChartVersion())
 
 	prodSam, err := state.Releases().Filter(rf.And(
@@ -166,7 +166,7 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 		rf.HasDestinationName("prod"),
 	))
 	require.NoError(t, err)
-	assert.Equal(t, "8f69c32bd9fe", prodSam[0].(terra.AppRelease).AppVersion())
+	assert.Equal(t, "8f69c32bd9fe", prodSam[0].AppVersion())
 	assert.Equal(t, "0.33.0", prodSam[0].ChartVersion())
 
 	chipmunkSam, err := state.Releases().Filter(rf.And(
@@ -174,7 +174,7 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 		rf.HasDestinationName("fiab-funky-chipmunk"),
 	))
 	require.NoError(t, err)
-	assert.Equal(t, "2d309b1645a0", chipmunkSam[0].(terra.AppRelease).AppVersion())
+	assert.Equal(t, "2d309b1645a0", chipmunkSam[0].AppVersion())
 	assert.Equal(t, "0.34.0", chipmunkSam[0].ChartVersion())
 
 	walrusSam, err := state.Releases().Filter(rf.And(
@@ -182,7 +182,7 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 		rf.HasDestinationName("fiab-nerdy-walrus"),
 	))
 	require.NoError(t, err)
-	assert.Equal(t, "1.2.3", walrusSam[0].(terra.AppRelease).AppVersion())
+	assert.Equal(t, "1.2.3", walrusSam[0].AppVersion())
 	assert.Equal(t, "0.34.0", walrusSam[0].ChartVersion())
 
 	snowflakeSam, err := state.Releases().Filter(rf.And(
@@ -197,7 +197,7 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 		rf.HasDestinationName("fiab-special-snowflake"),
 	))
 	require.NoError(t, err)
-	assert.Equal(t, "cead2f9206b5", snowflakeRawls[0].(terra.AppRelease).AppVersion())
+	assert.Equal(t, "cead2f9206b5", snowflakeRawls[0].AppVersion())
 	assert.Equal(t, "100.200.300", snowflakeRawls[0].ChartVersion())
 	assert.Equal(t, "my-terra-helmfile-branch", snowflakeRawls[0].TerraHelmfileRef())
 	assert.Equal(t, "", snowflakeRawls[0].FirecloudDevelopRef())


### PR DESCRIPTION
This PR adds support for passing app versions from Sherlock to charts for "cluster releases" (releases like Yale that do not belong to a Terra environment). We already do this for application charts; deploying services like Yale, Sherlock, and Beehive has been a huge pain because we can't leverage the same feature.

### Changes

* Make `AppVersion` an attribute of the `terra.Release` interface instead of `terra.AppRelease`
  * Regenerate mocks and update references to the above
  * Update Sherlock state provider to match new interface
  * Update Sherlock state loader to include AppVersion on charts loaded from Sherlock
* Update `helmfile` package to include AppVersion in state values for cluster releases
* Remove validation on render command that ensures `--app-version` is not set for `--cluster-releases`

### Testing

I tested against this terra-helmfile PR and rendering with
```
thelma render yale -c terra-dev --app-version=10.20.30
```
and verified that the container image was set correctly.