### PR TITLE
[DDO-3327] Make the GetTokenProvider safe for re-use

### DIFF
--- a/internal/thelma/app/credentials/credentials.go
+++ b/internal/thelma/app/credentials/credentials.go
@@ -9,8 +9,15 @@ import (
 const configKey = "credentials"
 
 type Credentials interface {
-	// NewTokenProvider returns a new TokenProvider for the given key
-	NewTokenProvider(key string, opts ...TokenOption) TokenProvider
+	// GetTokenProvider returns a TokenProvider for the given key, applying the given options if a new TokenProvider is
+	// created to fulfill the request. If a TokenProvider already exists for the given key, it will be returned.
+	// It's important for callers to be consistent with the options they pass in, at least for a given Thelma execution,
+	// since the options are only used on the first call for a given key.
+	//
+	// The caching means that there will only ever be one TokenProvider for a given key, so the TokenProvider's
+	// concurrency-safety guarantees will reliably apply (and the caller doesn't need to worry about caching the
+	// response of this function).
+	GetTokenProvider(key string, opts ...TokenOption) TokenProvider
 }
 
 type credentialsConfig struct {

--- a/internal/thelma/clients/github/github.go
+++ b/internal/thelma/clients/github/github.go
@@ -99,7 +99,7 @@ func WithDefaults(config config.Config, creds credentials.Credentials, vaultClie
 }
 
 func buildLocalGithubTokenProvider(creds credentials.Credentials) credentials.TokenProvider {
-	return creds.NewTokenProvider(credentialsKey, func(options *credentials.TokenOptions) {
+	return creds.GetTokenProvider(credentialsKey, func(options *credentials.TokenOptions) {
 		options.PromptEnabled = true
 
 		options.PromptMessage = `
@@ -111,7 +111,7 @@ Enter Personal Access Token: `
 }
 
 func buildVaultGithubTokenProvider(creds credentials.Credentials, vault *vault.Client, path, key string) credentials.TokenProvider {
-	return creds.NewTokenProvider(credentialsKey, func(options *credentials.TokenOptions) {
+	return creds.GetTokenProvider(credentialsKey, func(options *credentials.TokenOptions) {
 		options.IssueFn = func() ([]byte, error) {
 			accessTokenSecret, err := vault.Logical().Read(path)
 			if err != nil {

--- a/internal/thelma/clients/iap/iap.go
+++ b/internal/thelma/clients/iap/iap.go
@@ -115,7 +115,7 @@ func TokenProvider(thelmaConfig config.Config, creds credentials.Credentials, va
 
 	// if workload identity is enabled, try to issue an IAP token that way first, falling back to user credentials
 	if cfg.Provider == "workloadidentity" {
-		return creds.NewTokenProvider(tokenKey, func(options *credentials.TokenOptions) {
+		return creds.GetTokenProvider(tokenKey, func(options *credentials.TokenOptions) {
 			options.IssueFn = func() ([]byte, error) {
 				return getTokenFromWorkloadIdentity(cfg, oauthConfig)
 			}
@@ -127,7 +127,7 @@ func TokenProvider(thelmaConfig config.Config, creds credentials.Credentials, va
 
 	// else use browser provider
 	if cfg.Provider == "browser" {
-		provider := creds.NewTokenProvider(tokenKey, func(options *credentials.TokenOptions) {
+		provider := creds.GetTokenProvider(tokenKey, func(options *credentials.TokenOptions) {
 			options.IssueFn = func() ([]byte, error) {
 				token, err := issueNewToken(oauthConfig, oauthCreds, runner)
 				if err != nil {

--- a/internal/thelma/clients/vault/vault.go
+++ b/internal/thelma/clients/vault/vault.go
@@ -96,7 +96,7 @@ func buildClientOptions(thelmaConfig config.Config, clientOptions ...ClientOptio
 func buildVaultTokenProvider(unauthedClient *vaultapi.Client, creds credentials.Credentials, opts *ClientOptions) credentials.TokenProvider {
 	githubToken := buildGithubTokenProvider(unauthedClient, creds)
 
-	return creds.NewTokenProvider(vaultTokenCredentialKey, func(options *credentials.TokenOptions) {
+	return creds.GetTokenProvider(vaultTokenCredentialKey, func(options *credentials.TokenOptions) {
 		// Use custom credential store that stores token at ~/.vault-token instead ~/.thelma/credentials
 		options.CredentialStore = opts.CredentialStore
 
@@ -134,7 +134,7 @@ func buildVaultTokenProvider(unauthedClient *vaultapi.Client, creds credentials.
 }
 
 func buildGithubTokenProvider(unauthedClient *vaultapi.Client, creds credentials.Credentials) credentials.TokenProvider {
-	return creds.NewTokenProvider(githubTokenCredentialKey, func(options *credentials.TokenOptions) {
+	return creds.GetTokenProvider(githubTokenCredentialKey, func(options *credentials.TokenOptions) {
 		options.PromptEnabled = true
 
 		options.PromptMessage = `


### PR DESCRIPTION
#197 made TokenProvider safe for use in goroutines, but only if everything was pointing at the same TokenProvider for a given identifying key ("vault-token", "github-repo-pat", etc).

Turns out there's a few places in Thelma that call NewTokenProvider under the hood, making a new TokenProvider for the same identifying key, environment variables, and on-disk storage. This used to be totally fine because it was single-threaded anyway, and it was looking at the same state.

Now, though, that breaks the goroutine-safety of TokenProvider. This PR renames the function to GetTokenProvider and makes it goroutine-safe and adds caching (so all existing calls will work just as before, just routed through the same TokenProvider instances).

## Testing

Added a test for the concurrency/caching on GetTokenProvider (confirmed that it fails without my changes)

## Risk

Very low