### PR TITLE
[DDO-3575] ArgoCD plugin: set THELMA_HOME to current working directory

### DIFF
--- a/internal/thelma/app/config/profiles/argocd.yaml
+++ b/internal/thelma/app/config/profiles/argocd.yaml
@@ -1,5 +1,10 @@
 # This file contains custom configuration for Thelma that can be set for running in ArgoCD
 
+# ArgoCD runs plugins in the "Applications"'s repository, which means terra-helmfile for us.
+# Rather than worrying about setting `THELMA_HOME=.` (actually difficult to do for a plugin),
+# we set it directly in config here.
+home: .
+
 autoupdate:
   # Don't auto-update on ArgoCD, that's unproven and for now we'll
   # control Thelma's version with the ArgoCD appVersion from Beehive


### PR DESCRIPTION
https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#write-the-plugin-configuration-file notes that plugins are always run from the root of the "Application"'s repository. For us, that'll always be configured as terra-helmfile. 

Rather than leaving up the gotcha of making sure we set `THELMA_HOME=.` or something in the Kubernetes sidecar config, I'm adding it to the argocd profile (which we still need to set manually, but one gotcha is better than two).

## Testing

None, profile unused (but note that [config.go](https://github.com/broadinstitute/thelma/blob/b82cb2fcef75098723c5d2f5dcb9c22f2941b097/internal/thelma/app/config/config.go#L104-L104) specifically allows setting this from config file and it resolves relative paths to absolute based on the current working directory)

## Risk

None