### PR TITLE
Add support for propagating --kube-version flag down to helmfile template executions

### DIFF
--- a/internal/thelma/cli/commands/render/render_command.go
+++ b/internal/thelma/cli/commands/render/render_command.go
@@ -1,11 +1,12 @@
 package render
 
 import (
-	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
-	"github.com/pkg/errors"
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/broadinstitute/thelma/internal/thelma/charts/source"
+	"github.com/pkg/errors"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
@@ -95,6 +96,7 @@ var flagNames = struct {
 	scope                      string
 	validate                   string
 	exitZeroNoMatchingReleases string
+	kubeVersion                string
 }{
 	argocd:                     "argocd",
 	chartDir:                   "chart-dir",
@@ -110,6 +112,7 @@ var flagNames = struct {
 	scope:                      "scope",
 	validate:                   "validate",
 	exitZeroNoMatchingReleases: "exit-zero-no-matching-releases",
+	kubeVersion:                "kube-version",
 }
 
 // flagValues is a struct for capturing flag values that are parsed by Cobra.
@@ -128,6 +131,7 @@ type flagValues struct {
 	scope                      string
 	validate                   string
 	exitZeroNoMatchingReleases bool
+	kubeVersion                string
 }
 
 // NewRenderCommand constructs a new renderCommand
@@ -170,6 +174,7 @@ func (cmd *renderCommand) ConfigureCobra(cobraCommand *cobra.Command) {
 	cobraCommand.Flags().StringVar(&cmd.flagVals.scope, flagNames.scope, "all", `One of "release" (release-scoped resources only), "destination" (environment-/cluster-wide resources, such as Argo project, only), or "all" (include both types)`)
 	cobraCommand.Flags().StringVar(&cmd.flagVals.validate, flagNames.validate, "skip", `One of "skip" (no validation on render output), "warn" (print validation of render output but don't fail), or "fail" (exit with error if render output validation fails)`)
 	cobraCommand.Flags().BoolVar(&cmd.flagVals.exitZeroNoMatchingReleases, flagNames.exitZeroNoMatchingReleases, false, `Use to make Thelma exit with status code 0 if no chart releases match command-line arguments. Useful for CI/CD pipelines.`)
+	cobraCommand.Flags().StringVar(&cmd.flagVals.kubeVersion, flagNames.kubeVersion, "1.25.0", "Kubernetes version to pass to helmfile template --kube-version flag")
 
 	// Single-chart flags -- these can only be used for renders of a single chart
 	cobraCommand.Flags().StringVar(&cmd.flagVals.chartVersion, flagNames.chartVersion, "", "Override chart version")
@@ -284,6 +289,9 @@ func (cmd *renderCommand) fillRenderOptions(selection *selector.RenderSelection,
 
 	// debug mode
 	renderOptions.DebugMode = flagVals.debug
+
+	// kubeVersion
+	renderOptions.KubeVersion = flagVals.kubeVersion
 
 	// parallelWorkers
 	if flags.Changed(flagNames.parallelWorkers) && flags.Changed(flagNames.stdout) {

--- a/internal/thelma/cli/commands/render/render_command_test.go
+++ b/internal/thelma/cli/commands/render/render_command_test.go
@@ -1,14 +1,15 @@
 package render
 
 import (
-	"github.com/broadinstitute/thelma/internal/thelma/app"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"regexp"
 	"sort"
 	"testing"
+
+	"github.com/broadinstitute/thelma/internal/thelma/app"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app/builder"
 	"github.com/broadinstitute/thelma/internal/thelma/cli"
@@ -531,6 +532,14 @@ func TestRenderArgParsing(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			description: "--kube-version should set kube version",
+			arguments:   Args("render --kube-version 1.27.0 ALL"),
+			setupFn: func(tc *testConfig) error {
+				tc.expected.renderOptions.KubeVersion = "1.27.0"
+				return nil
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -555,6 +564,7 @@ func TestRenderArgParsing(t *testing.T) {
 			expected.renderOptions.ChartSourceDir = path.Join(thelmaHome, "charts")
 			expected.renderOptions.ParallelWorkers = 1
 			expected.renderOptions.Scope = scope.All
+			expected.renderOptions.KubeVersion = "1.25.0"
 			expected.renderOptions.Releases = defaultReleases(fixture)
 
 			// set command-line args

--- a/internal/thelma/render/helmfile/cmd.go
+++ b/internal/thelma/render/helmfile/cmd.go
@@ -2,8 +2,9 @@ package helmfile
 
 import (
 	"fmt"
-	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 	"strings"
+
+	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
 )
 
 // ProgName is the name of the `helmfile` binary
@@ -21,6 +22,7 @@ type Cmd struct {
 	outputDir       string
 	stdout          bool
 	debugMode       bool
+	kubeVersion     string
 }
 
 // newCmd returns a new Cmd object with all fields initialized
@@ -64,6 +66,14 @@ func (cmd *Cmd) toShellCommand() shell.Command {
 		cliArgs = append(cliArgs, outputDirFlag)
 	}
 
+	// Append kubeVersion flag if set
+	// If not set, this will default to an old version that is hardcoded into the
+	// helm binary. This can cause any 3rd party charts that have kubeVersion constraints
+	// to fail to render.
+	if cmd.kubeVersion != "" {
+		cliArgs = append(cliArgs, fmt.Sprintf("--kube-version=%s", cmd.kubeVersion))
+	}
+
 	shellCmd := shell.Command{
 		Prog: ProgName,
 		Args: cliArgs,
@@ -104,6 +114,10 @@ func (cmd *Cmd) setStdout(stdout bool) {
 
 func (cmd *Cmd) setDebugMode(debugMode bool) {
 	cmd.debugMode = debugMode
+}
+
+func (cmd *Cmd) setKubeVersion(kubeVersion string) {
+	cmd.kubeVersion = kubeVersion
 }
 
 func (cmd *Cmd) addValuesFiles(valuesFiles ...string) {

--- a/internal/thelma/render/render.go
+++ b/internal/thelma/render/render.go
@@ -3,8 +3,9 @@ package render
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/broadinstitute/thelma/internal/thelma/app"
 	"github.com/broadinstitute/thelma/internal/thelma/app/metrics/labels"
@@ -24,6 +25,7 @@ type Options struct {
 	Stdout          bool            // Stdout if true, render to stdout instead of output directory
 	OutputDir       string          // OutputDir output directory where manifests should be rendered
 	DebugMode       bool            // DebugMode if true, pass --debug to helmfile to render out invalid manifests
+	KubeVersion     string          // kubernetes client version to pass to the helmfile --kube-version flag
 	ChartSourceDir  string          // ChartSourceDir path on filesystem where chart sources live
 	ResolverMode    resolver.Mode   // ResolverMode resolver mode
 	ParallelWorkers int             // ParallelWorkers number of parallel workers
@@ -108,6 +110,7 @@ func newRender(app app.ThelmaApp, options *Options) (*multiRender, error) {
 		HelmfileLogLevel: cfg.Helmfile.LogLevel,
 		Stdout:           options.Stdout,
 		DebugMode:        options.DebugMode,
+		KubeVersion:      options.KubeVersion,
 		OutputDir:        options.OutputDir,
 		ScratchDir:       scratchDir,
 		ShellRunner:      app.ShellRunner(),

--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 # the target directory, it won't download them again.
 
 HELM_VERSION=3.6.0
-HELMFILE_VERSION=0.143.1
+HELMFILE_VERSION=0.165.0
 YQ_VERSION=4.11.2
 HELM_DOCS_VERSION=1.5.0
 ARGOCD_VERSION=2.10.2
@@ -82,9 +82,10 @@ install_helm() {
 }
 
 install_helmfile() {
-  URL="https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${OS}_${ARCH}"
+  URL="https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_${OS}_${ARCH}.tar.gz"
   echo "Downloading helmfile from ${URL}"
-  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O helmfile && \
+  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - | \
+    tar xz && \
     chmod +x helmfile && \
     testexec ./helmfile --version && \
     mv ./helmfile "${INSTALL_DIR}/helmfile"


### PR DESCRIPTION
I ran into an issue where a a third party chart I was attempting to work with enforces a `kubeVersion` constraint in it's `Chart.yaml`. This has unfortunate interaction where because helm template doesn't actually run it against a live k8s server the kubeVersion will default to a hard coded value that is determined by the version of the k8s client library in the helm binary in runtime deps. Previously this chart would fail to render with `Error: chart requires kubeVersion: >= 1.23.0-0 which is incompatible with Kubernetes v1.20.0`. With these changes I am able to render the chart locally.

In our particular case this kubeVersion that gets defaulted to is `1.20.0` which is quite old. However both helm and helmfile expose a `--kube-version` flag in their template commands that can override this behavior. This pr adds the ability to set this flag in thelma. I have set a default of v1.25.0 for this new flag.

This also required a more recent version of helmfile than what was packaged in runtime-deps currently so I updated it here, helmfile has also been migrated to a new repository so I updated the runtime deps script accordingly.

I have tested this by running a variety of thelma renders and making sure they still work and that the flag is propagating through correctly. I also made [this pr](https://github.com/broadinstitute/terra-helmfile/pull/5577) which uses a thelma built from this branch to perform manifest diffs.
