### PR TITLE
[DDO-3303] Parallelize BEE Seeding

### DIFF
--- a/internal/thelma/bee/seed/seed_step_4_register_test_users.go
+++ b/internal/thelma/bee/seed/seed_step_4_register_test_users.go
@@ -1,7 +1,10 @@
 package seed
 
 import (
+	"github.com/broadinstitute/thelma/internal/thelma/clients/google"
+	"github.com/broadinstitute/thelma/internal/thelma/clients/google/terraapi"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/pool"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -23,33 +26,61 @@ func (s *seeder) seedStep4RegisterTestUsers(appReleases map[string]terra.AppRele
 				return errors.Errorf("suffix %s of project %s maps to no test users", sam.Cluster().ProjectSuffix(), sam.Cluster().Project())
 			}
 
-			googleClient, err := s.googleAuthAs(orch)
-			if err != nil {
-				return err
+			var jobs []pool.Job
+			for _, unsafe := range users {
+				user := unsafe
+				jobs = append(jobs, pool.Job{
+					Name: user.Email,
+					Run: func(reporter pool.StatusReporter) error {
+						var err error
+						reporter.Update(pool.Status{
+							Message: "Authenticating",
+						})
+						var googleClient google.Clients
+						googleClient, err = s.googleAuthAs(orch)
+						if err = opts.handleErrorWithForce(err); err != nil {
+							return err
+						}
+						var terraClient terraapi.TerraClient
+						terraClient, err = googleClient.SetSubject(user.Email).Terra()
+						if err = opts.handleErrorWithForce(err); err != nil {
+							return err
+						}
+						terraClient.SetPoolStatusReporter(reporter)
+						reporter.Update(pool.Status{
+							Message: "Registering",
+						})
+						_, _, err = terraClient.FirecloudOrch(orch).RegisterProfile(
+							user.FirstName, user.LastName, user.Role, user.Email,
+							"Hogwarts", "dsde",
+							"Cambridge", "MA", "USA",
+							"Remus Lupin", "Non-Profit")
+						if err = opts.handleErrorWithForce(err); err != nil {
+							return err
+						}
+						reporter.Update(pool.Status{
+							Message: "Approving TOS",
+						})
+						_, _, err = terraClient.Sam(sam).AcceptToS()
+						if err = opts.handleErrorWithForce(err); err != nil {
+							return err
+						}
+						reporter.Update(pool.Status{
+							Message: "Registered",
+						})
+						return nil
+					},
+				})
 			}
 
-			for index, user := range users {
-				log.Info().Msgf("User %d - %s - registering", index+1, user.Email)
-				terraClient, err := googleClient.SetSubject(user.Email).Terra()
-				if err != nil {
-					if opts.handleErrorWithForce(err) != nil {
-						return err
-					}
-					continue
-				}
-				_, _, err = terraClient.FirecloudOrch(orch).RegisterProfile(
-					user.FirstName, user.LastName, user.Role, user.Email,
-					"Hogwarts", "dsde",
-					"Cambridge", "MA", "USA",
-					"Remus Lupin", "Non-Profit")
-				if err = opts.handleErrorWithForce(err); err != nil {
-					return err
-				}
-				log.Info().Msgf("User %d - %s - approving Terms of Service", index+1, user.Email)
-				_, _, err = terraClient.Sam(sam).AcceptToS()
-				if err = opts.handleErrorWithForce(err); err != nil {
-					return err
-				}
+			err = pool.New(jobs, func(o *pool.Options) {
+				o.NumWorkers = opts.RegistrationParallelism
+				o.Summarizer.Enabled = true
+				o.Metrics.Enabled = false
+				o.StopProcessingOnError = !opts.Force
+			}).Execute()
+			if err = opts.handleErrorWithForce(err); err != nil {
+				return err
 			}
 		} else {
 			log.Info().Msg("Sam not present in environment, skipping all")

--- a/internal/thelma/bee/seed/seeder.go
+++ b/internal/thelma/bee/seed/seeder.go
@@ -10,8 +10,9 @@ import (
 )
 
 type commonOptions struct {
-	Force   bool
-	NoSteps bool
+	Force                   bool
+	NoSteps                 bool
+	RegistrationParallelism int
 }
 
 type SeedOptions struct {

--- a/internal/thelma/cli/commands/bee/common/seedflags/seedflags.go
+++ b/internal/thelma/cli/commands/bee/common/seedflags/seedflags.go
@@ -40,6 +40,7 @@ var flagNames = struct {
 	step6ExtraUser           string
 	noSteps                  string
 	registerSelfShortcut     string
+	registrationParallelism  string
 }{
 	force:                    "force",
 	step1CreateElasticsearch: "step-1-create-elasticsearch",
@@ -50,6 +51,7 @@ var flagNames = struct {
 	step6ExtraUser:           "step-6-extra-user",
 	noSteps:                  "no-steps",
 	registerSelfShortcut:     "me",
+	registrationParallelism:  "registration-parallelism",
 }
 
 type seedFlags struct {
@@ -84,6 +86,9 @@ func (s *seedFlags) AddFlags(cobraCommand *cobra.Command) {
 
 	cobraCommand.Flags().BoolVar(&s.seedOptions.RegisterSelfShortcut, s.withPrefix(flagNames.registerSelfShortcut), false, "shorthand for --step-6-extra-user use-adc")
 	s.maybeHide(cobraCommand, flagNames.registerSelfShortcut)
+
+	cobraCommand.Flags().IntVar(&s.seedOptions.RegistrationParallelism, s.withPrefix(flagNames.registrationParallelism), 20, "how many users/SAs should be registered/unregistered at once")
+	s.maybeHide(cobraCommand, flagNames.registrationParallelism)
 
 	s.addShorthand(cobraCommand, flagNames.force, "f")
 	s.addShorthand(cobraCommand, flagNames.step6ExtraUser, "u")

--- a/internal/thelma/cli/commands/bee/common/unseedflags/unseedflags.go
+++ b/internal/thelma/cli/commands/bee/common/unseedflags/unseedflags.go
@@ -34,10 +34,12 @@ var flagNames = struct {
 	force                   string
 	step1UnregisterAllUsers string
 	noSteps                 string
+	registrationParallelism string
 }{
 	force:                   "force",
 	step1UnregisterAllUsers: "step-1-unregister-all-users",
 	noSteps:                 "no-steps",
+	registrationParallelism: "registration-parallelism",
 }
 
 type unseedFlags struct {
@@ -54,6 +56,9 @@ func (s *unseedFlags) AddFlags(cobraCommand *cobra.Command) {
 
 	cobraCommand.Flags().BoolVar(&s.unseedOptions.NoSteps, s.withPrefix(flagNames.noSteps), false, "convenience flag to skip all unspecified steps, which would otherwise run by default")
 	s.maybeHide(cobraCommand, flagNames.noSteps)
+
+	cobraCommand.Flags().IntVar(&s.unseedOptions.RegistrationParallelism, s.withPrefix(flagNames.registrationParallelism), 20, "how many users/SAs should be registered/unregistered at once")
+	s.maybeHide(cobraCommand, flagNames.registrationParallelism)
 
 	s.addShorthand(cobraCommand, flagNames.force, "f")
 }


### PR DESCRIPTION
**I'm calling this a five-minute speed up**

1. Adds `--registration-parallelism=N` CLI arg to seed and unseed commands ([9b6e838](https://github.com/broadinstitute/thelma/pull/189/commits/9b6e838f6c2961264549eeddfc53ffe798045470))
2. Make the `terra` package play nice with the `pool` package (`terra.TerraClient` can now accept a `pool.StatusReporter`, which it will use for retry output instead of `log` when present) ([e672965](https://github.com/broadinstitute/thelma/pull/189/commits/e672965ab9d0c11b35a7ae9d4c0a8f60dc6a69bd))
3. Parallelize seeding step 2, registering SAs with orch ([f9baf0a](https://github.com/broadinstitute/thelma/pull/189/commits/f9baf0ab5253c636da23838fe5754815a6c513cb)) **(minute -> 20 seconds, YMMV)**
4. Parallelize seeding step 4, registering test users with orch and accepting terms of service with sam ([101d4dd](https://github.com/broadinstitute/thelma/pull/189/commits/101d4ddfb55b9b3156663bda2c7bb86d9aec625e)) **(5 minutes -> 40 seconds, YMMV)**
5. Parallelize unseeding step 1, unregistering users with sam ([c21989d](https://github.com/broadinstitute/thelma/pull/189/commits/c21989d7833bb2c624d44681a25462057e84a4f1)) (didn't test how long this took before, seems basically instant now)

## Testing

Made a BEE with Beehive but skipped the GHA, used this build of Thelma to do various `provision`, `seed`, and `unseed` commands on it.

## Risk

I don't think we'll get the risk much lower than "it worked for me." Can tweak if we see issues but the speed gains here are significant enough I think we should make the improvement.