### PR TITLE
[DDO-3437] Remove `Filter()` from state interfaces

### DIFF
--- a/internal/thelma/bee/bee.go
+++ b/internal/thelma/bee/bee.go
@@ -535,14 +535,12 @@ func (b *bees) FilterBees(_filter terra.EnvironmentFilter) ([]terra.Environment,
 }
 
 func (b *bees) templateNames() ([]string, error) {
-	templateFilter := filter.Environments().HasLifecycle(terra.Template)
-
 	allEnvs, err := b.state.Environments().All()
 	if err != nil {
 		return nil, err
 	}
 
-	templates := templateFilter.Filter(allEnvs)
+	templates := filter.Environments().IsTemplate().Filter(allEnvs)
 
 	var names []string
 	for _, t := range templates {

--- a/internal/thelma/charts/changedfiles/changedfiles.go
+++ b/internal/thelma/charts/changedfiles/changedfiles.go
@@ -151,7 +151,11 @@ func (c *changedFiles) identifyImpactedCharts(inputFile string) (set.Set[string]
 
 	// identify releases that are impacted by global values files, and add all their charts to the list
 	_filter := matchesToReleaseFilter(matches)
-	matchingReleases, err := c.state.Releases().Filter(_filter)
+	allReleases, err := c.state.Releases().All()
+	if err != nil {
+		return nil, err
+	}
+	matchingReleases := _filter.Filter(allReleases)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/thelma/cli/commands/sql/sqlhelpers/command.go
+++ b/internal/thelma/cli/commands/sql/sqlhelpers/command.go
@@ -101,10 +101,12 @@ func (c *command) Run(app app.ThelmaApp, ctx cli.RunContext) error {
 		if err != nil {
 			return err
 		}
-		releases, err := state.Releases().Filter(filter.Releases().HasFullName(c.flags.chartRelease))
+		allReleases, err := state.Releases().All()
 		if err != nil {
 			return err
 		}
+		// TODO we will soon have a Releases().ByName() method that will be waaay more efficient than this
+		releases := filter.Releases().HasFullName(c.flags.chartRelease).Filter(allReleases)
 		if len(releases) != 1 {
 			return errors.Errorf("found %d releases matching name %q, expected 1", len(releases), c.flags.chartRelease)
 		}

--- a/internal/thelma/cli/selector/enum_flags.go
+++ b/internal/thelma/cli/selector/enum_flags.go
@@ -177,11 +177,13 @@ func newEnvironmentTemplatesFlag() *enumFlag {
 		usageMessage:  `Run for dynamic environments with a specific template (eg. "swatomation")`,
 
 		validValues: func(state terra.State) (set.StringSet, error) {
-			envs, err := state.Environments().Filter(filter.Environments().HasLifecycle(terra.Template))
+			allEnvs, err := state.Environments().All()
 			if err != nil {
 				return nil, err
 			}
-			return namesSet(envs), nil
+
+			templates := filter.Environments().IsTemplate().Filter(allEnvs)
+			return namesSet(templates), nil
 		},
 
 		buildFilter: func(f *filterBuilder, values []string) {

--- a/internal/thelma/cli/selector/filter_builder.go
+++ b/internal/thelma/cli/selector/filter_builder.go
@@ -81,10 +81,12 @@ func (f *filterBuilder) addDestinationInclude(filter terra.DestinationFilter) {
 }
 
 func applyFilter(state terra.State, filter terra.ReleaseFilter) ([]terra.Release, error) {
-	releases, err := state.Releases().Filter(filter)
+	allReleases, err := state.Releases().All()
 	if err != nil {
 		return nil, err
 	}
+
+	releases := filter.Filter(allReleases)
 
 	log.Debug().Msgf("%d releases matched filter: %s", len(releases), filter.String())
 	sort.Releases(releases)

--- a/internal/thelma/state/api/terra/destinations.go
+++ b/internal/thelma/state/api/terra/destinations.go
@@ -4,8 +4,6 @@ package terra
 type Destinations interface {
 	// All returns a list of all destinations
 	All() ([]Destination, error)
-	// Filter returns a list of clusters matching the given filter
-	Filter(filter DestinationFilter) ([]Destination, error)
 	// Get returns the destination with the given name, or an error if no such destination exists
 	Get(name string) (Destination, error)
 }

--- a/internal/thelma/state/api/terra/environments.go
+++ b/internal/thelma/state/api/terra/environments.go
@@ -4,8 +4,6 @@ package terra
 type Environments interface {
 	// All returns a list of all environments
 	All() ([]Environment, error)
-	// Filter returns a list of environments matching the given filter
-	Filter(filter EnvironmentFilter) ([]Environment, error)
 	// Get returns the environment with the given name, or nil if no such environment exists
 	Get(name string) (Environment, error)
 	// Exists returns true if an environment by the given name exists

--- a/internal/thelma/state/api/terra/filter/environment_filters.go
+++ b/internal/thelma/state/api/terra/filter/environment_filters.go
@@ -23,6 +23,8 @@ type EnvironmentFilters interface {
 	HasLifecycleName(lifecycleName ...string) terra.EnvironmentFilter
 	// HasTemplate matches environments with the given template
 	HasTemplate(template terra.Environment) terra.EnvironmentFilter
+	// IsTemplate matches environments that are templates
+	IsTemplate() terra.EnvironmentFilter
 	// HasTemplateName matches environments with the given template name(s)
 	HasTemplateName(templateNames ...string) terra.EnvironmentFilter
 	// NameIncludes returns environments with names that include the given substring
@@ -91,6 +93,15 @@ func (e environmentFilters) HasTemplate(template terra.Environment) terra.Enviro
 		string: fmt.Sprintf("hasTemplate(%s)", template.Name()),
 		matcher: func(environment terra.Environment) bool {
 			return environment.Template() == template.Name()
+		},
+	}
+}
+
+func (e environmentFilters) IsTemplate() terra.EnvironmentFilter {
+	return environmentFilter{
+		string: "isTemplate()",
+		matcher: func(environment terra.Environment) bool {
+			return environment.Lifecycle().IsTemplate()
 		},
 	}
 }

--- a/internal/thelma/state/api/terra/filter/environment_filters_test.go
+++ b/internal/thelma/state/api/terra/filter/environment_filters_test.go
@@ -1,0 +1,158 @@
+package filter
+
+import (
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra"
+	"github.com/broadinstitute/thelma/internal/thelma/state/api/terra/mocks"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestEnvironmentFilters(t *testing.T) {
+	noAutoDelete := &mocks.AutoDelete{}
+	noAutoDelete.EXPECT().Enabled().Return(false)
+
+	autoDeleteAfter2HoursAgo := &mocks.AutoDelete{}
+	autoDeleteAfter2HoursAgo.EXPECT().Enabled().Return(true)
+	autoDeleteAfter2HoursAgo.EXPECT().After().Return(time.Now().Add(-1 * 2 * time.Hour))
+
+	dev := &mocks.Environment{}
+	dev.EXPECT().Name().Return("dev")
+	dev.EXPECT().Lifecycle().Return(terra.Static)
+	dev.EXPECT().Base().Return("live")
+	dev.EXPECT().Template().Return("")
+	dev.EXPECT().CreatedAt().Return(time.Now().Add(-1 * 24 * 100 * time.Hour)) // 100 days old
+	dev.EXPECT().AutoDelete().Return(noAutoDelete)
+	dev.EXPECT().PreventDeletion().Return(true)
+
+	swat := &mocks.Environment{}
+	swat.EXPECT().Name().Return("swatomation")
+	swat.EXPECT().Lifecycle().Return(terra.Template)
+	swat.EXPECT().Base().Return("bee")
+	swat.EXPECT().Template().Return("")
+	swat.EXPECT().CreatedAt().Return(time.Now().Add(-1 * 24 * 30 * time.Hour)) // 30 days old
+	swat.EXPECT().AutoDelete().Return(noAutoDelete)
+	swat.EXPECT().PreventDeletion().Return(false)
+
+	bee := &mocks.Environment{}
+	bee.EXPECT().Name().Return("my-bee")
+	bee.EXPECT().Lifecycle().Return(terra.Dynamic)
+	bee.EXPECT().Base().Return("bee")
+	bee.EXPECT().Template().Return("swatomation")
+	bee.EXPECT().CreatedAt().Return(time.Now().Add(-1 * 6 * time.Hour)) // 6 hours old
+	bee.EXPECT().AutoDelete().Return(autoDeleteAfter2HoursAgo)
+	bee.EXPECT().PreventDeletion().Return(false)
+
+	testCases := []struct {
+		filter terra.EnvironmentFilter
+		expect []terra.Environment
+	}{
+		{
+			filter: Environments().Any(),
+			expect: []terra.Environment{dev, swat, bee},
+		},
+		{
+			filter: Environments().Any().Negate(),
+			expect: nil,
+		},
+		{
+			filter: Environments().IsTemplate(),
+			expect: []terra.Environment{swat},
+		},
+		{
+			filter: Environments().IsTemplate().Negate(),
+			expect: []terra.Environment{dev, bee},
+		},
+		{
+			filter: Environments().HasBase("live"),
+			expect: []terra.Environment{dev},
+		},
+		{
+			filter: Environments().HasBase("live").Negate(),
+			expect: []terra.Environment{swat, bee},
+		},
+		{
+			filter: Environments().HasBase("bee"),
+			expect: []terra.Environment{swat, bee},
+		},
+		{
+			filter: Environments().HasBase("bee").Negate(),
+			expect: []terra.Environment{dev},
+		},
+		{
+			filter: Environments().HasBase("live", "bee").Negate(),
+			expect: nil,
+		},
+		{
+			filter: Environments().HasLifecycle(terra.Template),
+			expect: []terra.Environment{swat},
+		},
+		{
+			filter: Environments().HasLifecycle(terra.Dynamic),
+			expect: []terra.Environment{bee},
+		},
+		{
+			filter: Environments().HasLifecycle(terra.Static),
+			expect: []terra.Environment{dev},
+		},
+		{
+			filter: Environments().HasLifecycleName("template"),
+			expect: []terra.Environment{swat},
+		},
+		{
+			filter: Environments().HasLifecycleName("dynamic"),
+			expect: []terra.Environment{bee},
+		},
+		{
+			filter: Environments().HasLifecycleName("static"),
+			expect: []terra.Environment{dev},
+		},
+		{
+			filter: Environments().HasLifecycleName("static", "template"),
+			expect: []terra.Environment{dev, swat},
+		},
+		{
+			filter: Environments().HasTemplate(swat),
+			expect: []terra.Environment{bee},
+		},
+		{
+			filter: Environments().HasTemplateName("swatomation"),
+			expect: []terra.Environment{bee},
+		},
+		{
+			filter: Environments().NameIncludes("e"),
+			expect: []terra.Environment{dev, bee},
+		},
+		{
+			filter: Environments().OlderThan(12 * time.Hour),
+			expect: []terra.Environment{dev, swat},
+		},
+		{
+			filter: Environments().OlderThan(60 * 24 * time.Hour),
+			expect: []terra.Environment{dev},
+		},
+		{
+			filter: Environments().OlderThan(4 * time.Hour).And(Environments().HasLifecycle(terra.Dynamic)),
+			expect: []terra.Environment{bee},
+		},
+		{
+			filter: Environments().OlderThan(24 * time.Hour).Or(Environments().HasLifecycle(terra.Dynamic)),
+			expect: []terra.Environment{bee, dev, swat},
+		},
+		{
+			filter: Environments().AutoDeletable(),
+			expect: []terra.Environment{bee},
+		},
+		{
+			filter: Environments().AutoDeletable().Negate(),
+			expect: []terra.Environment{dev, swat},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filter.String(), func(t *testing.T) {
+			assert.ElementsMatch(t, tc.expect, tc.filter.Filter([]terra.Environment{dev, swat, bee}))
+
+		})
+	}
+}

--- a/internal/thelma/state/api/terra/mocks/destinations.go
+++ b/internal/thelma/state/api/terra/mocks/destinations.go
@@ -77,64 +77,6 @@ func (_c *Destinations_All_Call) RunAndReturn(run func() ([]terra.Destination, e
 	return _c
 }
 
-// Filter provides a mock function with given fields: filter
-func (_m *Destinations) Filter(filter terra.DestinationFilter) ([]terra.Destination, error) {
-	ret := _m.Called(filter)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Filter")
-	}
-
-	var r0 []terra.Destination
-	var r1 error
-	if rf, ok := ret.Get(0).(func(terra.DestinationFilter) ([]terra.Destination, error)); ok {
-		return rf(filter)
-	}
-	if rf, ok := ret.Get(0).(func(terra.DestinationFilter) []terra.Destination); ok {
-		r0 = rf(filter)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]terra.Destination)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(terra.DestinationFilter) error); ok {
-		r1 = rf(filter)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Destinations_Filter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Filter'
-type Destinations_Filter_Call struct {
-	*mock.Call
-}
-
-// Filter is a helper method to define mock.On call
-//   - filter terra.DestinationFilter
-func (_e *Destinations_Expecter) Filter(filter interface{}) *Destinations_Filter_Call {
-	return &Destinations_Filter_Call{Call: _e.mock.On("Filter", filter)}
-}
-
-func (_c *Destinations_Filter_Call) Run(run func(filter terra.DestinationFilter)) *Destinations_Filter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(terra.DestinationFilter))
-	})
-	return _c
-}
-
-func (_c *Destinations_Filter_Call) Return(_a0 []terra.Destination, _a1 error) *Destinations_Filter_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Destinations_Filter_Call) RunAndReturn(run func(terra.DestinationFilter) ([]terra.Destination, error)) *Destinations_Filter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Get provides a mock function with given fields: name
 func (_m *Destinations) Get(name string) (terra.Destination, error) {
 	ret := _m.Called(name)

--- a/internal/thelma/state/api/terra/mocks/environments.go
+++ b/internal/thelma/state/api/terra/mocks/environments.go
@@ -330,64 +330,6 @@ func (_c *Environments_Exists_Call) RunAndReturn(run func(string) (bool, error))
 	return _c
 }
 
-// Filter provides a mock function with given fields: filter
-func (_m *Environments) Filter(filter terra.EnvironmentFilter) ([]terra.Environment, error) {
-	ret := _m.Called(filter)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Filter")
-	}
-
-	var r0 []terra.Environment
-	var r1 error
-	if rf, ok := ret.Get(0).(func(terra.EnvironmentFilter) ([]terra.Environment, error)); ok {
-		return rf(filter)
-	}
-	if rf, ok := ret.Get(0).(func(terra.EnvironmentFilter) []terra.Environment); ok {
-		r0 = rf(filter)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]terra.Environment)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(terra.EnvironmentFilter) error); ok {
-		r1 = rf(filter)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Environments_Filter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Filter'
-type Environments_Filter_Call struct {
-	*mock.Call
-}
-
-// Filter is a helper method to define mock.On call
-//   - filter terra.EnvironmentFilter
-func (_e *Environments_Expecter) Filter(filter interface{}) *Environments_Filter_Call {
-	return &Environments_Filter_Call{Call: _e.mock.On("Filter", filter)}
-}
-
-func (_c *Environments_Filter_Call) Run(run func(filter terra.EnvironmentFilter)) *Environments_Filter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(terra.EnvironmentFilter))
-	})
-	return _c
-}
-
-func (_c *Environments_Filter_Call) Return(_a0 []terra.Environment, _a1 error) *Environments_Filter_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Environments_Filter_Call) RunAndReturn(run func(terra.EnvironmentFilter) ([]terra.Environment, error)) *Environments_Filter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Get provides a mock function with given fields: name
 func (_m *Environments) Get(name string) (terra.Environment, error) {
 	ret := _m.Called(name)

--- a/internal/thelma/state/api/terra/mocks/releases.go
+++ b/internal/thelma/state/api/terra/mocks/releases.go
@@ -77,64 +77,6 @@ func (_c *Releases_All_Call) RunAndReturn(run func() ([]terra.Release, error)) *
 	return _c
 }
 
-// Filter provides a mock function with given fields: filter
-func (_m *Releases) Filter(filter terra.ReleaseFilter) ([]terra.Release, error) {
-	ret := _m.Called(filter)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Filter")
-	}
-
-	var r0 []terra.Release
-	var r1 error
-	if rf, ok := ret.Get(0).(func(terra.ReleaseFilter) ([]terra.Release, error)); ok {
-		return rf(filter)
-	}
-	if rf, ok := ret.Get(0).(func(terra.ReleaseFilter) []terra.Release); ok {
-		r0 = rf(filter)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]terra.Release)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(terra.ReleaseFilter) error); ok {
-		r1 = rf(filter)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Releases_Filter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Filter'
-type Releases_Filter_Call struct {
-	*mock.Call
-}
-
-// Filter is a helper method to define mock.On call
-//   - filter terra.ReleaseFilter
-func (_e *Releases_Expecter) Filter(filter interface{}) *Releases_Filter_Call {
-	return &Releases_Filter_Call{Call: _e.mock.On("Filter", filter)}
-}
-
-func (_c *Releases_Filter_Call) Run(run func(filter terra.ReleaseFilter)) *Releases_Filter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(terra.ReleaseFilter))
-	})
-	return _c
-}
-
-func (_c *Releases_Filter_Call) Return(_a0 []terra.Release, _a1 error) *Releases_Filter_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Releases_Filter_Call) RunAndReturn(run func(terra.ReleaseFilter) ([]terra.Release, error)) *Releases_Filter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewReleases creates a new instance of Releases. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewReleases(t interface {

--- a/internal/thelma/state/api/terra/releases.go
+++ b/internal/thelma/state/api/terra/releases.go
@@ -4,6 +4,4 @@ package terra
 type Releases interface {
 	// All returns a list of all releases
 	All() ([]Release, error)
-	// Filter filters releases
-	Filter(filter ReleaseFilter) ([]Release, error)
 }

--- a/internal/thelma/state/providers/sherlock/destinations.go
+++ b/internal/thelma/state/providers/sherlock/destinations.go
@@ -35,15 +35,6 @@ func (d *destinations) All() ([]terra.Destination, error) {
 	return result, nil
 }
 
-func (d *destinations) Filter(filter terra.DestinationFilter) ([]terra.Destination, error) {
-	all, err := d.All()
-	if err != nil {
-		return nil, err
-	}
-
-	return filter.Filter(all), nil
-}
-
 func (d *destinations) Get(name string) (terra.Destination, error) {
 	if destination, exists := d.state.clusters[name]; exists {
 		return destination, nil

--- a/internal/thelma/state/providers/sherlock/environments.go
+++ b/internal/thelma/state/providers/sherlock/environments.go
@@ -26,15 +26,6 @@ func (e *environments) All() ([]terra.Environment, error) {
 	return result, nil
 }
 
-func (e *environments) Filter(filter terra.EnvironmentFilter) ([]terra.Environment, error) {
-	all, err := e.All()
-	if err != nil {
-		return nil, err
-	}
-
-	return filter.Filter(all), nil
-}
-
 func (e *environments) Get(name string) (terra.Environment, error) {
 	env, exists := e.state.environments[name]
 	if !exists {

--- a/internal/thelma/state/providers/sherlock/releases.go
+++ b/internal/thelma/state/providers/sherlock/releases.go
@@ -26,12 +26,3 @@ func (r *releases) All() ([]terra.Release, error) {
 
 	return result, nil
 }
-
-func (r *releases) Filter(filter terra.ReleaseFilter) ([]terra.Release, error) {
-	all, err := r.All()
-	if err != nil {
-		return nil, err
-	}
-
-	return filter.Filter(all), nil
-}

--- a/internal/thelma/state/providers/sherlock/state_exporter_writer.go
+++ b/internal/thelma/state/providers/sherlock/state_exporter_writer.go
@@ -19,23 +19,19 @@ func NewSherlockStateWriter(state terra.State, writer terra.StateWriter) *StateE
 
 func (s *StateExporterWriter) WriteEnvironments() error {
 	// Need to create template envs first as other envs that reference them will 404 in sherlock otherwise
-	templateEnvfilter := filter.Environments().HasLifecycle(terra.Template)
-
 	allEnvs, err := s.state.Environments().All()
 	if err != nil {
 		return err
 	}
 
-	templateEnvs := templateEnvfilter.Filter(allEnvs)
+	isTemplate := filter.Environments().IsTemplate()
+
+	templateEnvs := isTemplate.Filter(allEnvs)
 	if _, err = s.stateWriter.WriteEnvironments(templateEnvs); err != nil {
 		return err
 	}
 
-	allOtherEnvsFilter := filter.Environments().
-		Or(
-			filter.Environments().HasLifecycle(terra.Dynamic),
-			filter.Environments().HasLifecycle(terra.Static),
-		)
+	allOtherEnvsFilter := isTemplate.Negate()
 
 	allOtherEnvs := allOtherEnvsFilter.Filter(allEnvs)
 

--- a/internal/thelma/state/providers/sherlock/state_exporter_writer.go
+++ b/internal/thelma/state/providers/sherlock/state_exporter_writer.go
@@ -20,11 +20,14 @@ func NewSherlockStateWriter(state terra.State, writer terra.StateWriter) *StateE
 func (s *StateExporterWriter) WriteEnvironments() error {
 	// Need to create template envs first as other envs that reference them will 404 in sherlock otherwise
 	templateEnvfilter := filter.Environments().HasLifecycle(terra.Template)
-	templateEnvs, err := s.state.Environments().Filter(templateEnvfilter)
+
+	allEnvs, err := s.state.Environments().All()
 	if err != nil {
 		return err
 	}
-	if _, err := s.stateWriter.WriteEnvironments(templateEnvs); err != nil {
+
+	templateEnvs := templateEnvfilter.Filter(allEnvs)
+	if _, err = s.stateWriter.WriteEnvironments(templateEnvs); err != nil {
 		return err
 	}
 
@@ -34,7 +37,7 @@ func (s *StateExporterWriter) WriteEnvironments() error {
 			filter.Environments().HasLifecycle(terra.Static),
 		)
 
-	allOtherEnvs, err := s.state.Environments().Filter(allOtherEnvsFilter)
+	allOtherEnvs := allOtherEnvsFilter.Filter(allEnvs)
 
 	if err != nil {
 		return err

--- a/internal/thelma/state/testing/statefixtures/tests/statefixtures_test.go
+++ b/internal/thelma/state/testing/statefixtures/tests/statefixtures_test.go
@@ -63,16 +63,13 @@ func TestDefaultFixtureHasExpectedInitialState(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 17, len(envs))
 
-	lives, err := state.Environments().Filter(ef.HasBase("live"))
-	require.NoError(t, err)
+	lives := ef.HasBase("live").Filter(envs)
 	assert.Equal(t, len(lives), 5)
 
-	bees, err := state.Environments().Filter(ef.HasBase("bee"))
-	require.NoError(t, err)
+	bees := ef.HasBase("bee").Filter(envs)
 	assert.Equal(t, 9, len(bees))
 
-	personals, err := state.Environments().Filter(ef.HasBase("personal"))
-	require.NoError(t, err)
+	personals := ef.HasBase("personal").Filter(envs)
 	assert.Equal(t, 3, len(personals))
 
 	// make sure we have the expected number of clusters
@@ -81,62 +78,57 @@ func TestDefaultFixtureHasExpectedInitialState(t *testing.T) {
 	assert.Equal(t, 12, len(clusters))
 
 	// make sure we have the expected number of releases
-	sams, err := state.Releases().Filter(rf.HasName("sam"))
+	releases, err := state.Releases().All()
 	require.NoError(t, err)
+
+	sams := rf.HasName("sam").Filter(releases)
 	assert.Equal(t, 13, len(sams))
 
-	liveSams, err := state.Releases().Filter(rf.And(
+	liveSams := rf.And(
 		rf.HasName("sam"),
 		rf.DestinationMatches(df.HasBase("live")),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, 5, len(liveSams))
 
-	personalSams, err := state.Releases().Filter(rf.And(
+	personalSams := rf.And(
 		rf.HasName("sam"),
 		rf.DestinationMatches(df.HasBase("personal")),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, 0, len(personalSams))
 
-	swatBeeSams, err := state.Releases().Filter(rf.And(
+	swatBeeSams := rf.And(
 		rf.HasName("sam"),
 		rf.DestinationMatches(
 			df.IsEnvironmentMatching(ef.HasTemplateName("swatomation")),
 		),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, 4, len(swatBeeSams))
 
-	samciBeeSams, err := state.Releases().Filter(rf.And(
+	samciBeeSams := rf.And(
 		rf.HasName("sam"),
 		rf.DestinationMatches(
 			df.IsEnvironmentMatching(ef.HasTemplateName("sam-ci")),
 		),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, 2, len(samciBeeSams))
 
-	templateSams, err := state.Releases().Filter(rf.And(
+	templateSams := rf.And(
 		rf.HasName("sam"),
 		rf.DestinationMatches(
 			df.IsEnvironmentMatching(
 				ef.HasLifecycle(terra.Template),
 			),
 		),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, 2, len(templateSams))
 
-	rawlses, err := state.Releases().Filter(rf.HasName("rawls"))
-	require.NoError(t, err)
+	rawlses := rf.HasName("rawls").Filter(releases)
 	assert.Equal(t, 11, len(rawlses)) // 5 live, 1 template, 5 bees
 
-	datarepos, err := state.Releases().Filter(rf.HasName("datarepo"))
-	require.NoError(t, err)
+	datarepos := rf.HasName("datarepo").Filter(releases)
 	assert.Equal(t, 3, len(datarepos)) // 3 live (only in alpha, staging, prod)
 
-	externalcredses, err := state.Releases().Filter(rf.HasName("externalcreds"))
+	externalcredses := rf.HasName("externalcreds").Filter(releases)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(externalcredses)) // 2 live (only in dev and perf)
 }
@@ -152,68 +144,63 @@ func TestDefaultFixtureHasCorrectVersions(t *testing.T) {
 	state, err := app.State()
 	require.NoError(t, err)
 
+	releases, err := state.Releases().All()
+	require.NoError(t, err)
+
 	// test we have correct app and chart version for sam in 4 types of envs
-	devSam, err := state.Releases().Filter(rf.And(
+	devSam := rf.And(
 		rf.HasName("sam"),
 		rf.HasDestinationName("dev"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "2d309b1645a0", devSam[0].AppVersion())
 	assert.Equal(t, "0.34.0", devSam[0].ChartVersion())
 
-	prodSam, err := state.Releases().Filter(rf.And(
+	prodSam := rf.And(
 		rf.HasName("sam"),
 		rf.HasDestinationName("prod"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "8f69c32bd9fe", prodSam[0].AppVersion())
 	assert.Equal(t, "0.33.0", prodSam[0].ChartVersion())
 
-	chipmunkSam, err := state.Releases().Filter(rf.And(
+	chipmunkSam := rf.And(
 		rf.HasName("sam"),
 		rf.HasDestinationName("fiab-funky-chipmunk"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "2d309b1645a0", chipmunkSam[0].AppVersion())
 	assert.Equal(t, "0.34.0", chipmunkSam[0].ChartVersion())
 
-	walrusSam, err := state.Releases().Filter(rf.And(
+	walrusSam := rf.And(
 		rf.HasName("sam"),
 		rf.HasDestinationName("fiab-nerdy-walrus"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "1.2.3", walrusSam[0].AppVersion())
 	assert.Equal(t, "0.34.0", walrusSam[0].ChartVersion())
 
-	snowflakeSam, err := state.Releases().Filter(rf.And(
+	snowflakeSam := rf.And(
 		rf.HasName("sam"),
 		rf.HasDestinationName("fiab-special-snowflake"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, 0, len(snowflakeSam), "sam is disabled in fiab-special-snowflake")
 
-	snowflakeRawls, err := state.Releases().Filter(rf.And(
+	snowflakeRawls := rf.And(
 		rf.HasName("rawls"),
 		rf.HasDestinationName("fiab-special-snowflake"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "cead2f9206b5", snowflakeRawls[0].AppVersion())
 	assert.Equal(t, "100.200.300", snowflakeRawls[0].ChartVersion())
 	assert.Equal(t, "my-terra-helmfile-branch", snowflakeRawls[0].TerraHelmfileRef())
 	assert.Equal(t, "", snowflakeRawls[0].FirecloudDevelopRef())
 
-	paniniSam, err := state.Releases().Filter(rf.And(
+	paniniSam := rf.And(
 		rf.HasName("sam"),
 		rf.HasDestinationName("fiab-snarky-panini"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "some-pr", paniniSam[0].TerraHelmfileRef())
 
-	paniniRawls, err := state.Releases().Filter(rf.And(
+	paniniRawls := rf.And(
 		rf.HasName("rawls"),
 		rf.HasDestinationName("fiab-snarky-panini"),
-	))
-	require.NoError(t, err)
+	).Filter(releases)
 	assert.Equal(t, "completely-different-pr", paniniRawls[0].TerraHelmfileRef())
 
 	// test urp is loaded correctly


### PR DESCRIPTION
Since I'm touching Thelma, take a stab at [the first bullet in the Thelma state cleanup design doc](https://docs.google.com/document/d/1LDQwYbTJPzEpf-xHmXPNX7T0qJkdVy2xD23xELeNJf4/edit?usp=sharing). This task involves removing Filter() methods from the state interface, since they assume all state information is available locally.

### Testing

In addition to making sure the linter and unit tests pass, I created a Bee with my locally-compiled Thelma to make sure all worked as expected.