### PR TITLE
[DDO-3692] Fix bug preventing some BEEs from being shut down

### DIFF
--- a/internal/thelma/utils/schedule/schedule.go
+++ b/internal/thelma/utils/schedule/schedule.go
@@ -1,6 +1,8 @@
 package schedule
 
-import "time"
+import (
+	"time"
+)
 
 // CheckDailyScheduleMatch determines if the `schedule` time's daily repetition happened between `since` and `now`.
 // We assume that `since` is before `now`.
@@ -16,9 +18,11 @@ import "time"
 // This edge case handling is correct in all cases because this function is concerned just with daily repetitions.
 // We could brute-force check all possible dates here and this function wouldn't be incorrect.
 func CheckDailyScheduleMatch(schedule time.Time, since time.Time, now time.Time) bool {
-	scheduleToUse := replaceDateOfTime(schedule, now)
+	scheduleLocalized := schedule.In(now.Location())
+	scheduleToUse := replaceDateOfTime(scheduleLocalized, now)
+
 	if scheduleToUse.After(now) {
-		scheduleToUse = replaceDateOfTime(schedule, since)
+		scheduleToUse = replaceDateOfTime(scheduleLocalized, since)
 	}
 	return scheduleToUse.After(since) && scheduleToUse.Before(now)
 }

--- a/internal/thelma/utils/schedule/schedule_test.go
+++ b/internal/thelma/utils/schedule/schedule_test.go
@@ -99,6 +99,24 @@ func TestCheckDailyScheduleMatch(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "thelma in UTC, schedule in PT - positive",
+			args: args{
+				schedule: testTimeFactory(t, "2000-01-01T18:00:00-08:00"),
+				since:    testTimeFactory(t, "2023-02-25T01:45:00-00:00"),
+				now:      testTimeFactory(t, "2023-02-25T02:15:00-00:00"),
+			},
+			want: true,
+		},
+		{
+			name: "thelma in UTC, schedule in PT - negative",
+			args: args{
+				schedule: testTimeFactory(t, "2000-01-01T18:00:00-08:00"),
+				since:    testTimeFactory(t, "2023-02-25T00:45:00-00:00"),
+				now:      testTimeFactory(t, "2023-02-25T01:15:00-00:00"),
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
@jyang-broad and I discovered a bug in the BEE apply schedule job where BEEs with west coast working hours schedules (offline at 9pm EST or later) are never shut off. This appears to be due to a time zone comparison issue. Schedules are in the BEE creator's local time zone, and Thelma-in-GHA runs in UTC, causing a subset of the date comparisons to fail.