### PR TITLE
[DDO-3709] Hacky work-around for recent BEE seed failures

### DIFF
--- a/internal/thelma/bee/seed/seed_step_4_register_test_users.go
+++ b/internal/thelma/bee/seed/seed_step_4_register_test_users.go
@@ -57,6 +57,7 @@ func (s *seeder) seedStep4RegisterTestUsers(appReleases map[string]terra.AppRele
 							"Hogwarts", "dsde",
 							"Cambridge", "MA", "USA",
 							"Remus Lupin", "Non-Profit")
+						err = _ignore409Conflict(err)
 						if err = opts.handleErrorWithForce(err); err != nil {
 							return err
 						}


### PR DESCRIPTION
For some reason, Google Workspace API calls that have worked well for years [started failing yesterday](https://broadinstitute.slack.com/archives/C03GMG4DUSE/p1717012586622649) during BEE creates. However, things seem to succeed on retry (we think?). The retry results in a 409 conflict from Sam, which is intentionally excluded from the retry logic in the orch client, but is not treated as an ignorable error by the BEE seed code. This PR makes it ignore-able.

We have an open Google Workspaces support ticket to figure out why these API calls have suddenly started returning 400 errors.

### Testing

I tested with a local BEE create, it seemed to ignore the 409-on-retry successfully.