### PR TITLE
[DDO-3282] Bugfix: Report new chart versions even if not deploying

### DIFF
--- a/internal/thelma/charts/deploy/config.go
+++ b/internal/thelma/charts/deploy/config.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
 	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/stateutils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
@@ -50,7 +51,7 @@ func newConfigLoader(chartsDir source.ChartsDir, state terra.State) (ConfigLoade
 
 	return &configLoaderImpl{
 		chartsDir: chartsDir,
-		releases:  buildReleaseMap(releases),
+		releases:  stateutils.BuildReleaseMap(releases),
 	}, nil
 }
 

--- a/internal/thelma/charts/deploy/config_test.go
+++ b/internal/thelma/charts/deploy/config_test.go
@@ -4,6 +4,7 @@ import (
 	sourcemocks "github.com/broadinstitute/thelma/internal/thelma/charts/source/mocks"
 	statemocks "github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
 	"github.com/broadinstitute/thelma/internal/thelma/state/testing/statefixtures"
+	"github.com/broadinstitute/thelma/internal/thelma/utils/stateutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -116,7 +117,7 @@ sherlock:
 
 			releases, err := suite.configLoader.FindReleasesToUpdate(tc.chartName)
 			require.NoError(suite.T(), err)
-			assert.ElementsMatch(suite.T(), tc.expectReleases, releaseFullNames(releases))
+			assert.ElementsMatch(suite.T(), tc.expectReleases, stateutils.ReleaseFullNames(releases))
 		})
 	}
 }

--- a/internal/thelma/charts/deploy/deployer_test.go
+++ b/internal/thelma/charts/deploy/deployer_test.go
@@ -273,7 +273,7 @@ func TestDeployerSuite(t *testing.T) {
 }
 
 func (suite *DeployerSuite) newDeployer(opts Options) Deployer {
-	updater := releaser.DeployedVersionUpdater{
+	updater := &releaser.DeployedVersionUpdater{
 		SherlockUpdaters: []sherlock.ChartVersionUpdater{suite.mockSherlock},
 	}
 

--- a/internal/thelma/charts/deploy/deployer_test.go
+++ b/internal/thelma/charts/deploy/deployer_test.go
@@ -273,7 +273,7 @@ func TestDeployerSuite(t *testing.T) {
 }
 
 func (suite *DeployerSuite) newDeployer(opts Options) Deployer {
-	updater := DeployedVersionUpdater{
+	updater := releaser.DeployedVersionUpdater{
 		SherlockUpdaters: []sherlock.ChartVersionUpdater{suite.mockSherlock},
 	}
 

--- a/internal/thelma/charts/releaser/deployed_version_updater_test.go
+++ b/internal/thelma/charts/releaser/deployed_version_updater_test.go
@@ -1,9 +1,10 @@
-package deploy
+package releaser
 
 import (
-	"github.com/broadinstitute/thelma/internal/thelma/charts/releaser"
 	"github.com/broadinstitute/thelma/internal/thelma/clients/sherlock"
 	sherlockmocks "github.com/broadinstitute/thelma/internal/thelma/clients/sherlock/mocks"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	statemocks "github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
 	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
@@ -89,7 +90,7 @@ func TestAutoReleaser_UpdateVersionsFile(t *testing.T) {
 			err := updater.UpdateChartReleaseVersions(
 				chartName,
 				releases,
-				releaser.VersionPair{
+				VersionPair{
 					PriorVersion: lastVersion,
 					NewVersion:   newVersion,
 				},
@@ -105,4 +106,18 @@ func TestAutoReleaser_UpdateVersionsFile(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func mockReleases(fullNames []string) []terra.Release {
+	var releases []terra.Release
+	for _, n := range fullNames {
+		releases = append(releases, mockRelease(n))
+	}
+	return releases
+}
+
+func mockRelease(fullName string) terra.Release {
+	r := &statemocks.Release{}
+	r.EXPECT().FullName().Return(fullName)
+	return r
 }

--- a/internal/thelma/charts/releaser/releaser.go
+++ b/internal/thelma/charts/releaser/releaser.go
@@ -107,6 +107,7 @@ func (r *chartReleaser) reportNewVersionsToSherlock(chartVersions map[string]Ver
 			return err
 		}
 	}
+	log.Info().Msgf("%d new chart versions were reported to Sherlock", len(chartVersions))
 	return nil
 }
 

--- a/internal/thelma/charts/releaser/releaser.go
+++ b/internal/thelma/charts/releaser/releaser.go
@@ -29,19 +29,21 @@ type ChartReleaser interface {
 	//   "bar": "0.2.0",
 	// }
 	//
-	Release(chartsToPublish []string) (publishedVersions map[string]VersionPair, err error)
+	Release(chartsToPublish []string, changeDescription string) (publishedVersions map[string]VersionPair, err error)
 }
 
-func NewChartReleaser(chartsDir source.ChartsDir, publisher publish.Publisher) ChartReleaser {
+func NewChartReleaser(chartsDir source.ChartsDir, publisher publish.Publisher, deployedVersionUpdater *DeployedVersionUpdater) ChartReleaser {
 	return &chartReleaser{
-		chartsDir: chartsDir,
-		publisher: publisher,
+		chartsDir:              chartsDir,
+		publisher:              publisher,
+		deployedVersionUpdater: deployedVersionUpdater,
 	}
 }
 
 type chartReleaser struct {
-	chartsDir source.ChartsDir
-	publisher publish.Publisher
+	chartsDir              source.ChartsDir
+	publisher              publish.Publisher
+	deployedVersionUpdater *DeployedVersionUpdater
 }
 
 type VersionPair struct {
@@ -51,7 +53,7 @@ type VersionPair struct {
 	NewVersion string
 }
 
-func (r *chartReleaser) Release(chartNames []string) (map[string]VersionPair, error) {
+func (r *chartReleaser) Release(chartNames []string, description string) (map[string]VersionPair, error) {
 	// make sure all charts exist in source dir
 	chartsToPublish := chartNames
 	for _, chartName := range chartsToPublish {
@@ -91,7 +93,21 @@ func (r *chartReleaser) Release(chartNames []string) (map[string]VersionPair, er
 		return nil, err
 	}
 
+	// report new chart versions to Sherlock
+	if err = r.reportNewVersionsToSherlock(chartVersions, description); err != nil {
+		return nil, err
+	}
+
 	return chartVersions, nil
+}
+
+func (r *chartReleaser) reportNewVersionsToSherlock(chartVersions map[string]VersionPair, description string) error {
+	for chartName, versions := range chartVersions {
+		if err := r.deployedVersionUpdater.ReportNewChartVersion(chartName, versions, description); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *chartReleaser) publishCharts() error {

--- a/internal/thelma/cli/commands/charts/sherlockflags/sherlockflags.go
+++ b/internal/thelma/cli/commands/charts/sherlockflags/sherlockflags.go
@@ -62,7 +62,6 @@ func (f *sherlockUpdaterFlags) GetDeployedVersionUpdater(app app.ThelmaApp, dryR
 	if dryRun {
 		return &updater, nil
 	}
-
 	if len(f.flagVals.sherlock) > 0 || len(f.flagVals.softFailSherlock) > 0 {
 		for _, sherlockURL := range f.flagVals.sherlock {
 			if sherlockURL != "" {

--- a/internal/thelma/cli/commands/charts/sherlockflags/sherlockflags.go
+++ b/internal/thelma/cli/commands/charts/sherlockflags/sherlockflags.go
@@ -1,0 +1,92 @@
+package sherlockflags
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/app"
+	"github.com/broadinstitute/thelma/internal/thelma/charts/releaser"
+	"github.com/broadinstitute/thelma/internal/thelma/clients/sherlock"
+	"github.com/spf13/cobra"
+)
+
+const sherlockProdURL = "https://sherlock.dsp-devops.broadinstitute.org"
+const sherlockDevURL = "https://sherlock-dev.dsp-devops.broadinstitute.org"
+
+type flagValues struct {
+	description      string
+	sherlock         []string
+	softFailSherlock []string
+}
+
+var flagNames = struct {
+	description      string
+	sherlock         string
+	softFailSherlock string
+}{
+	description:      "description",
+	sherlock:         "sherlock",
+	softFailSherlock: "soft-fail-sherlock",
+}
+
+type sherlockUpdaterFlags struct {
+	flagVals flagValues
+}
+
+func (f *sherlockUpdaterFlags) Description() string {
+	return f.flagVals.description
+}
+
+// SherlockUpdaterFlags adds sherlock update flags to a cobra command and supports converting those flags to a releaser.DeployedVersionUpdater
+type SherlockUpdaterFlags interface {
+	// AddFlags add  flags to a command
+	AddFlags(*cobra.Command)
+	// GetDeployedVersionUpdater should be called during a Run function to get a releaser.DeployedVersionUpdater that matches the given flags
+	GetDeployedVersionUpdater(thelmaApp app.ThelmaApp, dryRun bool) (*releaser.DeployedVersionUpdater, error)
+	// Description returns value of --description flag
+	Description() string
+}
+
+// NewSherlockUpdaterFlags returns a new SherlockUpdaterFlags
+func NewSherlockUpdaterFlags() SherlockUpdaterFlags {
+	return &sherlockUpdaterFlags{}
+}
+
+func (f *sherlockUpdaterFlags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&f.flagVals.sherlock, flagNames.sherlock, []string{sherlockProdURL}, "Sherlock servers to use as versioning systems to release to")
+	cmd.Flags().StringSliceVar(&f.flagVals.softFailSherlock, flagNames.softFailSherlock, []string{sherlockDevURL}, "Sherlock server to use as versioning systems to release to, always using soft-fail behavior")
+	cmd.Flags().StringVarP(&f.flagVals.description, flagNames.description, "d", "", "The description to use for these version bumps on any Sherlock versioning systems")
+}
+
+func (f *sherlockUpdaterFlags) GetDeployedVersionUpdater(app app.ThelmaApp, dryRun bool) (*releaser.DeployedVersionUpdater, error) {
+	var updater releaser.DeployedVersionUpdater
+
+	// If we're dry-running, the updater will be empty so we don't mutate anything.
+	if dryRun {
+		return &updater, nil
+	}
+
+	if len(f.flagVals.sherlock) > 0 || len(f.flagVals.softFailSherlock) > 0 {
+		for _, sherlockURL := range f.flagVals.sherlock {
+			if sherlockURL != "" {
+				client, err := app.Clients().Sherlock(func(options *sherlock.Options) {
+					options.Addr = sherlockURL
+				})
+				if err != nil {
+					return &updater, err
+				}
+				updater.SherlockUpdaters = append(updater.SherlockUpdaters, client)
+			}
+		}
+		for _, sherlockURL := range f.flagVals.softFailSherlock {
+			if sherlockURL != "" {
+				client, err := app.Clients().Sherlock(func(options *sherlock.Options) {
+					options.Addr = sherlockURL
+				})
+				if err != nil {
+					return &updater, err
+				}
+				updater.SoftFailSherlockUpdaters = append(updater.SoftFailSherlockUpdaters, client)
+			}
+		}
+	}
+
+	return &updater, nil
+}

--- a/internal/thelma/clients/sherlock/chart_version_updater.go
+++ b/internal/thelma/clients/sherlock/chart_version_updater.go
@@ -12,6 +12,9 @@ import (
 )
 
 type ChartVersionUpdater interface {
+	// ReportNewChartVersion reports a new chart version to Sherlock
+	ReportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error
+
 	// UpdateForNewChartVersion does three things in sequence, all directly with Sherlock's API.
 	//
 	// 1. Report new chart version to Sherlock (meaning there's a new latest chart version)
@@ -24,7 +27,7 @@ type ChartVersionUpdater interface {
 }
 
 // Step 1 of UpdateForNewChartVersion
-func (c *clientImpl) reportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error {
+func (c *clientImpl) ReportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error {
 	chartVersion := &models.SherlockChartVersionV3Create{
 		Chart:        chartSelector,
 		ChartVersion: newVersion,
@@ -136,7 +139,7 @@ func (c *clientImpl) refreshDownstreamTemplateChartReleases(chartSelector string
 }
 
 func (c *clientImpl) UpdateForNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string, chartReleaseSelectors []string) error {
-	if err := c.reportNewChartVersion(chartSelector, newVersion, lastVersion, description); err != nil {
+	if err := c.ReportNewChartVersion(chartSelector, newVersion, lastVersion, description); err != nil {
 		return errors.Errorf("error reporting chart version %s/%s: %v", chartSelector, newVersion, err)
 	}
 	log.Info().Msgf("reported new chart version %s/%s to Sherlock", chartSelector, newVersion)

--- a/internal/thelma/clients/sherlock/mocks/chart_version_updater.go
+++ b/internal/thelma/clients/sherlock/mocks/chart_version_updater.go
@@ -17,6 +17,51 @@ func (_m *ChartVersionUpdater) EXPECT() *ChartVersionUpdater_Expecter {
 	return &ChartVersionUpdater_Expecter{mock: &_m.Mock}
 }
 
+// ReportNewChartVersion provides a mock function with given fields: chartSelector, newVersion, lastVersion, description
+func (_m *ChartVersionUpdater) ReportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error {
+	ret := _m.Called(chartSelector, newVersion, lastVersion, description)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
+		r0 = rf(chartSelector, newVersion, lastVersion, description)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ChartVersionUpdater_ReportNewChartVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReportNewChartVersion'
+type ChartVersionUpdater_ReportNewChartVersion_Call struct {
+	*mock.Call
+}
+
+// ReportNewChartVersion is a helper method to define mock.On call
+//   - chartSelector string
+//   - newVersion string
+//   - lastVersion string
+//   - description string
+func (_e *ChartVersionUpdater_Expecter) ReportNewChartVersion(chartSelector interface{}, newVersion interface{}, lastVersion interface{}, description interface{}) *ChartVersionUpdater_ReportNewChartVersion_Call {
+	return &ChartVersionUpdater_ReportNewChartVersion_Call{Call: _e.mock.On("ReportNewChartVersion", chartSelector, newVersion, lastVersion, description)}
+}
+
+func (_c *ChartVersionUpdater_ReportNewChartVersion_Call) Run(run func(chartSelector string, newVersion string, lastVersion string, description string)) *ChartVersionUpdater_ReportNewChartVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *ChartVersionUpdater_ReportNewChartVersion_Call) Return(_a0 error) *ChartVersionUpdater_ReportNewChartVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ChartVersionUpdater_ReportNewChartVersion_Call) RunAndReturn(run func(string, string, string, string) error) *ChartVersionUpdater_ReportNewChartVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateForNewChartVersion provides a mock function with given fields: chartSelector, newVersion, lastVersion, description, chartReleaseSelectors
 func (_m *ChartVersionUpdater) UpdateForNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string, chartReleaseSelectors []string) error {
 	ret := _m.Called(chartSelector, newVersion, lastVersion, description, chartReleaseSelectors)

--- a/internal/thelma/clients/sherlock/mocks/sherlock.go
+++ b/internal/thelma/clients/sherlock/mocks/sherlock.go
@@ -457,6 +457,51 @@ func (_c *Client_Releases_Call) RunAndReturn(run func() (sherlock.Releases, erro
 	return _c
 }
 
+// ReportNewChartVersion provides a mock function with given fields: chartSelector, newVersion, lastVersion, description
+func (_m *Client) ReportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error {
+	ret := _m.Called(chartSelector, newVersion, lastVersion, description)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
+		r0 = rf(chartSelector, newVersion, lastVersion, description)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Client_ReportNewChartVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReportNewChartVersion'
+type Client_ReportNewChartVersion_Call struct {
+	*mock.Call
+}
+
+// ReportNewChartVersion is a helper method to define mock.On call
+//   - chartSelector string
+//   - newVersion string
+//   - lastVersion string
+//   - description string
+func (_e *Client_Expecter) ReportNewChartVersion(chartSelector interface{}, newVersion interface{}, lastVersion interface{}, description interface{}) *Client_ReportNewChartVersion_Call {
+	return &Client_ReportNewChartVersion_Call{Call: _e.mock.On("ReportNewChartVersion", chartSelector, newVersion, lastVersion, description)}
+}
+
+func (_c *Client_ReportNewChartVersion_Call) Run(run func(chartSelector string, newVersion string, lastVersion string, description string)) *Client_ReportNewChartVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Client_ReportNewChartVersion_Call) Return(_a0 error) *Client_ReportNewChartVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_ReportNewChartVersion_Call) RunAndReturn(run func(string, string, string, string) error) *Client_ReportNewChartVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResetEnvironmentAndPinToDev provides a mock function with given fields: environment
 func (_m *Client) ResetEnvironmentAndPinToDev(environment terra.Environment) error {
 	ret := _m.Called(environment)

--- a/internal/thelma/utils/stateutils/stateutils.go
+++ b/internal/thelma/utils/stateutils/stateutils.go
@@ -1,0 +1,21 @@
+package stateutils
+
+import "github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+
+// ReleaseFullNames return the full names of a slice of releases
+func ReleaseFullNames(releases []terra.Release) []string {
+	var names []string
+	for _, r := range releases {
+		names = append(names, r.FullName())
+	}
+	return names
+}
+
+// BuildReleaseMap build a map of releases keyed by full names
+func BuildReleaseMap(releases []terra.Release) map[string]terra.Release {
+	m := make(map[string]terra.Release)
+	for _, release := range releases {
+		m[release.FullName()] = release
+	}
+	return m
+}


### PR DESCRIPTION
@em-may ran into a bug this morning where a new chart version was not reported for the `vaultcopy` chart.

This was a logical error; the `thelma charts publish` command needs to report new versions while the `thelma charts deploy` needs to update chart releases to use new versions.

This PR fixes the issue by adding the appropriate functionality to each command.