### PR TITLE
[DDO-3376] Increase wait healthy timeout

### DIFF
--- a/internal/thelma/toolbox/argocd/argocd.go
+++ b/internal/thelma/toolbox/argocd/argocd.go
@@ -137,7 +137,7 @@ type argocdConfig struct {
 	SyncRetries int `default:"4"`
 
 	// WaitHealthyTimeoutSeconds how long to wait for an application to become healthy after syncing
-	WaitHealthyTimeoutSeconds int `default:"600"`
+	WaitHealthyTimeoutSeconds int `default:"900"`
 
 	WaitExistOptions
 }

--- a/internal/thelma/toolbox/argocd/argocd_test.go
+++ b/internal/thelma/toolbox/argocd/argocd_test.go
@@ -190,7 +190,7 @@ func Test_SyncRelease(t *testing.T) {
 
 	_mocks.expectCmd("app", "sync", "leonardo-configs-dev", "--retry-limit", "4", "--prune", "--timeout", "600")
 
-	_mocks.expectCmd("app", "wait", "leonardo-configs-dev", "--timeout", "600", "--health")
+	_mocks.expectCmd("app", "wait", "leonardo-configs-dev", "--timeout", "900", "--health")
 
 	// sync primary app
 	_mocks.expectCmd("app", "set", "leonardo-dev", "--revision", "HEAD", "--validate=false")
@@ -201,14 +201,14 @@ func Test_SyncRelease(t *testing.T) {
 
 	_mocks.expectCmd("app", "sync", "leonardo-dev", "--retry-limit", "4", "--prune", "--timeout", "600")
 
-	_mocks.expectCmd("app", "wait", "leonardo-dev", "--timeout", "600", "--health")
+	_mocks.expectCmd("app", "wait", "leonardo-dev", "--timeout", "900", "--health")
 
 	// restart deployments
 	_mocks.expectCmd("app", "actions", "list", "--kind=Deployment", "leonardo-dev")
 
 	_mocks.expectCmd("app", "actions", "run", "--kind=Deployment", "leonardo-dev", "restart", "--all")
 
-	_mocks.expectCmd("app", "wait", "leonardo-dev", "--timeout", "600", "--health")
+	_mocks.expectCmd("app", "wait", "leonardo-dev", "--timeout", "900", "--health")
 
 	require.NoError(t, _argocd.SyncRelease(leonardoDev))
 }


### PR DESCRIPTION
Increase the default post-sync wait-healthy timeout from 10 minutes to 15 minutes.