### PR TITLE
[DDO-3575] Disable output coloring on ArgoCD

### DIFF
--- a/internal/thelma/app/config/profiles/argocd.yaml
+++ b/internal/thelma/app/config/profiles/argocd.yaml
@@ -30,6 +30,7 @@ iap:
 logging:
   console:
     level: info
+    color: false
   file:
     enabled: false
 

--- a/internal/thelma/app/logging/logging.go
+++ b/internal/thelma/app/logging/logging.go
@@ -32,6 +32,8 @@ type logConfig struct {
 		Level string `default:"info" validate:"oneof=trace debug info warn error"`
 		// WordWrap if true, wrap long log lines at word boundary to max terminal width
 		WordWrap bool `default:"true"`
+		// Color if true, colorize console output
+		Color bool `default:"true"`
 	}
 	File struct {
 		// Log
@@ -179,6 +181,7 @@ func newConsoleWriter(cfg *logConfig, consoleStream io.Writer) zerolog.LevelWrit
 		w.Out = outputStream
 		w.TimeFormat = consoleTimeFormatter
 		w.FieldsExclude = []string{pidField}
+		w.NoColor = !cfg.Console.Color
 	})
 
 	return NewFilteredWriter(zerolog.MultiLevelWriter(consoleWriter), parseLogLevel(cfg.Console.Level))


### PR DESCRIPTION
ArgoCD doesn't strip the back color markers from the output it shows, which makes Thelma's output really hard to read. I'm having to do that a lot to get it working in super-prod so I'd like to split this change out now to make it a bit easier.

## Testing

I felt that manual testing was sufficient for a change as trivial as this -- I didn't want to spend the time trying to figure out how to capture and test for bash color codes. I checked default behavior, explicit true, and explicit false (the latter two using `THELMA_LOGGING_CONSOLE_COLOR`).

## Risk

Low, by default there's no change and this just affects the `argocd` profile that's in use in super-prod.