### PR TITLE
[DDO-3575] ArgoCD plugin: always use --stdout

### DIFF
--- a/argocd/plugin.yaml
+++ b/argocd/plugin.yaml
@@ -11,7 +11,11 @@ spec:
   # https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#write-the-plugin-configuration-file
   generate:
     command: ["thelma", "render"]
-    args: ["--flags-from-environment-prefix=PARAM_"]
+    args:
+      # ArgoCD requires all plugins to return manifests (and nothing but manifests) to STDOUT
+      - "--stdout"
+      # Enable parsing other parameters below
+      - "--flags-from-environment-prefix=PARAM_"
   # Parameter declarations are for UI sugar only. They have no bearing on what actually gets passed to the Thelma:
   # even the `string` default values aren't passed, and it's up to Thelma to supply these defaults internally.
   #


### PR DESCRIPTION
I realized pretty quickly that since ArgoCD requires all plugins to use stdout, we always would need to set `PARAM_STDOUT=true` or the plugin would fail. Might as well specify the command line argument. 

The stdout parameter was already omitted in the plugin documentation because earlier-me was like "it'll always have the same value, no need to document it." I think it slipped my mind that the default is false.

## Testing

None (but this is a non-code change, this plugin isn't currently used)

## Risk

None