### PR TITLE
[DDO-3282] Bugfix: Fix for data plane charts such as `wds`

### DIFF
--- a/internal/thelma/charts/deploy/config_test.go
+++ b/internal/thelma/charts/deploy/config_test.go
@@ -56,6 +56,16 @@ func (suite *ConfigSuite) Test_findReleases() {
 			expectReleases: []string{"agora-dev"},
 		},
 		{
+			name:      "chart with release in .autorelease.yaml that does not exist",
+			chartName: "agora",
+			configFile: `
+sherlock:
+  chartReleasesToUseLatest:
+    - agora-doesnotexist
+`,
+			expectReleases: []string{},
+		},
+		{
 			name:      "chart should use releases in .autorelease.yaml if specified",
 			chartName: "agora",
 			configFile: `

--- a/internal/thelma/charts/deploy/deployer.go
+++ b/internal/thelma/charts/deploy/deployer.go
@@ -79,7 +79,7 @@ func (d *deployer) updateSherlock(chartVersionsToDeploy map[string]releaser.Vers
 		}
 
 		if len(releases) == 0 {
-			log.Info().Msgf("No releases found in Sherlock for chart %s, skipping", chartName)
+			log.Info().Msgf("No auto-release chart releases found in Sherlock for %s, skipping", chartName)
 			continue
 		}
 

--- a/internal/thelma/clients/sherlock/chart_version_updater.go
+++ b/internal/thelma/clients/sherlock/chart_version_updater.go
@@ -1,7 +1,6 @@
 package sherlock
 
 import (
-	"context"
 	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/changesets"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/chart_releases"
@@ -9,10 +8,8 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/charts"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/environments"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/models"
-	"github.com/go-openapi/runtime"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"time"
 )
 
 type ChartVersionUpdater interface {
@@ -32,13 +29,7 @@ type ChartVersionUpdater interface {
 
 // Step 1 of UpdateForNewChartVersion
 func (c *clientImpl) ReportNewChartVersion(chartName string, newVersion string, lastVersion string, description string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	resp, err := c.client.Charts.GetAPIChartsV3(&charts.GetAPIChartsV3Params{
-		Name: &chartName,
-	}, func(operation *runtime.ClientOperation) {
-		operation.Context = ctx
-	})
-	cancel()
+	resp, err := c.client.Charts.GetAPIChartsV3(charts.NewGetAPIChartsV3Params().WithName(&chartName))
 	if err != nil {
 		return errors.Errorf("error from Sherlock: %v", err)
 	}

--- a/internal/thelma/clients/sherlock/chart_version_updater.go
+++ b/internal/thelma/clients/sherlock/chart_version_updater.go
@@ -1,6 +1,7 @@
 package sherlock
 
 import (
+	"context"
 	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/changesets"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/chart_releases"
@@ -8,13 +9,15 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/charts"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/environments"
 	"github.com/broadinstitute/sherlock/sherlock-go-client/client/models"
+	"github.com/go-openapi/runtime"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"time"
 )
 
 type ChartVersionUpdater interface {
 	// ReportNewChartVersion reports a new chart version to Sherlock
-	ReportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error
+	ReportNewChartVersion(chartName string, newVersion string, lastVersion string, description string) error
 
 	// UpdateForNewChartVersion does three things in sequence, all directly with Sherlock's API.
 	//
@@ -28,21 +31,30 @@ type ChartVersionUpdater interface {
 }
 
 // Step 1 of UpdateForNewChartVersion
-func (c *clientImpl) ReportNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string) error {
-	params := &charts.GetAPIChartsV3SelectorParams{Selector: chartSelector}
-	_, err := c.client.Charts.GetAPIChartsV3Selector(params)
+func (c *clientImpl) ReportNewChartVersion(chartName string, newVersion string, lastVersion string, description string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	resp, err := c.client.Charts.GetAPIChartsV3(&charts.GetAPIChartsV3Params{
+		Name: &chartName,
+	}, func(operation *runtime.ClientOperation) {
+		operation.Context = ctx
+	})
+	cancel()
 	if err != nil {
-		log.Warn().Msgf("error looking up chart %s in Sherlock, won't report new version: %v", chartSelector, err)
+		return errors.Errorf("error from Sherlock: %v", err)
+	}
+
+	if len(resp.GetPayload()) == 0 {
+		log.Warn().Msgf("no chart with name %q in Sherlock, won't report new version", chartName)
 		return nil
 	}
 
 	chartVersion := &models.SherlockChartVersionV3Create{
-		Chart:        chartSelector,
+		Chart:        chartName,
 		ChartVersion: newVersion,
 		Description:  description,
 	}
 	if lastVersion != "" {
-		chartVersion.ParentChartVersion = fmt.Sprintf("%s/%s", chartSelector, lastVersion)
+		chartVersion.ParentChartVersion = fmt.Sprintf("%s/%s", chartName, lastVersion)
 	}
 	_, err = c.client.ChartVersions.PutAPIChartVersionsV3(
 		chart_versions.NewPutAPIChartVersionsV3Params().WithChartVersion(chartVersion))
@@ -146,24 +158,24 @@ func (c *clientImpl) refreshDownstreamTemplateChartReleases(chartSelector string
 	return chartReleasesToRefresh, nil
 }
 
-func (c *clientImpl) UpdateForNewChartVersion(chartSelector string, newVersion string, lastVersion string, description string, chartReleaseSelectors []string) error {
-	if err := c.ReportNewChartVersion(chartSelector, newVersion, lastVersion, description); err != nil {
-		return errors.Errorf("error reporting chart version %s/%s: %v", chartSelector, newVersion, err)
+func (c *clientImpl) UpdateForNewChartVersion(chartName string, newVersion string, lastVersion string, description string, chartReleaseSelectors []string) error {
+	if err := c.ReportNewChartVersion(chartName, newVersion, lastVersion, description); err != nil {
+		return errors.Errorf("error reporting chart version %s/%s: %v", chartName, newVersion, err)
 	}
-	log.Info().Msgf("reported new chart version %s/%s to Sherlock", chartSelector, newVersion)
+	log.Info().Msgf("reported new chart version %s/%s to Sherlock", chartName, newVersion)
 
 	if err := c.setChartReleasesToLatestChartVersion(chartReleaseSelectors...); err != nil {
-		return errors.Errorf("error setting chart releases to latest version of chart %s (%v): %v", chartSelector, chartReleaseSelectors, err)
+		return errors.Errorf("error setting chart releases to latest version of chart %s (%v): %v", chartName, chartReleaseSelectors, err)
 	} else {
-		log.Info().Msgf("updated chart releases in Sherlock to latest version of chart %s: %v", chartSelector, chartReleaseSelectors)
+		log.Info().Msgf("updated chart releases in Sherlock to latest version of chart %s: %v", chartName, chartReleaseSelectors)
 	}
 
-	if refreshedChartReleases, err := c.refreshDownstreamTemplateChartReleases(chartSelector, chartReleaseSelectors...); err != nil {
-		return errors.Errorf("error refreshing downstream template chart releases after reporting new chart version (%s/%s) and updating the following direct chart releases (%v): %v", chartSelector, newVersion, chartReleaseSelectors, err)
+	if refreshedChartReleases, err := c.refreshDownstreamTemplateChartReleases(chartName, chartReleaseSelectors...); err != nil {
+		return errors.Errorf("error refreshing downstream template chart releases after reporting new chart version (%s/%s) and updating the following direct chart releases (%v): %v", chartName, newVersion, chartReleaseSelectors, err)
 	} else if len(refreshedChartReleases) > 0 {
-		log.Info().Msgf("updated further downstream template chart releases in Sherlock to reflect new version %s/%s: %v", chartSelector, newVersion, refreshedChartReleases)
+		log.Info().Msgf("updated further downstream template chart releases in Sherlock to reflect new version %s/%s: %v", chartName, newVersion, refreshedChartReleases)
 	} else {
-		log.Info().Msgf("no further downstream template chart releases in Sherlock to update to reflect new version %s/%s", chartSelector, newVersion)
+		log.Info().Msgf("no further downstream template chart releases in Sherlock to update to reflect new version %s/%s", chartName, newVersion)
 	}
 
 	return nil


### PR DESCRIPTION
Yet another issue with the new post-publish deploy workflow.

[This fix](https://github.com/broadinstitute/thelma/pull/231) is causing an issue where data plane charts such as WDS, that do not have a corresponding chart in Sherlock, are failing to publish.

This PR updates the Sherlock chart version publishing code to check if the chart exists in Sherlock before attempting to report a new version.

### Background

Before my changes to support post-publish deploys, this corner of Thelma code made a best-effort attempt to report charts to sherlock but basically suppressed any errors it encountered. I removed the error suppression because I wanted to report unexpected errors appropriately, and this has exposed two cases that didn't occur to me to test:
* charts that exist in terra-helmfile have no `Chart` object in Sherlock
* charts that have a `Chart` object in Sherlock, but no autorelease chart releases

### Testing

I performed a successful test publish of multiple chart cases (not in Sherlock, in Sherlock with autorelease, etc) in this terra-helmfile PR:

https://github.com/broadinstitute/terra-helmfile/pull/4963
