### PR TITLE
[DDO-3575] Various tweaks for super-prod ArgoCD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,17 @@ COPY output/releases/${THELMA_LINUX_RELEASE} .
 # Include ArgoCD plugin.yaml
 # https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#place-the-plugin-configuration-file-in-the-sidecar
 COPY argocd/plugin.yaml /home/argocd/cmp-server/config/
+
+# ArgoCD plugins always run as UID 999. This is set by Kubernetes, so no need to make it the default here,
+# but Thelma does attempt to use the home directory *a lot*, and we need to have the 999 user not have /
+# as its home directory (because 999 isn't root, so it can't modify /). Normally we'd just create a new
+# user with `adduser -u 999 argocd-thelma`, but `adduser` refuses because it'll say that 999 is taken.
+# 999 isn't defined in any of the /etc files, though, so to set its home directory we manually add lines
+# to those files.
+RUN mkdir /home/argocd-thelma
 RUN echo 'argocd-thelma:!::0:::::' >> /etc/shadow
 RUN echo 'argocd-thelma:x:999:' >> /etc/group
 RUN echo 'argocd-thelma:x:999:999:argocd-thelma:/home/argocd-thelma:/bin/nologin' >> /etc/passwd
-RUN mkdir /home/argocd-thelma
 RUN chown 999:999 /home/argocd-thelma
 
 # OS updates for security

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ COPY output/releases/${THELMA_LINUX_RELEASE} .
 # Include ArgoCD plugin.yaml
 # https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#place-the-plugin-configuration-file-in-the-sidecar
 COPY argocd/plugin.yaml /home/argocd/cmp-server/config/
+RUN echo 'argocd-thelma:!::0:::::' >> /etc/shadow
+RUN echo 'argocd-thelma:x:999:' >> /etc/group
+RUN echo 'argocd-thelma:x:999:999:/home/argocd-thelma:/sbin/nologin' >> /etc/passwd
+RUN mkdir /home/argocd-thelma
+RUN chown 999:999 /home/argocd-thelma
 
 # OS updates for security
 RUN apk update

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY output/releases/${THELMA_LINUX_RELEASE} .
 COPY argocd/plugin.yaml /home/argocd/cmp-server/config/
 RUN echo 'argocd-thelma:!::0:::::' >> /etc/shadow
 RUN echo 'argocd-thelma:x:999:' >> /etc/group
-RUN echo 'argocd-thelma:x:999:999:/home/argocd-thelma:/sbin/nologin' >> /etc/passwd
+RUN echo 'argocd-thelma:x:999:999:/home/argocd-thelma:/bin/sh' >> /etc/passwd
 RUN mkdir /home/argocd-thelma
 RUN chown 999:999 /home/argocd-thelma
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY output/releases/${THELMA_LINUX_RELEASE} .
 COPY argocd/plugin.yaml /home/argocd/cmp-server/config/
 RUN echo 'argocd-thelma:!::0:::::' >> /etc/shadow
 RUN echo 'argocd-thelma:x:999:' >> /etc/group
-RUN echo 'argocd-thelma:x:999:999:/home/argocd-thelma:/bin/sh' >> /etc/passwd
+RUN echo 'argocd-thelma:x:999:999:argocd-thelma:/home/argocd-thelma:/bin/nologin' >> /etc/passwd
 RUN mkdir /home/argocd-thelma
 RUN chown 999:999 /home/argocd-thelma
 

--- a/internal/thelma/app/config/profiles/argocd.yaml
+++ b/internal/thelma/app/config/profiles/argocd.yaml
@@ -23,9 +23,8 @@ google:
       verifybroademail: false
 
 iap:
-  # Use Google auth to generate IAP tokens (will work since the Google
-  # auth is via a service account)
-  provider: google
+  # Use Workload Identity directly to generate ID tokens for IAP
+  provider: workloadidentity
 
 logging:
   console:

--- a/internal/thelma/cli/environmentflags/parse_from_environment.go
+++ b/internal/thelma/cli/environmentflags/parse_from_environment.go
@@ -56,7 +56,9 @@ func SetFlagsFromEnvironment(flags *pflag.FlagSet) []error {
 
 			// If the environment variable is set, even if it's empty, we'll set the flag.
 			if value, present := os.LookupEnv(envVar); present {
-				if flagSetErr := flag.Value.Set(value); flagSetErr != nil {
+				// We use flags.Set instead of flag.Value.Set because the latter doesn't set
+				// the flag as "changed", which is important for how we validate inputs.
+				if flagSetErr := flags.Set(flag.Name, value); flagSetErr != nil {
 					// Include the value in the error message for better debugging; this is
 					// safe enough because we don't accept secret values from flags.
 					errs = append(errs, errors.Wrapf(flagSetErr,

--- a/internal/thelma/cli/environmentflags/parse_from_environment_test.go
+++ b/internal/thelma/cli/environmentflags/parse_from_environment_test.go
@@ -38,34 +38,46 @@ func restoreEnvVars() error {
 
 func TestSetFlagsFromEnvironment(t *testing.T) {
 	testCases := []struct {
-		name         string
-		args         []string
-		envVars      map[string]string
-		expectErrors []string
-		expectString string
-		expectBool   bool
-		expectInt    int
-		expectSlice  []string
+		name                string
+		args                []string
+		envVars             map[string]string
+		expectErrors        []string
+		expectString        string
+		expectStringChanged bool
+		expectBool          bool
+		expectBoolChanged   bool
+		expectInt           int
+		expectIntChanged    bool
+		expectSlice         []string
+		expectSliceChanged  bool
 	}{
 		{
-			name:         "base case",
-			args:         []string{},
-			envVars:      map[string]string{},
-			expectErrors: nil,
-			expectString: "default",
-			expectBool:   true,
-			expectInt:    1,
-			expectSlice:  []string{"list"},
+			name:                "base case",
+			args:                []string{},
+			envVars:             map[string]string{},
+			expectErrors:        nil,
+			expectString:        "default",
+			expectStringChanged: false,
+			expectBool:          true,
+			expectBoolChanged:   false,
+			expectInt:           1,
+			expectIntChanged:    false,
+			expectSlice:         []string{"list"},
+			expectSliceChanged:  false,
 		},
 		{
-			name:         "set all on command line",
-			args:         Args("--test-string=blah --test-bool=false --test-int=2 --test-string-slice=foo,bar"),
-			envVars:      map[string]string{},
-			expectErrors: nil,
-			expectString: "blah",
-			expectBool:   false,
-			expectInt:    2,
-			expectSlice:  []string{"foo", "bar"},
+			name:                "set all on command line",
+			args:                Args("--test-string=blah --test-bool=false --test-int=2 --test-string-slice=foo,bar"),
+			envVars:             map[string]string{},
+			expectErrors:        nil,
+			expectString:        "blah",
+			expectStringChanged: true,
+			expectBool:          false,
+			expectBoolChanged:   true,
+			expectInt:           2,
+			expectIntChanged:    true,
+			expectSlice:         []string{"foo", "bar"},
+			expectSliceChanged:  true,
 		},
 		{
 			name: "set all in environment",
@@ -76,11 +88,15 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_INT":          "2",
 				"THELMA_TEST_PARAM_TEST_STRING_SLICE": "foo,bar",
 			},
-			expectErrors: nil,
-			expectString: "blah",
-			expectBool:   false,
-			expectInt:    2,
-			expectSlice:  []string{"foo", "bar"},
+			expectErrors:        nil,
+			expectString:        "blah",
+			expectStringChanged: true,
+			expectBool:          false,
+			expectBoolChanged:   true,
+			expectInt:           2,
+			expectIntChanged:    true,
+			expectSlice:         []string{"foo", "bar"},
+			expectSliceChanged:  true,
 		},
 		{
 			name: "cli takes precedence over environment",
@@ -91,11 +107,15 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_INT":          "3",
 				"THELMA_TEST_PARAM_TEST_STRING_SLICE": "baz",
 			},
-			expectErrors: nil,
-			expectString: "blah",
-			expectBool:   false,
-			expectInt:    2,
-			expectSlice:  []string{"foo", "bar"},
+			expectErrors:        nil,
+			expectString:        "blah",
+			expectStringChanged: true,
+			expectBool:          false,
+			expectBoolChanged:   true,
+			expectInt:           2,
+			expectIntChanged:    true,
+			expectSlice:         []string{"foo", "bar"},
+			expectSliceChanged:  true,
 		},
 		{
 			name: "mixed",
@@ -104,11 +124,15 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_BOOL": "true",
 				"THELMA_TEST_PARAM_TEST_INT":  "2",
 			},
-			expectErrors: nil,
-			expectString: "blah",           // CLI, uncontested
-			expectBool:   false,            // CLI, precedence over env
-			expectInt:    2,                // env, uncontested
-			expectSlice:  []string{"list"}, // default
+			expectErrors:        nil,
+			expectString:        "blah", // CLI, uncontested
+			expectStringChanged: true,
+			expectBool:          false, // CLI, precedence over env
+			expectBoolChanged:   true,
+			expectInt:           2, // env, uncontested
+			expectIntChanged:    true,
+			expectSlice:         []string{"list"}, // default
+			expectSliceChanged:  false,
 		},
 		{
 			name: "ignores spurious env vars",
@@ -120,11 +144,15 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_test_string":        "blah", // wrong name transform
 				"THELMA_TEST_PARAM_TEST-STRING":        "blah", // wrong name transform
 			},
-			expectErrors: nil,
-			expectString: "default",
-			expectBool:   true,
-			expectInt:    1,
-			expectSlice:  []string{"list"},
+			expectErrors:        nil,
+			expectString:        "default",
+			expectStringChanged: false,
+			expectBool:          true,
+			expectBoolChanged:   false,
+			expectInt:           1,
+			expectIntChanged:    false,
+			expectSlice:         []string{"list"},
+			expectSliceChanged:  false,
 		},
 		{
 			name: "errors upon bool type coercion",
@@ -133,7 +161,7 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_BOOL": "not a bool",
 			},
 			expectErrors: []string{
-				"failed to set --test-bool from environment variable THELMA_TEST_PARAM_TEST_BOOL with value `not a bool`: strconv.ParseBool: parsing \"not a bool\": invalid syntax",
+				"failed to set --test-bool from environment variable THELMA_TEST_PARAM_TEST_BOOL with value `not a bool`: invalid argument \"not a bool\" for \"--test-bool\" flag: strconv.ParseBool: parsing \"not a bool\": invalid syntax",
 			},
 		},
 		{
@@ -143,7 +171,7 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_BOOL": "",
 			},
 			expectErrors: []string{
-				"failed to set --test-bool from environment variable THELMA_TEST_PARAM_TEST_BOOL with value ``: strconv.ParseBool: parsing \"\": invalid syntax",
+				"failed to set --test-bool from environment variable THELMA_TEST_PARAM_TEST_BOOL with value ``: invalid argument \"\" for \"--test-bool\" flag: strconv.ParseBool: parsing \"\": invalid syntax",
 			},
 		},
 		{
@@ -153,7 +181,7 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_INT": "not an int",
 			},
 			expectErrors: []string{
-				"failed to set --test-int from environment variable THELMA_TEST_PARAM_TEST_INT with value `not an int`: strconv.ParseInt: parsing \"not an int\": invalid syntax",
+				"failed to set --test-int from environment variable THELMA_TEST_PARAM_TEST_INT with value `not an int`: invalid argument \"not an int\" for \"--test-int\" flag: strconv.ParseInt: parsing \"not an int\": invalid syntax",
 			},
 		},
 		{
@@ -163,7 +191,7 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 				"THELMA_TEST_PARAM_TEST_INT": "",
 			},
 			expectErrors: []string{
-				"failed to set --test-int from environment variable THELMA_TEST_PARAM_TEST_INT with value ``: strconv.ParseInt: parsing \"\": invalid syntax",
+				"failed to set --test-int from environment variable THELMA_TEST_PARAM_TEST_INT with value ``: invalid argument \"\" for \"--test-int\" flag: strconv.ParseInt: parsing \"\": invalid syntax",
 			},
 		},
 		{
@@ -172,11 +200,15 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 			envVars: map[string]string{
 				"THELMA_TEST_PARAM_TEST_STRING": "",
 			},
-			expectErrors: nil,
-			expectString: "",
-			expectBool:   true,
-			expectInt:    1,
-			expectSlice:  []string{"list"},
+			expectErrors:        nil,
+			expectString:        "",
+			expectStringChanged: true,
+			expectBool:          true,
+			expectBoolChanged:   false,
+			expectInt:           1,
+			expectIntChanged:    false,
+			expectSlice:         []string{"list"},
+			expectSliceChanged:  false,
 		},
 		{
 			name: "string slice accepts empty",
@@ -184,11 +216,15 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 			envVars: map[string]string{
 				"THELMA_TEST_PARAM_TEST_STRING_SLICE": ",,,",
 			},
-			expectErrors: nil,
-			expectString: "default",
-			expectBool:   true,
-			expectInt:    1,
-			expectSlice:  []string{"", "", "", ""},
+			expectErrors:        nil,
+			expectString:        "default",
+			expectStringChanged: false,
+			expectBool:          true,
+			expectBoolChanged:   false,
+			expectInt:           1,
+			expectIntChanged:    false,
+			expectSlice:         []string{"", "", "", ""},
+			expectSliceChanged:  true,
 		},
 	}
 
@@ -225,15 +261,19 @@ func TestSetFlagsFromEnvironment(t *testing.T) {
 			gotString, err := flags.GetString("test-string")
 			assert.Equal(t, testCase.expectString, gotString)
 			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectStringChanged, flags.Changed("test-string"))
 			gotBool, err := flags.GetBool("test-bool")
 			assert.Equal(t, testCase.expectBool, gotBool)
 			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectBoolChanged, flags.Changed("test-bool"))
 			gotInt, err := flags.GetInt("test-int")
 			assert.Equal(t, testCase.expectInt, gotInt)
 			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectIntChanged, flags.Changed("test-int"))
 			gotSlice, err := flags.GetStringSlice("test-string-slice")
 			assert.Equal(t, testCase.expectSlice, gotSlice)
 			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectSliceChanged, flags.Changed("test-string-slice"))
 		})
 	}
 }


### PR DESCRIPTION
- Use `workloadidentity` for IAP (`google` works too but requires the SA to have `roles/iam.serviceAccountOpenIdTokenCreator` on itself)
- Check for ArgoCD environment variables before trying to access the process owner ([ArgoCD sidecar plugins run as user 999](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#register-the-plugin-sidecar:~:text=Make%20sure%20that%20sidecar%20container%20is%20running%20as%20user%20999), which is unexpected enough that `user.Current()` has trouble -- checking for the environment variable first will bail us out before we get to that part)
- Use `flags.Set(name, value)` instead of `flag.Value.Set(value)` when parsing flags from the environment because the former actually makes `flags.Changed(name)` work while the latter doesn't touch it (which leads to an impressively unintuitive state where the flag has a nondefault value but Cobra reports it as not having changed)
  - Altered all test cases in `parse_from_environment_test.go` to check for this issue
- Add a home directory for the 999 UID that ArgoCD will run Thelma as so that it can write to ~ (if we don't do this, ~ resolves to /, which causes permissions errors upon non-root writes)
  - Documentation in-line for why we're editing /etc files directly
  - Regression-tested Docker image behavior via https://github.com/broadinstitute/terra-helmfile/pull/5373 