### PR TITLE
[DDO-3356] Parse GitHub's OIDC response `.value` as a string specifically

### DIFF
--- a/internal/thelma/clients/github/gha/oidc_issuer.go
+++ b/internal/thelma/clients/github/gha/oidc_issuer.go
@@ -70,12 +70,14 @@ func getOidcToken() ([]byte, error) {
 
 	// This type isn't really documented but you can infer it based on the example at
 	// https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#requesting-the-jwt-using-environment-variables
+	// and at
+	// https://github.com/actions/toolkit/blob/main/packages/core/src/oidc-utils.ts#L7-L9
 	type responseJson struct {
-		Value json.RawMessage `json:"value"`
+		Value string `json:"value"`
 	}
 	var result responseJson
 	if err = json.Unmarshal(body, &result); err != nil {
 		return nil, errors.Errorf("failed to unmarshal response body from %s: %v", requestUrl, err)
 	}
-	return result.Value, nil
+	return []byte(result.Value), nil
 }

--- a/internal/thelma/clients/github/gha/oidc_issuer_test.go
+++ b/internal/thelma/clients/github/gha/oidc_issuer_test.go
@@ -74,10 +74,7 @@ func Test_getOidcToken(t *testing.T) {
 				mockStatusCode = statusCode
 				tokenBytes, err := getOidcToken()
 				require.NoError(t, err)
-				var token string
-				err = json.Unmarshal(tokenBytes, &token)
-				require.NoError(t, err)
-				require.Equal(t, mockOidcResponseToken, token)
+				require.Equal(t, mockOidcResponseToken, string(tokenBytes))
 			}
 		})
 	})


### PR DESCRIPTION
I admittedly forgot that JSON doesn't have a []bytes type so "binary data" would be represented as a base64 string. The right thing to do is parse this as a string, [as GitHub's own package for doing this does](https://github.com/actions/toolkit/blob/main/packages/core/src/oidc-utils.ts#L8) 

## Testing / Risk

Can't test this, but it's failing currently without effect so not big deal. You can see the failures if you turn on trace-level debugging in terra-github-workflows (workflows there actually don't get the OIDC token right now, go figure)