### PR TITLE
[DDO-3575] Move ArgoCD `--mode` logic into Thelma

### DIFF
--- a/argocd/plugin.yaml
+++ b/argocd/plugin.yaml
@@ -87,6 +87,16 @@ spec:
         required: false
         string: "false"
 
+      - name: mode
+        title: >-
+          Either "development" (use the ArgoCD git ref's terra-helmfile), "deploy" (use published chart versions), 
+          or "argocd-auto" (use "development" for a unique ArgoCD git ref, "deploy" otherwise). Defaults to 
+          "development" for backwards compatibility.
+        tooltip: String
+        itemType: string
+        required: false
+        string: "development"
+
       - name: scope
         title: One of "release" (release-scoped resources only), "destination" (environment-/cluster-wide resources, such as Argo project, only), or "all" (include both types) (default "all")
         tooltip: String

--- a/internal/thelma/cli/commands/render/render_command.go
+++ b/internal/thelma/cli/commands/render/render_command.go
@@ -3,6 +3,7 @@ package render
 import (
 	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
 	"github.com/pkg/errors"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -63,6 +64,11 @@ const defaultOutputDir = "output"
 
 // defaultChartSourceDir name of default chart source directory
 const defaultChartSourceDir = "charts"
+
+// modeArgocdAutoRefEnvVar is the environment variable that --mode=argocd-auto uses to determine the ref
+// of terra-helmfile. If it's a versioned or otherwise unique ref, it'll use --mode=development, otherwise
+// it'll use --mode=deploy.
+const modeArgocdAutoRefEnvVar = "ARGOCD_APP_SOURCE_TARGET_REVISION"
 
 // renderCommand contains state and configuration for executing a render from the command-line
 type renderCommand struct {
@@ -160,7 +166,7 @@ func (cmd *renderCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 	cobraCommand.Flags().BoolVar(&cmd.flagVals.stdout, flagNames.stdout, false, "Render manifests to stdout instead of output directory")
 	cobraCommand.Flags().BoolVar(&cmd.flagVals.debug, flagNames.debug, false, "Pass --debug to helmfile to render out invalid YAML for debugging")
 	cobraCommand.Flags().IntVar(&cmd.flagVals.parallelWorkers, flagNames.parallelWorkers, 1, "Number of parallel workers to launch when rendering")
-	cobraCommand.Flags().StringVar(&cmd.flagVals.mode, flagNames.mode, "development", `Either "development" (render from chart source directory) or "deploy" (render using released chart versions). Defaults to "development"`)
+	cobraCommand.Flags().StringVar(&cmd.flagVals.mode, flagNames.mode, "development", `Either "development" (render from chart source directory), "deploy" (render using released chart versions), or "argocd-auto" (use "development" when running on ArgoCD with a unique git ref, "deploy" otherwise). Defaults to "development"`)
 	cobraCommand.Flags().StringVar(&cmd.flagVals.scope, flagNames.scope, "all", `One of "release" (release-scoped resources only), "destination" (environment-/cluster-wide resources, such as Argo project, only), or "all" (include both types)`)
 	cobraCommand.Flags().StringVar(&cmd.flagVals.validate, flagNames.validate, "skip", `One of "skip" (no validation on render output), "warn" (print validation of render output but don't fail), or "fail" (exit with error if render output validation fails)`)
 	cobraCommand.Flags().BoolVar(&cmd.flagVals.exitZeroNoMatchingReleases, flagNames.exitZeroNoMatchingReleases, false, `Use to make Thelma exit with status code 0 if no chart releases match command-line arguments. Useful for CI/CD pipelines.`)
@@ -304,8 +310,20 @@ func (cmd *renderCommand) fillRenderOptions(selection *selector.RenderSelection,
 		renderOptions.ResolverMode = resolver.Development
 	case "deploy":
 		renderOptions.ResolverMode = resolver.Deploy
+	case "argocd-auto":
+		// Logic inherited from https://github.com/broadinstitute/terra-helmfile/blob/fd939dc4a127020f595b4e50a4d58694b757232e/charts/dsp-argocd/plugin-scripts/terra-helmfile-app.sh#L42
+		renderOptions.ResolverMode = resolver.Development
+		argocdRef, argocdRefPresent := os.LookupEnv(modeArgocdAutoRefEnvVar)
+		if argocdRefPresent {
+			for _, unversionedRef := range []string{"", "master", "main", "HEAD"} {
+				if argocdRef == unversionedRef {
+					renderOptions.ResolverMode = resolver.Deploy
+					break
+				}
+			}
+		}
 	default:
-		return errors.Errorf(`invalid value for --%s (must be "development" or "deploy"): %v`, flagNames.mode, flagVals.mode)
+		return errors.Errorf(`invalid value for --%s (must be "development", "deploy", or "argocd-auto"): %v`, flagNames.mode, flagVals.mode)
 	}
 
 	// validate mode


### PR DESCRIPTION
Adds a `thelma render --mode=argocd-auto` flag with [logic](https://github.com/broadinstitute/thelma/pull/285/files#diff-b5649879a47c4894e58600c6f28ac624840f30770280f130d6d9eb6a74b269dfR313) that exactly mirrors what the [bash shim](https://github.com/broadinstitute/terra-helmfile/blob/master/charts/dsp-argocd/plugin-scripts/terra-helmfile-app.sh#L42) does today.

## Testing

Added test cases to the render command test function.

## Risk

Very low, additive non-default behavior