### PR TITLE
[DDO-3239] Tell ArgoCD to allow environments across multiple namespaces

### DIFF
--- a/internal/thelma/render/helmfile/argocd/argocd_test.go
+++ b/internal/thelma/render/helmfile/argocd/argocd_test.go
@@ -1,9 +1,128 @@
 package argocd
 
 import (
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestWriteDestinationValuesFile(t *testing.T) {
 	t.Skip("TODO")
+}
+
+func Test_argoDestinationsForEnvironment(t *testing.T) {
+	tests := []struct {
+		name                      string
+		releaseMockConfigurations []func(m *mocks.AppRelease)
+		want                      []ArgoDestination
+	}{
+		{
+			name: "simple case",
+			releaseMockConfigurations: []func(m *mocks.AppRelease){
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace").Once()
+				},
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace").Once()
+				},
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace").Once()
+				},
+			},
+			want: []ArgoDestination{
+				{
+					Server:    "192.168.3.4",
+					Namespace: "namespace",
+				},
+			},
+		},
+		{
+			name: "multi cluster",
+			releaseMockConfigurations: []func(m *mocks.AppRelease){
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace").Once()
+				},
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.5").Once()
+					m.EXPECT().Namespace().Return("namespace").Once()
+				},
+			},
+			want: []ArgoDestination{
+				{
+					Server:    "192.168.3.4",
+					Namespace: "namespace",
+				},
+				{
+					Server:    "192.168.3.5",
+					Namespace: "namespace",
+				},
+			},
+		},
+		{
+			name: "multi namespace",
+			releaseMockConfigurations: []func(m *mocks.AppRelease){
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace-1").Once()
+				},
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace-2").Once()
+				},
+			},
+			want: []ArgoDestination{
+				{
+					Server:    "192.168.3.4",
+					Namespace: "namespace-1",
+				},
+				{
+					Server:    "192.168.3.4",
+					Namespace: "namespace-2",
+				},
+			},
+		},
+		{
+			name: "multi namespace and multi cluster",
+			releaseMockConfigurations: []func(m *mocks.AppRelease){
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.4").Once()
+					m.EXPECT().Namespace().Return("namespace-1").Once()
+				},
+				func(m *mocks.AppRelease) {
+					m.EXPECT().ClusterAddress().Return("192.168.3.5").Once()
+					m.EXPECT().Namespace().Return("namespace-2").Once()
+				},
+			},
+			want: []ArgoDestination{
+				{
+					Server:    "192.168.3.4",
+					Namespace: "namespace-1",
+				},
+				{
+					Server:    "192.168.3.5",
+					Namespace: "namespace-2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mockReleases []terra.Release
+			for _, configFn := range tt.releaseMockConfigurations {
+				mockRelease := mocks.NewAppRelease(t)
+				configFn(mockRelease)
+				mockReleases = append(mockReleases, mockRelease)
+			}
+			mockEnvironment := mocks.NewEnvironment(t)
+			mockEnvironment.EXPECT().Releases().Return(mockReleases).Once()
+			if got := argoDestinationsForEnvironment(mockEnvironment); !assert.ElementsMatch(t, got, tt.want) {
+				t.Errorf("argoDestinationsForEnvironment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Check out the original implementation of argoDestinationsForEnvironment and you'll notice that it handles environments existing across multiple clusters -- it reads cluster addresses out of the releases themselves -- but [it ignores the namespace of those releases and assumes it'll match that of the environment](https://github.com/broadinstitute/thelma/blob/main/internal/thelma/render/helmfile/argocd/argocd.go#L72).

Fair assumption... one that I'm now breaking. [datarepo-dev](https://beehive.dsp-devops.broadinstitute.org/clusters/datarepo-dev/chart-releases/dev/datarepo) exists in the dev environment, but in the `dev` namespace, not `terra-dev`.

Luckily, I guess, I didn't know about that assumption when I built the corresponding parts of Sherlock and Beehive, so the rest of our platform already stores and handles namespace on a per-chart-release basis. This ended up being convenient to fill out Thelma's state, too, _[so Thelma's own state already has per-chart-release namespaces in it!](https://github.com/broadinstitute/thelma/blob/main/internal/thelma/state/providers/sherlock/state_loader.go#L169)_ 

This PR just collects both addresses and namespaces out of the release, rather than just the address.

## Testing

I added tests for this function relying on mocked state. :party_blob:

I also went and rendered out some stuff locally, including dev and prod, to verify both my changes to fix the issue and that other things didn't change.

## Risk

Low due to the testing. If there are unexpected diffs in the terra-app-generator, can revert before the auto-sync overnight.