### PR TITLE
[DDO-3664] Some adjustments to ArgoCD retry behavior

### DIFF
--- a/internal/thelma/toolbox/argocd/argocd_test.go
+++ b/internal/thelma/toolbox/argocd/argocd_test.go
@@ -187,7 +187,7 @@ func Test_SyncRelease(t *testing.T) {
 
 	_mocks.expectCmd("app", "wait", "leonardo-configs-dev", "--operation", "--timeout", "300")
 
-	_mocks.expectCmd("app", "sync", "leonardo-configs-dev", "--retry-limit", "4", "--prune", "--timeout", "600")
+	_mocks.expectCmd("app", "sync", "leonardo-configs-dev", "--retry-limit", "4", "--prune", "--timeout", "900")
 
 	_mocks.expectCmd("app", "wait", "leonardo-configs-dev", "--timeout", "900", "--health")
 
@@ -198,7 +198,7 @@ func Test_SyncRelease(t *testing.T) {
 
 	_mocks.expectCmd("app", "wait", "leonardo-dev", "--operation", "--timeout", "300")
 
-	_mocks.expectCmd("app", "sync", "leonardo-dev", "--retry-limit", "4", "--prune", "--timeout", "600")
+	_mocks.expectCmd("app", "sync", "leonardo-dev", "--retry-limit", "4", "--prune", "--timeout", "900")
 
 	_mocks.expectCmd("app", "wait", "leonardo-dev", "--timeout", "900", "--health")
 
@@ -260,20 +260,12 @@ func Test_isRetryableError(t *testing.T) {
 		exp bool
 	}{
 		{
-			msg: "not retryable",
+			msg: "is retryable",
+			exp: true,
+		},
+		{
+			msg: "rpc error: code = Canceled desc = context canceled",
 			exp: false,
-		},
-		{
-			msg: "error communicating with server: EOF",
-			exp: true,
-		},
-		{
-			msg: "dial tcp 140.82.113.3:443: i/o timeout (Client.Timeout exceeded while awaiting headers)",
-			exp: true,
-		},
-		{
-			msg: `rpc error: code = Unknown desc = Post "https://argocd.dsp-devops-prod.broadinstitute.org:443/application.ApplicationService/Get": "dial tcp: lookup argocd.dsp-devops-prod.broadinstitute.org on 169.254.169.254:53: read udp 172.17.0.1:59204->169.254.169.254:53: i/o timeout"`,
-			exp: true,
 		},
 	}
 


### PR DESCRIPTION
This PR makes the following adjustments to Thelma's ArgoCD retry logic:
* **Bump sync operation timeout from 10 minutes to 15 minutes**. We've seen lots of sync operation timeouts lately that in [some cases](https://broadinstitute.slack.com/archives/CADM7MZ35/p1715088927043469) are non-fatal (the sync terminates eventually); this gives the BEE sync a bit longer to complete while we continue optimizing the server.
* **Retry all failed commands by default** instead of the previous behavior, which was retrying a specific list of known errors. This will specifically catch the 500 errors we've seen lately, and also allows us to stop playing whackamole if ArgoCD upgrades and the client error messages change. For 90% of calls this is harmless; I added an exception for timeout errors, because if we time out after 20 minutes waiting for healthy, we don't want to retry that 20 minute wait 3 more times.

### Testing

This PR includes unit test updates; I also was able to create a BEE locally.