### PR TITLE
[DDO-3849] Use Appsec's Blessed Python Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ALPINE_IMAGE_VERSION='3.14'
-
+# If this base image has issues, try using a raw alpine image.
 #
-# Copy dist into runtime image
-#
-FROM alpine:${ALPINE_IMAGE_VERSION}
+# We use this image as the base Thelma image even though we don't need Python because it's a blessed
+# Alpine image. Using a blessed image lowers the burden on our infosec folks (who can manage
+# vulnerabilities easier this way) and using an existing one lowers the burden on our appsec folks.
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:alpine
 
 ARG THELMA_LINUX_RELEASE
 
@@ -24,10 +24,6 @@ RUN echo 'argocd-thelma:!::0:::::' >> /etc/shadow
 RUN echo 'argocd-thelma:x:999:' >> /etc/group
 RUN echo 'argocd-thelma:x:999:999:argocd-thelma:/home/argocd-thelma:/bin/nologin' >> /etc/passwd
 RUN chown 999:999 /home/argocd-thelma
-
-# OS updates for security
-RUN apk update
-RUN apk upgrade
 
 # Unpack Thelma into runtime image
 RUN mkdir /thelma && tar -xvf ${THELMA_LINUX_RELEASE} -C /thelma

--- a/internal/thelma/charts/mirror/mirror.go
+++ b/internal/thelma/charts/mirror/mirror.go
@@ -1,7 +1,6 @@
 package mirror
 
 import (
-	"fmt"
 	"github.com/broadinstitute/thelma/internal/thelma/charts/publish"
 	"github.com/broadinstitute/thelma/internal/thelma/toolbox/helm"
 	"github.com/broadinstitute/thelma/internal/thelma/utils/shell"
@@ -157,7 +156,7 @@ func (m *mirror) fetchChart(chart ChartDefinition) error {
 		Prog: helm.ProgName,
 		Args: []string{
 			"fetch",
-			fmt.Sprintf(chart.Name),
+			chart.Name,
 			"--version",
 			chart.Version,
 			"--destination",

--- a/internal/thelma/charts/repo/index/index.go
+++ b/internal/thelma/charts/repo/index/index.go
@@ -60,7 +60,7 @@ func (index *index) HasVersion(chartName string, version string) bool {
 func (index *index) Versions(chartName string) []string {
 	var versions []string
 
-	if index.Entries == nil || len(index.Entries) == 0 {
+	if len(index.Entries) == 0 {
 		log.Warn().Msgf("index is empty, can't look up chart version for %s", chartName)
 		return versions
 	}

--- a/internal/thelma/clients/google/bucket/logging.go
+++ b/internal/thelma/clients/google/bucket/logging.go
@@ -56,7 +56,7 @@ func (i *operationLogger) operationFinished(err error) error {
 		event.Str("status", "error")
 		event.Err(err)
 		returnErr := errors.Errorf("%s %q failed: %v", i.operationKind, i.objectUrl(), err)
-		event.Msgf(returnErr.Error())
+		event.Msg(returnErr.Error())
 		return returnErr
 	}
 

--- a/internal/thelma/state/providers/sherlock/state_loader_test.go
+++ b/internal/thelma/state/providers/sherlock/state_loader_test.go
@@ -131,7 +131,7 @@ func (suite *sherlockStateLoaderSuite) TestStateLoading() {
 func (suite *sherlockStateLoaderSuite) TestStateLoadingError() {
 	stateSource := mocks.NewClient(suite.T())
 	errMsg := "this is an error from sherlock"
-	stateSource.On("Clusters").Return(nil, errors.Errorf(errMsg))
+	stateSource.On("Clusters").Return(nil, errors.New(errMsg))
 
 	thelmaHome := suite.T().TempDir()
 	s := NewStateLoader(thelmaHome, stateSource)


### PR DESCRIPTION
Infosec wants us to use a blessed image if possible because that makes it easier to manage and report vulnerabilities.

Appsec doesn't want to make a blessed version of the raw Alpine image we currently use because it would be more overhead for them.

Seems a happy medium is to use their blessed _Python_ Alpine image. Denis suggested trying to remove Python from the image, but that seems error-prone to me: I want to avoid complexity here because this is already complex enough.

Denis did say that we can remove the OS update commands from the Dockerfile.

It seems golangci-lint got updated and now has some new rules. I've fixed the linting issues here for brevity.

## Testing

[I opened a terra-helmfile PR using this branch of Thelma](https://github.com/broadinstitute/terra-helmfile/pull/5829) to test that the Docker image still works properly.

[I ran a sync-release using this branch of Thelma](https://github.com/broadinstitute/terra-github-workflows/actions/runs/10476824249) to test the image in a slightly different way.

## Risk

Low? If Argo doesn't like it the repo server replicas would fail to come up, which isn't the end of the world -- no downtime and we'd have to push a revert through.