### PR TITLE
[DDO-3383] Allow generating IAP tokens with Google authentication

### DIFF
--- a/internal/thelma/app/config/profile.go
+++ b/internal/thelma/app/config/profile.go
@@ -39,6 +39,8 @@ func chooseProfile(options Options) string {
 		return name
 	}
 
+	// GoLand's inspection will be wrong here, because it doesn't know that runtime.GOOS can change.
+	//goland:noinspection GoBoolExpressions
 	if utils.Interactive() || runtime.GOOS == osx {
 		return defaultProfile
 	} else {

--- a/internal/thelma/app/config/profiles/gha.yaml
+++ b/internal/thelma/app/config/profiles/gha.yaml
@@ -1,0 +1,39 @@
+# this file contains bleeding-edge configuration for Thelma that can be custom set for running in GitHub Actions
+
+autoupdate:
+  # we never want auto-update enabled in CI environments
+  enabled: false
+
+argocd:
+  # pull token from Vault instead of local user credentials
+  vault:
+    enabled: true
+
+credentials:
+  # use inmemory store so creds aren't persistent to disk
+  storetype: inmemory
+
+github:
+  auth:
+    type: vault
+
+google:
+  auth:
+    type: adc
+    adc:
+      verifybroademail: false
+
+iap:
+  # use google auth to generate IAP tokens
+  provider: google
+
+logging:
+  console:
+    level: info
+  file:
+    # disable file logging
+    enabled: false
+
+vault:
+  # do not manage ~/.vault-token in ArgoCD/Jenkins/GitHub actions, treat vault token like a regular credential
+  manageusertoken: false

--- a/internal/thelma/clients/clients.go
+++ b/internal/thelma/clients/clients.go
@@ -72,7 +72,7 @@ func (c *clients) Google(options ...google.Option) google.Clients {
 }
 
 func (c *clients) IAP() (credentials.TokenProvider, error) {
-	return iap.TokenProvider(c.thelmaConfig, c.creds, c.Vault, c.runner)
+	return iap.TokenProvider(c.thelmaConfig, c.creds, c.Vault, c.Google, c.runner)
 }
 
 func (c *clients) IAPToken() (string, error) {

--- a/internal/thelma/clients/google/google.go
+++ b/internal/thelma/clients/google/google.go
@@ -352,7 +352,11 @@ func (c *clientsImpl) IdTokenGenerator(audience string, serviceAccountChain ...s
 	return func() ([]byte, error) {
 		resp, err := serviceAccountService.GenerateIdToken(serviceAccountChain[0], idTokenRequest).Do()
 		if err != nil {
-			return nil, errors.Errorf("error generating ID token: %v", err)
+			if userinfo, err2 := c.GoogleUserinfo(); err2 != nil {
+				return nil, errors.Errorf("error generating ID token for %s, and couldn't identify caller (GoogleUserinfo() = %v): %v", serviceAccountChain[0], err2, err)
+			} else {
+				return nil, errors.Errorf("error generating ID token for %s (called by %s): %v", serviceAccountChain[0], userinfo.Email, err)
+			}
 		}
 		return []byte(resp.Token), nil
 	}, nil

--- a/internal/thelma/clients/google/google.go
+++ b/internal/thelma/clients/google/google.go
@@ -318,7 +318,7 @@ func (c *clientsImpl) IdTokenGenerator(audience string, serviceAccountChain ...s
 		}
 		serviceAccountChain = []string{userinfo.Email}
 	}
-	for i := 0; i < len(serviceAccountChain)-1; i++ {
+	for i := 0; i < len(serviceAccountChain); i++ {
 		if !strings.HasSuffix(serviceAccountChain[i], serviceAccountEmailSuffix) {
 			return nil, errors.Errorf("IdTokenGenerator called with non-service-account email %q", serviceAccountChain[i])
 		} else if !strings.HasPrefix(serviceAccountChain[i], serviceAccountResourceNamePrefix) {

--- a/internal/thelma/clients/google/mocks/clients.go
+++ b/internal/thelma/clients/google/mocks/clients.go
@@ -152,6 +152,75 @@ func (_c *Clients_ClusterManager_Call) RunAndReturn(run func() (*container.Clust
 	return _c
 }
 
+// IdTokenGenerator provides a mock function with given fields: audience, serviceAccountChain
+func (_m *Clients) IdTokenGenerator(audience string, serviceAccountChain ...string) (func() ([]byte, error), error) {
+	_va := make([]interface{}, len(serviceAccountChain))
+	for _i := range serviceAccountChain {
+		_va[_i] = serviceAccountChain[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, audience)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 func() ([]byte, error)
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, ...string) (func() ([]byte, error), error)); ok {
+		return rf(audience, serviceAccountChain...)
+	}
+	if rf, ok := ret.Get(0).(func(string, ...string) func() ([]byte, error)); ok {
+		r0 = rf(audience, serviceAccountChain...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(func() ([]byte, error))
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, ...string) error); ok {
+		r1 = rf(audience, serviceAccountChain...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Clients_IdTokenGenerator_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IdTokenGenerator'
+type Clients_IdTokenGenerator_Call struct {
+	*mock.Call
+}
+
+// IdTokenGenerator is a helper method to define mock.On call
+//   - audience string
+//   - serviceAccountChain ...string
+func (_e *Clients_Expecter) IdTokenGenerator(audience interface{}, serviceAccountChain ...interface{}) *Clients_IdTokenGenerator_Call {
+	return &Clients_IdTokenGenerator_Call{Call: _e.mock.On("IdTokenGenerator",
+		append([]interface{}{audience}, serviceAccountChain...)...)}
+}
+
+func (_c *Clients_IdTokenGenerator_Call) Run(run func(audience string, serviceAccountChain ...string)) *Clients_IdTokenGenerator_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(string)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Clients_IdTokenGenerator_Call) Return(_a0 func() ([]byte, error), _a1 error) *Clients_IdTokenGenerator_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Clients_IdTokenGenerator_Call) RunAndReturn(run func(string, ...string) (func() ([]byte, error), error)) *Clients_IdTokenGenerator_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PubSub provides a mock function with given fields: projectId
 func (_m *Clients) PubSub(projectId string) (*pubsub.Client, error) {
 	ret := _m.Called(projectId)

--- a/internal/thelma/clients/iap/google-provider.go
+++ b/internal/thelma/clients/iap/google-provider.go
@@ -1,0 +1,18 @@
+package iap
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app/credentials"
+	"github.com/broadinstitute/thelma/internal/thelma/clients/google"
+)
+
+func googleProvider(creds credentials.Credentials, cfg iapConfig, googleClient google.Clients) (credentials.TokenProvider, error) {
+	issuer, err := googleClient.IdTokenGenerator(cfg.Audience)
+	if err != nil {
+		return nil, err
+	}
+	return creds.GetTokenProvider(tokenKey, func(options *credentials.TokenOptions) {
+		options.EnvVars = []string{defaultTokenEnvVar, backwardsCompatibilityTokenEnvVar}
+		options.IssueFn = issuer
+		options.ValidateFn = idtokenValidator
+	}), nil
+}


### PR DESCRIPTION
Adds a new IAP mechanism, `google`, in addition to `workloadidentity` and `browser`. It borrows Thelma's Google authentication to generate an IAP token that way. That'll only work if Thelma's Google auth is a service account. It only gets called by a new special profile, `gha` (so all the existing `ci` usages/autodetection won't trigger these new code paths).

## Testing

Some test coverage in-codebase where possible, but I manually tested this.

This PR uses new Thelma with the GHA profile (and modifications to make that work -- just auth with `thelma-ci` when using Thelma instead of using different accounts for different parts of Thelma). As soon as this PR is merged, I'm going to get that one ready to be merged (undo the "manually use this Thelma version" change)

[This PR](https://github.com/broadinstitute/terra-helmfile/pull/4895) uses new Thelma with the nothing else changed, just to demonstrate that this Thelma change doesn't break anything. This one won't be merged, it's just for testing.

## Risk

Low because of the above testing