### PR TITLE
[DDO-3687] [DDO-3788] Fixes for local Thelma browser auth

### DIFF
--- a/internal/thelma/clients/iap/browser-provider.go
+++ b/internal/thelma/clients/iap/browser-provider.go
@@ -176,7 +176,8 @@ func useBrowserForAuthorizationCode(config *oauth2.Config, runner shell.Runner, 
 
 	var authorizationCode string
 
-	http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Query().Get("code") == "" {
 			// Browsers insist on looking for a /favicon.ico, so ignore it silently
 			writer.WriteHeader(http.StatusBadRequest)
@@ -197,7 +198,7 @@ func useBrowserForAuthorizationCode(config *oauth2.Config, runner shell.Runner, 
 		}
 	})
 
-	redirectServer := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+	redirectServer := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
 	go func() {
 		// We actually do want to precisely compare errors here, we're outputting at the trace level anyway
 		//goland:noinspection GoDirectComparisonOfErrors

--- a/internal/thelma/toolbox/argocd/argocd.go
+++ b/internal/thelma/toolbox/argocd/argocd.go
@@ -67,6 +67,9 @@ var unretryableErrors = []*regexp.Regexp{
 	// don't retry commands that fail with a timeout error, whatever we were waiting for (sync to finish, app to
 	// become healthy) did not finish successfully within the desired timeout.
 	regexp.MustCompile(regexp.QuoteMeta("rpc error: code = Canceled")),
+	// don't retry commands that fail with a 401, because we actually use 401s from ArgoCD to indicate that we
+	// need to re-run ArgoCD auth process -- if we retry, it seems to the user like Thelma is hanging.
+	regexp.MustCompile(regexp.QuoteMeta("failed with status code 401")),
 }
 
 // SyncOptions options for an ArgoCD sync operation


### PR DESCRIPTION
# [DDO-3687] Thelma shouldn't panic when trying to open the browser for multiple IAP credentials at once

1. Thelma mutexes usage of the browser / local server pairing for getting IAP credentials -- it runs sequentially for authenticating to different project. `credentials.TokenProvider`'s got a ton of concurrency control already so blocking like this in an issuer function is fine 
2. Thelma sets up each local server instance using a local mux router, not the default global one (this is actually the issue @mflinn-broad was hitting, but the first fix still improves UX because now there's not a flurry of browser windows)

## Testing

Local; deleted my credentials folder and ran it.

## Risk

Very low

# [DDO-3688] Thelma shouldn't retry 401s from ArgoCD, it should re-issue the token immediately

https://github.com/broadinstitute/thelma/pull/297 did such a great job of retrying everything that it even retries the fully-expected-to-error "is my auth valid" request to ArgoCD that's embedded in the ArgoCD client. The full error looks like this:

```
10:27 DBG argocd cli command failed, will retry up to 4 times error="Command \"ARGOCD_SERVER=argocd.dsp-devops-prod.broadinstitute.org argocd --header Proxy-Authorization: Bearer ****** --grpc-web account get-user-info --output yaml\" exited with status 1:\ntime=\"2024-05-15T10:27:56-04:00\" level=fatal msg=\"rpc error: code = Unknown desc = POST \
          https://argocd.dsp-devops-prod.broadinstitute.org/cluster.SettingsService/Get failed with status code 401\"\n"

```

I'm adding `failed with status code 401` to the list of things Thelma won't retry, it seems safe, I checked Chelsea's pull request and we weren't previously retrying anything like that.

## Testing

Local; deleted my credentials folder and ran it.

## Risk

Very low.

[DDO-3687]: https://broadworkbench.atlassian.net/browse/DDO-3687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDO-3688]: https://broadworkbench.atlassian.net/browse/DDO-3688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ