### PR TITLE
[DDO-3357] Make Dependabot work

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,6 +63,7 @@ env:
   THELMA_MACOS_APP_PWD: ${{ secrets.THELMA_MACOS_APP_PWD }}
 jobs:
   bump:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.tag }}
@@ -82,6 +83,7 @@ jobs:
           WITH_V: true
 
   cache-go-deps:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up GCP auth
+      if: ${{ github.actor != 'dependabot[bot]' }}
       id: setup-gcp-auth
       run: |
         GCP_CREDS_PATH=$(pwd)/service_account.json
@@ -27,13 +28,20 @@ jobs:
         echo gcp-creds-path=${GCP_CREDS_PATH} >> $GITHUB_OUTPUT
 
     - name: Run tests
+      if: ${{ github.actor != 'dependabot[bot]' }}
       uses: ./.github/actions/make
       with:
         target: "smoke"
       env:
-        # full path is needed because go tests switch into package directories,
-        # and some smoke tests use GCP credentials
+        # Some smoke tests use GCP credentials
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.setup-gcp-auth.outputs.gcp-creds-path }}
+
+    - name: Run tests (dependabot)
+      if: ${{ github.actor == 'dependabot[bot]' }}
+      uses: ./.github/actions/make
+      with:
+        # Dependabot can't run smoke tests but unit tests are better than nothing
+        target: "test"
 
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
Thelma's workflows use secrets that dependabot PRs don't have. This change skips things that require those secrets within dependabot PRs to hopefully make their CI pass.

## Testing

The workflows passed below, can't test how dependabot will execute them until it does.

## Risk

None