### PR TITLE
[DDO-3470] Bump Sherlock dependency to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/storage v1.33.0
 	github.com/alecthomas/chroma v0.10.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/broadinstitute/sherlock/sherlock-go-client v0.4.33
+	github.com/broadinstitute/sherlock/sherlock-go-client v1.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/broadinstitute/sherlock/sherlock-go-client v0.4.33 h1:1Wrp+uoA4cNT+wAy71qt/meOd7CwI2Px/j/jmBY7GPE=
-github.com/broadinstitute/sherlock/sherlock-go-client v0.4.33/go.mod h1:tESxIu0poc+JXljMji8LwCQP7CbXJc2L5GPT7Q18+WY=
+github.com/broadinstitute/sherlock/sherlock-go-client v1.0.0 h1:sw5lwElGWXI/KXdov2F10SS35rQuER6mOezpV2TqwzU=
+github.com/broadinstitute/sherlock/sherlock-go-client v1.0.0/go.mod h1:tESxIu0poc+JXljMji8LwCQP7CbXJc2L5GPT7Q18+WY=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=


### PR DESCRIPTION
Bump Thelma's usage of the client library to https://github.com/broadinstitute/sherlock/pull/484

## Testing

CI passes (so there's no usage of the removed stuff in the client library) so that's enough by me

## Risk

Very low