### PR TITLE
[DDO-3841] Temporarily Disable Slack Client due to segfault in Vault client trigered from brownout test

### DIFF
--- a/internal/thelma/clients/slack/slack.go
+++ b/internal/thelma/clients/slack/slack.go
@@ -22,7 +22,7 @@ type slackConfig struct {
 	// Vault is the only (current) mechanism to obtain Slack credentials, since we want to always authenticate as
 	// a bot user instead of relying on user-credentials when running locally.
 	Vault struct {
-		Enabled bool   `default:"true"`
+		Enabled bool   `default:"false"`
 		Path    string `default:"secret/suitable/beehive/prod/slack"`
 		Key     string `default:"bot-user-oauth-token"`
 	}


### PR DESCRIPTION
Vault brownout testing revealed an error in the Thelma's slack message sending functionality where a null pointer deref occurs if a certain vault path doesn't exist, but the error from the vault api is being swallowed somewhere which resulted in segfault trying to inspect the error response. 

Solution is to temporarily flag off the slack token retrieval to unblock bee creation while we work on porting this functionality to GSM. This is a non-critical code path that just sends people running thelma locally the result of their bee operations over slack when complete.

Tested by running a bee creation with a local build of thelma built from this branch which succeeded and confirmed from logs that problematic code path was not traversed.