### PR TITLE
[DDO-3486] Retry initializing the GHA OIDC verifier

### DIFF
--- a/internal/thelma/clients/github/gha/oidc_verifier.go
+++ b/internal/thelma/clients/github/gha/oidc_verifier.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"time"
 )
 
 var verifier *oidc.IDTokenVerifier
@@ -13,7 +15,13 @@ func initOidcVerifier(validatingIssuer string) error {
 	if verifier == nil {
 		provider, err := oidc.NewProvider(context.Background(), validatingIssuer)
 		if err != nil {
-			return err
+			time.Sleep(time.Second)
+			provider, err = oidc.NewProvider(context.Background(), validatingIssuer)
+			if err != nil {
+				return err
+			} else {
+				log.Info().Msg("Thelma recovered from a transient error while initializing the GHA OIDC verifier.")
+			}
 		}
 
 		type extraConfigurationClaims struct {

--- a/internal/thelma/clients/github/gha/oidc_verifier.go
+++ b/internal/thelma/clients/github/gha/oidc_verifier.go
@@ -13,15 +13,9 @@ var verifier *oidc.IDTokenVerifier
 // initOidcVerifier will initialize the verifier if it hasn't been initialized yet.
 func initOidcVerifier(validatingIssuer string) error {
 	if verifier == nil {
-		provider, err := oidc.NewProvider(context.Background(), validatingIssuer)
+		provider, err := makeOidcProvider(context.Background(), validatingIssuer)
 		if err != nil {
-			time.Sleep(time.Second)
-			provider, err = oidc.NewProvider(context.Background(), validatingIssuer)
-			if err != nil {
-				return err
-			} else {
-				log.Info().Msg("Thelma recovered from a transient error while initializing the GHA OIDC verifier")
-			}
+			return err
 		}
 
 		type extraConfigurationClaims struct {
@@ -42,6 +36,22 @@ func initOidcVerifier(validatingIssuer string) error {
 		})
 	}
 	return nil
+}
+
+// makeOidcProvider creates an oidc.Provider that can be used to make an oidc.IDTokenVerifier.
+// It has some basic retry logic to handle truly transient errors.
+func makeOidcProvider(ctx context.Context, validatingIssuer string) (*oidc.Provider, error) {
+	provider, err := oidc.NewProvider(ctx, validatingIssuer)
+	if err != nil {
+		time.Sleep(time.Second)
+		provider, err = oidc.NewProvider(ctx, validatingIssuer)
+		if err != nil {
+			return nil, err
+		} else {
+			log.Info().Msg("Thelma recovered from a transient error while initializing the GHA OIDC provider")
+		}
+	}
+	return provider, nil
 }
 
 func verifyOidcToken(token []byte) error {

--- a/internal/thelma/clients/github/gha/oidc_verifier.go
+++ b/internal/thelma/clients/github/gha/oidc_verifier.go
@@ -20,7 +20,7 @@ func initOidcVerifier(validatingIssuer string) error {
 			if err != nil {
 				return err
 			} else {
-				log.Info().Msg("Thelma recovered from a transient error while initializing the GHA OIDC verifier.")
+				log.Info().Msg("Thelma recovered from a transient error while initializing the GHA OIDC verifier")
 			}
 		}
 


### PR DESCRIPTION
I'm not positive that this is the true error people are seeing, but it seems like a fine thing to harden in a simple way.

If there's an error, we wait a second, try again, and then act based on the error-ness of the second invocation. That should theoretically help with truly transient errors when the verifier tries to connect to GitHub's OIDC description endpoint.

## Testing

Uh, none, I'm not even sure how to test this. But it can't be worse than how it works now, in my opinion.

## Risk

Low?