### PR TITLE
[DDO-3723] Remove `thelma bee unseed` Vault dependency

### DIFF
--- a/internal/thelma/bee/seed/config.go
+++ b/internal/thelma/bee/seed/config.go
@@ -81,9 +81,9 @@ type seedConfig struct {
 			Name        string `default:"sam"`
 			Port        int    `default:"5432"`
 			Credentials struct {
-				VaultPath        string `default:"secret/dsde/firecloud/%s/sam/secrets/postgres/app_sql_user"`
-				VaultUsernameKey string `default:"username"`
-				VaultPasswordKey string `default:"password"`
+				KubernetesSecretName  string `default:"sam-db-creds-eso"`
+				KubernetesUsernameKey string `default:"username"`
+				KubernetesPasswordKey string `default:"password"`
 			}
 		}
 		ListUserQuery string `default:"SELECT email, id FROM sam_user"`


### PR DESCRIPTION
`thelma bee unseed` pulls the Sam database credentials from Vault at runtime. This PR updates it to pull from the some K8s secret used by the Sam pod instead.

### Testing

This particular area of Thelma does not have unit test coverage, so I did a manual unseed. It worked, successfully pulling all registered users from the test user database and unregistering them in my BEE.

```
15:09 INF george.authdomain@quality.firecloud.org:              success status=Unregistered t=2s
15:09 INF ron.weasley@quality.firecloud.org:                    success status=Unregistered t=2s
15:09 INF gregory.goyle@quality.firecloud.org:                  success status=Unregistered t=2s
15:09 INF harry.potter@quality.firecloud.org:                   success status=Unregistered t=2s
15:09 INF percy.authdomain@quality.firecloud.org:               success status=Unregistered t=2s
15:09 INF mcgonagall.curator@quality.firecloud.org:             success status=Unregistered t=2s
15:09 INF sirius.owner@quality.firecloud.org:                   success status=Unregistered t=2s
15:09 INF fred.authdomain@quality.firecloud.org:                success status=Unregistered t=2s
15:09 INF molly.authdomain@quality.firecloud.org:               success status=Unregistered t=2s
15:09 INF arthur.authdomain@quality.firecloud.org:              success status=Unregistered t=2s
15:09 INF bill.authdomain@quality.firecloud.org:                success status=Unregistered t=2s
15:09 INF rawls-qa@broad-dsde-qa.iam.gserviceaccount.com:       success status=Unregistered t=2s
15:09 INF cho.chang@quality.firecloud.org:                      success status=Unregistered t=2s
15:09 INF hermione.owner@quality.firecloud.org:                 success status=Unregistered t=2s
15:09 INF tonks.owner@quality.firecloud.org:                    success status=Unregistered t=2s
15:09 INF flitwick.curator@quality.firecloud.org:               success status=Unregistered t=2s
15:09 INF firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com:   success status=Unregistered t=2s
15:09 INF draco.malfoy@quality.firecloud.org:                   success status=Unregistered t=2s
15:09 INF hagrid.curator@quality.firecloud.org:                 success status=Unregistered t=2s
15:09 INF tsps-qa@broad-dsde-qa.iam.gserviceaccount.com:        success status=Unregistered t=2s
15:09 INF cedric.diggory@quality.firecloud.org:                 success status=Unregistered t=1s
15:09 INF voldemort.admin@quality.firecloud.org:                success status=Unregistered t=1s
15:09 INF lavender.brown@quality.firecloud.org:                 success status=Unregistered t=1s
15:09 INF dumbledore.admin@quality.firecloud.org:               success status=Unregistered t=1s
15:09 INF lupin.curator@quality.firecloud.org:                  success status=Unregistered t=1s
15:09 INF vincent.crabbe@quality.firecloud.org:                 success status=Unregistered t=1s
15:09 INF oliver.wood@quality.firecloud.org:                    success status=Unregistered t=1s
15:09 INF ginny.weasley@quality.firecloud.org:                  success status=Unregistered t=1s
15:09 INF leonardo-qa@broad-dsde-qa.iam.gserviceaccount.com:    success status=Unregistered t=1s
15:09 INF workspace-dev@broad-dsde-dev.iam.gserviceaccount.com: success status=Unregistered t=1s
15:09 INF dean.thomas@quality.firecloud.org:                    success status=Unregistered t=1s
15:09 INF snape.curator@quality.firecloud.org:                  success status=Unregistered t=1s
15:09 INF unregistering Sam's own sam-qa@broad-dsde-qa.iam.gserviceaccount.com user
15:09 INF ...done
```