### PR TITLE
[DDO-3834] Upgrade Helm deps

### DIFF
--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -6,10 +6,10 @@ set -eo pipefail
 # This script implements basic caching -- if the binaries already exist in
 # the target directory, it won't download them again.
 
-HELM_VERSION=3.6.0
-HELMFILE_VERSION=0.165.0
+HELM_VERSION=3.15.3
+HELMFILE_VERSION=0.167.0
 YQ_VERSION=4.11.2
-HELM_DOCS_VERSION=1.5.0
+HELM_DOCS_VERSION=1.14.2
 ARGOCD_VERSION=2.10.2
 KUBECTL_VERSION=1.24.0
 KUBECONFORM_VERSION=0.5.0

--- a/scripts/install-runtime-deps.sh
+++ b/scripts/install-runtime-deps.sh
@@ -102,32 +102,13 @@ install_yq() {
 }
 
 install_helm_docs() {
-  if [[ "${OS}" == "linux" ]]; then
-    # linux artifacts are only made available as rpm or deb packages and not as tarballs :'(
-    URL="https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_${OS}_${ARCH}.deb"
-    echo "Downloading helm-docs from ${URL}"
-    wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O helm-docs.deb && \
-      ar x helm-docs.deb && \
-      tar -xzvf data.tar.gz && \
-      testexec ./usr/local/bin/helm-docs --version && \
-      mv ./usr/local/bin/helm-docs "${INSTALL_DIR}/helm-docs"
-    return $?
-  fi
-
-  if [[ "${OS}" == "darwin" ]]; then
-    os="Darwin"
-    arch="x86_64"
-    URL="https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_${os}_${arch}.tar.gz"
-    echo "Downloading helm-docs from ${URL}"
-    wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - |\
-      tar -xz && \
-      testexec ./helm-docs --version && \
-      mv ./helm-docs "${INSTALL_DIR}/helm-docs"
-    return $?
-  fi
-
-  echo "Unsupported OS / ARCH combo ${OS} ${ARCH}, don't know how to install helm-docs" >&2
-  return 1
+  arch=$([ "${ARCH}" == "amd64" ] && echo "x86_64" || echo "${ARCH}")
+  URL="https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_${OS}_${arch}.tar.gz"
+  echo "Downloading helm-docs from ${URL}"
+  wget --timeout="${WGET_TIMEOUT_SECONDS}" -q "${URL}" -O - |\
+    tar -xz && \
+    testexec ./helm-docs --version && \
+    mv ./helm-docs "${INSTALL_DIR}/helm-docs"
 }
 
 install_argocd() {


### PR DESCRIPTION
Now that https://github.com/broadinstitute/terra-helmfile/pull/5801 has been merged, newer versions of Helm are okay with terra-helmfile. Upgrades Helm, Helmfile, and Helm Docs to latest.

## Testing

I ran this in terra-helmfile:

```
thelma render -r ALL -e prod --parallel-workers 3 -d output/old
```

Then made this Thelma tweak, and from Thelma's repo:

```
# Clear cache of tools etc
rm -rf ./output
make build
./output/bin/thelma render -r ALL -e prod --parallel-workers 3 -d /Users/jwarren/src/terra-helmfile/output/new
```

Then back in terra-helmfile:

```
diff -bur output/old output/new
```

It showed no diff. I went and manually messed up one of the new manifests to confirm that this command would've highlighted any differences.

## Risk

Low but dependency risk is never zero. I'm going to make very sure to fully cycle the repo server before taking advantage of the new Helm version.