### PR TITLE
[DDO-3360] Typed TokenProvider

### DIFF
--- a/internal/thelma/app/credentials/token_provider_test.go
+++ b/internal/thelma/app/credentials/token_provider_test.go
@@ -17,6 +17,7 @@ type mockStore struct {
 	errorOnRead   bool
 	bluffRead     string
 	errorOnWrite  bool
+	bluffWrite    bool
 	errorOnExists bool
 	bluffExists   bool
 	errorOnRemove bool
@@ -44,6 +45,8 @@ func (s mockStore) Exists(key string) (bool, error) {
 func (s mockStore) Write(key string, credential []byte) error {
 	if s.errorOnWrite {
 		return errors.Errorf("write error")
+	} else if s.bluffWrite {
+		return nil
 	}
 	return s.delegate.Write(key, credential)
 }

--- a/internal/thelma/app/credentials/typed_token_provider.go
+++ b/internal/thelma/app/credentials/typed_token_provider.go
@@ -1,0 +1,113 @@
+package credentials
+
+import "github.com/pkg/errors"
+
+type TypedTokenOptions[T any] struct {
+	BaseTokenOptions
+
+	// UnmarshalFromStoreFn (required) parses T from the BaseTokenOptions.CredentialStore.
+	UnmarshalFromStoreFn func([]byte) (T, error)
+	// MarshalToStoreFn (required) will be used to store T in the BaseTokenOptions.CredentialStore.
+	MarshalToStoreFn func(T) ([]byte, error)
+
+	// MarshalToReturnFn (optional) will be used to return T to the caller of TokenProvider.Get.
+	// If omitted, MarshalToStoreFn will be used.
+	MarshalToReturnFn func(T) ([]byte, error)
+
+	// ValidateFn (optional) is like TokenOptions.ValidateFn, but for T.
+	ValidateFn func(T) error
+	// RefreshFn (optional) is like TokenOptions.RefreshFn, but for T.
+	RefreshFn func(T) (T, error)
+	// IssueFn (optional) is like TokenOptions.IssueFn, but for T.
+	IssueFn func() (T, error)
+}
+
+type TypedTokenOption[T any] func(*TypedTokenOptions[T])
+
+// GetTypedTokenProvider is like Credentials.GetTokenProvider but for TypedTokenOptions.
+// Go's lackluster generics support prevents this method from actually being present on
+// Credentials, so the receiver must be passed here.
+func GetTypedTokenProvider[T any](c Credentials, key string, options ...TypedTokenOption[T]) (TokenProvider, error) {
+	// Use given options
+	var typedOptions TypedTokenOptions[T]
+	for _, typedOption := range options {
+		typedOption(&typedOptions)
+	}
+
+	// Validate given options
+	if typedOptions.UnmarshalFromStoreFn == nil {
+		return nil, errors.Errorf("TypedTokenOptions.UnmarshalFromStoreFn is required")
+	} else if typedOptions.MarshalToStoreFn == nil {
+		return nil, errors.Errorf("TypedTokenOptions.MarshalToStoreFn is required")
+	}
+
+	// Set defaults
+	if typedOptions.MarshalToReturnFn == nil {
+		typedOptions.MarshalToReturnFn = typedOptions.MarshalToStoreFn
+	}
+
+	return c.GetTokenProvider(key, func(plainOptions *TokenOptions) {
+		// Translate typed options to plain options
+		if typedOptions.ValidateFn != nil {
+			plainOptions.ValidateFn = func(fromStore []byte) error {
+				t, err := typedOptions.UnmarshalFromStoreFn(fromStore)
+				if err != nil {
+					return errors.Errorf("error validating token: couldn't parse from []byte: %v", err)
+				}
+
+				return typedOptions.ValidateFn(t)
+			}
+		}
+		if typedOptions.RefreshFn != nil {
+			plainOptions.RefreshFn = func(fromStore []byte) ([]byte, error) {
+				t, err := typedOptions.UnmarshalFromStoreFn(fromStore)
+				if err != nil {
+					return nil, errors.Errorf("error refreshing token: couldn't parse from []byte: %v", err)
+				}
+
+				t, err = typedOptions.RefreshFn(t)
+				if err != nil {
+					return nil, errors.Errorf("error refreshing token: couldn't refresh: %v", err)
+				}
+
+				ret, err := typedOptions.MarshalToStoreFn(t)
+				if err != nil {
+					return nil, errors.Errorf("error refreshing token: couldn't marshal to []byte: %v", err)
+				} else {
+					return ret, nil
+				}
+			}
+		}
+		if typedOptions.IssueFn != nil {
+			plainOptions.IssueFn = func() ([]byte, error) {
+				t, err := typedOptions.IssueFn()
+				if err != nil {
+					return nil, errors.Errorf("error issuing token: couldn't issue: %v", err)
+				}
+
+				ret, err := typedOptions.MarshalToStoreFn(t)
+				if err != nil {
+					return nil, errors.Errorf("error issuing token: couldn't marshal to []byte: %v", err)
+				} else {
+					return ret, nil
+				}
+			}
+		}
+
+		// Configure plain options
+		plainOptions.transformForReturn = func(fromStore []byte) ([]byte, error) {
+			t, err := typedOptions.UnmarshalFromStoreFn(fromStore)
+			if err != nil {
+				return nil, errors.Errorf("error transforming token for return: couldn't parse from []byte: %v", err)
+			}
+
+			ret, err := typedOptions.MarshalToReturnFn(t)
+			if err != nil {
+				return nil, errors.Errorf("error transforming token for return: couldn't marshal to []byte: %v", err)
+			} else {
+				return ret, nil
+			}
+		}
+		plainOptions.BaseTokenOptions = typedOptions.BaseTokenOptions
+	}), nil
+}

--- a/internal/thelma/app/credentials/typed_token_provider_test.go
+++ b/internal/thelma/app/credentials/typed_token_provider_test.go
@@ -1,0 +1,298 @@
+package credentials
+
+import (
+	"encoding/json"
+	"github.com/broadinstitute/thelma/internal/thelma/app/credentials/stores"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_TypedTokenProvider(t *testing.T) {
+	type testToken struct {
+		SavedField    string `json:"savedField"`
+		ReturnedField string `json:"returnedField"`
+	}
+
+	var unmarshalShouldError, marshalShouldError, returnShouldError bool
+	unmarshalFunc := func(fromStore []byte) (*testToken, error) {
+		if unmarshalShouldError {
+			return nil, errors.New("some error")
+		}
+		var tt testToken
+		return &tt, json.Unmarshal(fromStore, &tt)
+	}
+	marshalFunc := func(tt *testToken) ([]byte, error) {
+		if marshalShouldError {
+			return nil, errors.New("some error")
+		}
+		return json.Marshal(tt)
+	}
+	returnFunc := func(tt *testToken) ([]byte, error) {
+		if returnShouldError {
+			return nil, errors.New("some error")
+		}
+		return []byte(tt.ReturnedField), nil
+	}
+
+	testCases := []struct {
+		name                 string
+		option               TypedTokenOption[*testToken]
+		setup                func(t *testing.T, tmpDir string)
+		unmarshalShouldError bool
+		marshalShouldError   bool
+		returnShouldError    bool
+		expectCreationError  string
+		expectValue          string
+		expectErr            string
+	}{
+		{
+			name: "unmarshal missing",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.MarshalToStoreFn = marshalFunc
+			},
+			expectCreationError: "TypedTokenOptions.UnmarshalFromStoreFn is required",
+		},
+		{
+			name: "marshal missing",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+			},
+			expectCreationError: "TypedTokenOptions.MarshalToStoreFn is required",
+		},
+		{
+			name: "normal issue",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.IssueFn = func() (*testToken, error) {
+					return &testToken{
+						SavedField:    "some-saved-value",
+						ReturnedField: "some-value",
+					}, nil
+				}
+			},
+			expectValue: "some-value",
+		},
+		{
+			name: "normal issue with no special return fn",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.IssueFn = func() (*testToken, error) {
+					return &testToken{
+						SavedField:    "some-saved-value",
+						ReturnedField: "some-value",
+					}, nil
+				}
+			},
+			expectValue: "{\"savedField\":\"some-saved-value\",\"returnedField\":\"some-value\"}",
+		},
+		{
+			name: "issue that errors",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.IssueFn = func() (*testToken, error) {
+					return nil, errors.New("some error")
+				}
+			},
+			expectErr: ".*some error",
+		},
+		{
+			name: "issue that can't marshal",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.IssueFn = func() (*testToken, error) {
+					return &testToken{
+						SavedField:    "some-saved-value",
+						ReturnedField: "some-value",
+					}, nil
+				}
+			},
+			marshalShouldError: true,
+			expectErr:          ".*couldn't marshal.*",
+		},
+		{
+			name: "transform fails to unmarshal",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.CredentialStore = mockStore{
+					bluffExists: true,
+					bluffRead:   "{\"savedField\":\"some-saved-value\",\"returnedField\":\"some-value\"}",
+				}
+			},
+			unmarshalShouldError: true,
+			expectErr:            "error transforming token for return: couldn't parse.*",
+		},
+		{
+			name: "transform fails to marshal",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.CredentialStore = mockStore{
+					bluffExists: true,
+					bluffRead:   "{\"savedField\":\"some-saved-value\",\"returnedField\":\"some-value\"}",
+				}
+			},
+			returnShouldError: true,
+			expectErr:         "error transforming token for return: couldn't marshal.*",
+		},
+		{
+			name: "validate fails to unmarshal",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.IssueFn = func() (*testToken, error) {
+					return &testToken{
+						SavedField:    "some-saved-value",
+						ReturnedField: "some-value",
+					}, nil
+				}
+				o.ValidateFn = func(tt *testToken) error {
+					return nil
+				}
+			},
+			unmarshalShouldError: true,
+			expectErr:            "error validating token: couldn't parse.*",
+		},
+		{
+			name: "validate returns error",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.IssueFn = func() (*testToken, error) {
+					return &testToken{
+						SavedField:    "some-saved-value",
+						ReturnedField: "some-value",
+					}, nil
+				}
+				o.ValidateFn = func(tt *testToken) error {
+					return errors.Errorf("some error")
+				}
+			},
+			expectErr: ".*some error",
+		},
+		{
+			name: "validate returns normally",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.CredentialStore = mockStore{
+					bluffExists: true,
+					bluffRead:   "{\"savedField\":\"some-saved-value\",\"returnedField\":\"some-value\"}",
+				}
+				o.ValidateFn = func(tt *testToken) error {
+					if tt.SavedField != "some-saved-value" {
+						return errors.Errorf("some error")
+					} else {
+						return nil
+					}
+				}
+			},
+			expectValue: "some-value",
+		},
+		{
+			name: "refresh errors",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.CredentialStore = mockStore{
+					bluffExists: true,
+					bluffRead:   "{\"savedField\":\"some-old-value\",\"returnedField\":\"some-value\"}",
+				}
+				o.ValidateFn = func(tt *testToken) error {
+					if tt.SavedField == "some-old-value" {
+						return errors.Errorf("expired")
+					} else {
+						return nil
+					}
+				}
+				o.RefreshFn = func(tt *testToken) (*testToken, error) {
+					return nil, errors.Errorf("some error")
+				}
+			},
+			expectErr: ".*no IssueFn set.*",
+		},
+		{
+			name: "refresh returns normally",
+			option: func(o *TypedTokenOptions[*testToken]) {
+				o.UnmarshalFromStoreFn = unmarshalFunc
+				o.MarshalToStoreFn = marshalFunc
+				o.MarshalToReturnFn = returnFunc
+				o.CredentialStore = mockStore{
+					bluffExists: true,
+					bluffRead:   "{\"savedField\":\"some-old-value\",\"returnedField\":\"some-value\"}",
+					bluffWrite:  true,
+				}
+				o.ValidateFn = func(tt *testToken) error {
+					if tt.SavedField == "some-old-value" {
+						return errors.Errorf("expired")
+					} else {
+						return nil
+					}
+				}
+				o.RefreshFn = func(tt *testToken) (*testToken, error) {
+					return &testToken{
+						SavedField:    "some-new-value",
+						ReturnedField: "some-new-value",
+					}, nil
+				}
+			},
+			expectValue: "some-new-value",
+		},
+		// Can't test marshalling/unmarshalling inside refresh fn very well because those happen before when reading and
+		// validating the token from the store and that would've been done already
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			unmarshalShouldError = tc.unmarshalShouldError
+			marshalShouldError = tc.marshalShouldError
+			returnShouldError = tc.returnShouldError
+			storeDir := t.TempDir()
+			if tc.setup != nil {
+				tc.setup(t, storeDir)
+			}
+			store, err := stores.NewDirectoryStore(storeDir)
+			require.NoError(t, err)
+			creds := NewWithStore(store)
+
+			var options []TypedTokenOption[*testToken]
+			if tc.option != nil {
+				options = append(options, tc.option)
+			}
+			tp, creationError := GetTypedTokenProvider[*testToken](creds, "my-token", options...)
+			if tc.expectCreationError != "" {
+				require.Error(t, creationError)
+				assert.Regexp(t, tc.expectCreationError, creationError.Error())
+				return
+			}
+
+			value, err := tp.Get()
+			tokenProvidersMutex.RLock()
+			TokenProviders = map[string]TokenProvider{}
+			tokenProvidersMutex.RUnlock()
+
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.Regexp(t, tc.expectErr, err.Error())
+				return
+			}
+
+			assert.Equal(t, tc.expectValue, string(value))
+		})
+	}
+}


### PR DESCRIPTION
TokenProvider reads `[]byte` from disk and returns the same `[]byte` from Get().

A semi-common pattern in more complex auth providers in Thelma, though, is to:
1. internally parse that `[]byte` to some other type for validation purposes
2. return some subset of that type as the `byte` from Get()

This is done manually with the delegate pattern from the sites where that functionality is necessary.

This PR introduces a GetTypedTokenProvider similar to GetTokenProvider except it requires marshal/unmarshal functions and in return makes the standard validate/refresh/issue functions work with that generic type instead. There's an optional "return this subset from Get()" function as well.

This PR is thoroughly tested but the code isn't used anywhere yet -- using it in the IAP code will require some refactoring and I'm going to shuffle the code around in preparation for adding another IAP mechanism. I figured I could split this out as its own PR.

## Testing

Tested with mocks and such -- there's two lines I can't cover because they're accounting for a function beginning to error during Thelma's lifetime

## Risk

None