### PR TITLE
[DDO-3660] Retry BEE env generator creation

### DIFF
--- a/internal/thelma/bee/bee_test.go
+++ b/internal/thelma/bee/bee_test.go
@@ -278,7 +278,13 @@ func (suite *BeesTestSuite) expectProvisionBeeNamespaceAndGenerator() {
 	myBeeGenerator := argocd_names.GeneratorName(suite.env)
 
 	// wait for terra-<name>-generator to exist
-	suite.mocks.argocd.EXPECT().WaitExist(myBeeGenerator).Return(nil)
+	suite.mocks.argocd.EXPECT().WaitExist(myBeeGenerator, mock.MatchedBy(func(opt argocd.WaitExistOption) bool {
+		var opts argocd.WaitExistOptions
+		opt(&opts)
+		assert.Equal(suite.T(), 60, opts.WaitExistTimeoutSeconds)
+		assert.Equal(suite.T(), 10, opts.WaitExistPollIntervalSeconds)
+		return true
+	})).Return(nil)
 
 	// sync terra-<name>-generator
 	suite.mocks.argocd.EXPECT().SyncApp(myBeeGenerator).Return(argocd.SyncResult{Synced: true}, nil)


### PR DESCRIPTION
Previously, we would hard refresh `terra-bee-generator` once and subsequently poll ArgoCD for 5 minutes to wait for the BEE's env generator had been created. Since the superprod migration, this step in the process has run into timeouts ([example](https://broadinstitute.slack.com/archives/CADM7MZ35/p1715088339735119)). See discussion [here](https://broadinstitute.slack.com/archives/CADM7MZ35/p1714398509502089) as well.

This PR attempts to address the issue by wrapping the refresh-poll step in up to 10 retries, and timing out the polling after 1 minute instead of 5 in order to force a hard refresh.

### Testing

I was able to create a BEE running local Thelma off this PR. This PR also includes unit test updates.